### PR TITLE
Added median consensus caller

### DIFF
--- a/scripts/Run.py
+++ b/scripts/Run.py
@@ -496,7 +496,7 @@ if __name__ == "__main__":
         "--consensusCaller",
         type=str,
         required=False,
-        choices=["Simple", "SimpleBayesian"],
+        choices=["Simple", "SimpleBayesian", "Median"],
         help="Whether to use Bayesian inference on read lengths during consensus calling"
     )
     parser.add_argument(

--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -3,6 +3,7 @@
 #include "SimpleConsensusCaller.hpp"
 #include "SimpleBayesianConsensusCaller.hpp"
 #include "TrainedBayesianConsensusCaller.hpp"
+#include "MedianConsensusCaller.hpp"
 using namespace ChanZuckerberg;
 using namespace shasta;
 
@@ -105,6 +106,12 @@ void Assembler::setupConsensusCaller(const string& s)
         consensusCaller = std::make_shared<BiasedGaussianConsensusCaller>();
         return;
     }
+
+    if(s == "MedianConsensusCaller") {
+        consensusCaller = std::make_shared<MedianConsensusCaller>();
+        return;
+    }
+
 
     // If getting here, the argument does not specify a supported
     // consensus caller.

--- a/src/MedianConsensusCaller.cpp
+++ b/src/MedianConsensusCaller.cpp
@@ -1,0 +1,171 @@
+#include "MedianConsensusCaller.hpp"
+#include "Coverage.hpp"
+#include <cmath>
+using namespace ChanZuckerberg;
+using namespace shasta;
+using std::floor;
+using std::ceil;
+
+
+size_t MedianConsensusCaller::predict_runlength(const Coverage &coverage, AlignedBase consensus_base) const{
+    size_t max_observed_repeat;     // Used to define the range of the loop over [base,length] observations
+    size_t n_coverage;              // How many reads support each run length
+    size_t n_total_coverage;        // How many reads support consensus base in total
+    size_t prev_length;             // Which length was last visited in sorted observations
+    size_t sum;                     // For tracking the cumulative coverage
+    size_t median;                  // The median repeat length (this is returned)
+    double midpoint;                // The point at which the CDF is 0.5
+
+    max_observed_repeat = coverage.repeatCountEnd(consensus_base);
+    n_total_coverage = coverage.coverage(consensus_base);
+
+    midpoint = double(n_total_coverage)/2;
+
+    sum = 0;
+    median = 0;
+    prev_length = 0;
+
+    // Iterate possible observed lengths (including placeholders which may be 0 coverage)
+    for (size_t length=0; length<=max_observed_repeat; length++){
+        n_coverage = coverage.coverage(consensus_base, length);
+        sum += n_coverage;
+
+        if (double(sum) > midpoint){
+            if (n_coverage > 1){
+                // Both flanking observations are the same value
+                median = length;
+            }else{
+                // Flanking observations differ in value (use the ceiling of their average)
+//                cout << double(prev_length+length)/2 << "\n";
+                median = size_t(ceil(double(prev_length+length)/2));
+            }
+            break;
+        }
+
+        // Update temp variable for boundary cases where midpoint happens between 2 different observations
+        if (n_coverage > 0){
+            prev_length = length;
+        }
+    }
+
+    return median;
+}
+
+
+Consensus MedianConsensusCaller::operator()(
+    const Coverage& coverage) const
+{
+    const AlignedBase base = coverage.mostFrequentBase();
+    const size_t repeatCount = predict_runlength(coverage, base);
+    return Consensus(base, repeatCount);
+}
+
+
+void testMedianConsensusCaller(){
+    MedianConsensusCaller classifier;
+    Coverage coverage;
+    AlignedBase consensus_base;
+    Consensus consensus;
+
+    // TEST CASE 1:
+    // True index = 0.5
+    // True median = 1
+    // ignoring non-consensus bases
+
+    // Arguments are base, strand, repeat count.
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)1), 0, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)2), 0, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)3), 0, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)4), 0, 0);
+
+    consensus_base = coverage.mostFrequentBase();
+    consensus = classifier(coverage);
+
+    cout << "CONSENSUS BASE = " << consensus_base << "\n";
+    cout << consensus.base << " " << consensus.repeatCount << "\n\n";
+
+    // TEST CASE 2:
+    // True index = 2.5
+    // True median = 1
+
+    coverage = Coverage();
+    consensus_base = AlignedBase();
+
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 1
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1); // 2
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 3
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1); // 4
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 2); // 5
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 3); // 6
+
+    consensus_base = coverage.mostFrequentBase();
+    consensus = classifier(coverage);
+
+    cout << "CONSENSUS BASE = " << consensus_base << "\n";
+    cout << consensus.base << " " << consensus.repeatCount << "\n\n";
+
+    // TEST CASE 3:
+    // True index = 3
+    // True median = 2
+
+    coverage = Coverage();
+    consensus_base = AlignedBase();
+
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 1
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1); // 2
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 3
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 2); // 4
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 3); // 5
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 4); // 6
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 5); // 7
+
+    consensus_base = coverage.mostFrequentBase();
+    consensus = classifier(coverage);
+
+    cout << "CONSENSUS BASE = " << consensus_base << "\n";
+    cout << consensus.base << " " << consensus.repeatCount << "\n\n";
+
+    // TEST CASE 4:
+    // True index = 2.5
+    // True median = 2
+
+    coverage = Coverage();
+    consensus_base = AlignedBase();
+
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 1
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1); // 2
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 3
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 3); // 4
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 4); // 5
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 5); // 6
+
+    consensus_base = coverage.mostFrequentBase();
+    consensus = classifier(coverage);
+
+    cout << "CONSENSUS BASE = " << consensus_base << "\n";
+    cout << consensus.base << " " << consensus.repeatCount << "\n\n";
+
+    // TEST CASE 5
+    // True index = 2.5
+    // True median = 1.5
+    // Rounded median = 2 (assuming ceiling rule)
+
+    coverage = Coverage();
+    consensus_base = AlignedBase();
+
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 1
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 1); // 2
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 1); // 3
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 2); // 4
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 0, 3); // 5
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)0), 1, 4); // 6
+
+    consensus_base = coverage.mostFrequentBase();
+    consensus = classifier(coverage);
+
+    cout << "CONSENSUS BASE = " << consensus_base << "\n";
+    cout << consensus.base << " " << consensus.repeatCount << "\n\n";
+
+}

