### PR TITLE
add new css classes

### DIFF
--- a/docs/ComputationalMethods.html
+++ b/docs/ComputationalMethods.html
@@ -247,7 +247,7 @@ There is a total 4&times;3<sup>2</sup> = 36 distinct such markers.
 We arbitrarily choose the following fixed subset of the 36, and we assign an id 
 to each of the kmers in the subset:
 
-<table>
+<table class="small-table">
 <tr><td><code>TGC</code><td>0
 <tr><td><code>GCA</code><td>1
 <tr><td><code>GAC</code><td>2
@@ -303,7 +303,7 @@ Below is the run-length representation of a portion of a read
 and its markers, as displayed by the Shasta http server.
 
 <p>
-<img src=Markers.png>
+<img class="fit-in-main" src=Markers.png>
 
 
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -86,6 +86,10 @@ main {
   nav {
     flex-direction: column;
   }
+
+}
+.fit-in-main {
+  max-width: 100%;
 }
 
 h1,
@@ -111,7 +115,9 @@ table {
   word-break: normal;
   word-break: keep-all;
   -webkit-overflow-scrolling: touch;
+  border-collapse: collapse;
 }
+
 @media screen and (min-width: 60em) and (max-width: 76em) {
   table {
     max-width: 60rem;
@@ -130,12 +136,18 @@ table {
     max-width: 76rem;
     margin-left: -15rem;
     margin-right: -15rem;
-    border-collapse: collapse;
+    
   }
   .table-legend {
     margin-left: -15rem;
     max-width: 46rem;
   }
+}
+
+table.small-table {
+  max-width: none;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 th,


### PR DESCRIPTION
I added two new classes to the css.

.main-width-100 - to add to an element that's default width is wider than the main container. Makes it fit into the main container

.small-table - add to tables that are <= than the width of the main container. The table will fit into the main container.

I added these to elements on the computational method's page.
![Screen Shot 2019-05-08 at 6 20 58 PM](https://user-images.githubusercontent.com/1517263/57420801-0e59c580-71be-11e9-9c03-c5c118050d6e.png)
![Screen Shot 2019-05-08 at 6 20 52 PM](https://user-images.githubusercontent.com/1517263/57420805-10238900-71be-11e9-8102-ecda91acea02.png)

