### PR TITLE
Make accent color complement of primary color

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,7 +1,7 @@
 :root {
   --primary: #2eccc1;
   --secondary: #bfbfbf;
-  --accent: #2fa39b;
+  --accent: #cc2e3c;
   --info: hsl(242, 80%, 80%);
   --success: hsl(112, 80%, 80%);
   --warning: hsl(55, 80%, 80%);


### PR DESCRIPTION
Changed `accent` color from darker version of `primary` to complement of `primary`. This fixes the issuer where links and code looked too similar. It may come off a little bright, still so LMK if you would prefer a different color/style.

![Screen Shot 2019-05-06 at 10 42 05 PM](https://user-images.githubusercontent.com/1517263/57274483-4642fa80-7050-11e9-8dae-ababeb102938.png)