--- a/src/MedianConsensusCaller.cpp
+++ b/src/MedianConsensusCaller.cpp
@@ -36,7 +36,6 @@ size_t MedianConsensusCaller::predict_runlength(const Coverage &coverage, Aligne
                 median = length;
             }else{
                 // Flanking observations differ in value (use the ceiling of their average)
-//                cout << double(prev_length+length)/2 << "\n";
                 median = size_t(ceil(double(prev_length+length)/2));
             }
             break;

--- a/src/MedianConsensusCaller.hpp
+++ b/src/MedianConsensusCaller.hpp
@@ -1,0 +1,42 @@
+#ifndef CZI_SHASTA_MEDIAN_CONSENSUS_CALLER_HPP
+#define CZI_SHASTA_MEDIAN_CONSENSUS_CALLER_HPP
+
+/*******************************************************************************
+
+A SimpleConsensusCaller is a ConsensusCaller
+that uses a very simple algorithm to compute
+the "best" base and repeat count:
+
+- The best base is the base with the most coverage,
+with ties broken in favor of the "earlier" base in
+ACGT order.
+- The best repeat count is the repeat count with
+the most coverage for the best base as defined above.
+Ties are broken in favor or larger repeat counts.
+Breaking ties in this way, rather than the opposite,
+improved sequence identity a bit, but the caller
+is still biased in favor of deletions.
+
+*******************************************************************************/
+
+
+#include "ConsensusCaller.hpp"
+
+namespace ChanZuckerberg {
+    namespace shasta {
+        class MedianConsensusCaller;
+    }
+}
+
+
+class ChanZuckerberg::shasta::MedianConsensusCaller :
+    public ChanZuckerberg::shasta::ConsensusCaller {
+public:
+
+    size_t predict_runlength(const Coverage &coverage, AlignedBase consensus_base) const;
+    virtual Consensus operator()(const Coverage&) const;
+};
+
+void testMedianConsensusCaller();
+
+#endif

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -13,6 +13,7 @@
 #include "testMarginCore.hpp"
 #include "testSpoa.hpp"
 #include "SimpleBayesianConsensusCaller.hpp"
+#include "MedianConsensusCaller.hpp"
 using namespace ChanZuckerberg;
 using namespace shasta;
 
@@ -492,8 +493,11 @@ PYBIND11_MODULE(shasta, module)
     module.def("testMarginCore",
         testMarginCore
         );
-    module.def("testConsensusCaller",
-        testConsensusCaller
+    module.def("testSimpleBayesianConsensusCaller",
+        testSimpleBayesianConsensusCaller
+        );
+    module.def("testMedianConsensusCaller",
+        testMedianConsensusCaller
         );
     module.def("dset64Test",
         dset64Test,

--- a/src/SimpleBayesianConsensusCaller.cpp
+++ b/src/SimpleBayesianConsensusCaller.cpp
@@ -272,25 +272,25 @@ Consensus SimpleBayesianConsensusCaller::operator()(const Coverage& coverage) co
 }
 
 
-void testConsensusCaller(){
+void testSimpleBayesianConsensusCaller(){
     SimpleBayesianConsensusCaller classifier;
-    Coverage c;
+    Coverage coverage;
 
-    c.addRead(AlignedBase::fromInteger((uint8_t)1), 1, 1);    // Arguments are base, strand, repeat count.
-    c.addRead(AlignedBase::fromInteger((uint8_t)1), 0, 2);
-    c.addRead(AlignedBase::fromInteger((uint8_t)2), 1, 3);
-    c.addRead(AlignedBase::fromInteger((uint8_t)1), 0, 2);
-    c.addRead(AlignedBase::fromInteger((uint8_t)1), 1, 2);
-    c.addRead(AlignedBase::fromInteger((uint8_t)2), 0, 2);
-    c.addRead(AlignedBase::fromInteger((uint8_t)4), 0, 0);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)1), 1, 1);    // Arguments are base, strand, repeat count.
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)1), 0, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)2), 1, 3);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)1), 0, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)1), 1, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)2), 0, 2);
+    coverage.addRead(AlignedBase::fromInteger((uint8_t)4), 0, 0);
 
     AlignedBase consensus_base;
 
-    consensus_base = c.mostFrequentBase();
+    consensus_base = coverage.mostFrequentBase();
 
     cout << "CONSENSUS BASE = " << consensus_base << "\n";
 
-    const Consensus consensus = classifier(c);
+    const Consensus consensus = classifier(coverage);
 
     cout << consensus.base << " " << consensus.repeatCount << '\n';
 }

--- a/src/SimpleBayesianConsensusCaller.hpp
+++ b/src/SimpleBayesianConsensusCaller.hpp
@@ -114,6 +114,6 @@ private:
 
 };
 
-void testConsensusCaller();
+void testSimpleBayesianConsensusCaller();
 
 #endif

--- a/src/TestSimpleBayesianConsensusCaller.py
+++ b/src/TestSimpleBayesianConsensusCaller.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+from shasta import testConsensusCaller
+
+
+def main():
+    testConsensusCaller()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This implementation of simple consensus caller chooses a length given the distribution of observed lengths by using the median of the distribution. In the event that the median is between 2 different observed lengths, the ceiling of the average is used.