### PR TITLE
configurable install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ docs/doxygen/latex
 .idea
 
 cmake-build-debug/
+
+\#*
+.#*
+*~
+build/
+.gdb_history

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,20 +125,39 @@ if(BUILD_DYNAMIC_EXECUTABLE)
     add_subdirectory(dynamicExecutable)
 endif(BUILD_DYNAMIC_EXECUTABLE)
 
-
+if(NOT SYSTEM_INSTALL)
+  # Install to the shasta-install directory.
+  set(CMAKE_INSTALL_PREFIX .)
+endif()
 
 # Install the scripts.
 file(GLOB SCRIPTS scripts/*.py scripts/*.sh)
-install(PROGRAMS ${SCRIPTS} DESTINATION share/shasta/scripts)
+if(NOT SYSTEM_INSTALL)
+  install(PROGRAMS ${SCRIPTS} DESTINATION shasta-install/bin)
+else()
+  install(PROGRAMS ${SCRIPTS} DESTINATION share/shasta/scripts)
+endif()
 
 # Install the configuration files.
-install(DIRECTORY conf DESTINATION share/shasta USE_SOURCE_PERMISSIONS)
+if(NOT SYSTEM_INSTALL)
+  install(DIRECTORY conf DESTINATION shasta-install USE_SOURCE_PERMISSIONS)
+else()
+  install(DIRECTORY conf DESTINATION share/shasta USE_SOURCE_PERMISSIONS)
+endif()
 
 # Install the docs directory.
-install(DIRECTORY docs DESTINATION share/shasta)
+if(NOT SYSTEM_INSTALL)
+  install(DIRECTORY docs DESTINATION shasta-install)
+else()
+  install(DIRECTORY docs DESTINATION share/shasta)
+endif()
 
 # Install the docker directory.
-install(DIRECTORY docker DESTINATION share/shasta)
+if(NOT SYSTEM_INSTALL)
+  install(DIRECTORY docker DESTINATION shasta-install)
+else()
+  install(DIRECTORY docker DESTINATION share/shasta)
+endif()
 
 # The targets built in each subdirectory are
 # installed by the cmake file of each subdirectory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,21 +127,18 @@ endif(BUILD_DYNAMIC_EXECUTABLE)
 
 
 
-# Install to the shasta-install directory.
-set(CMAKE_INSTALL_PREFIX .)
-
 # Install the scripts.
 file(GLOB SCRIPTS scripts/*.py scripts/*.sh)
-install(PROGRAMS ${SCRIPTS} DESTINATION shasta-install/bin)
+install(PROGRAMS ${SCRIPTS} DESTINATION share/shasta/scripts)
 
 # Install the configuration files.
-install(DIRECTORY conf DESTINATION shasta-install USE_SOURCE_PERMISSIONS)
+install(DIRECTORY conf DESTINATION share/shasta USE_SOURCE_PERMISSIONS)
 
 # Install the docs directory.
-install(DIRECTORY docs DESTINATION shasta-install)
+install(DIRECTORY docs DESTINATION share/shasta)
 
 # Install the docker directory.
-install(DIRECTORY docker DESTINATION shasta-install)
+install(DIRECTORY docker DESTINATION share/shasta)
 
 # The targets built in each subdirectory are
 # installed by the cmake file of each subdirectory.

--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -59,7 +59,11 @@ set_target_properties(shastaDynamicExecutable PROPERTIES OUTPUT_NAME "shastaDyna
 
 # This is needed to make sure the executable looks for the shared
 # library in the same directory.
-set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN")
+if(NOT SYSTEM_INSTALL)
+  set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN")
+else()
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
 
 # Libraries to link with.
 target_link_libraries(
@@ -71,10 +75,18 @@ if(BUILD_DEBUG)
 endif(BUILD_DEBUG)
 
 # Install the dynamic executable into the bin directory.
-install(TARGETS shastaDynamicExecutable DESTINATION bin)
+if(NOT SYSTEM_INSTALL)
+  install(TARGETS shastaDynamicExecutable DESTINATION shasta-install/bin)
+else()
+  install(TARGETS shastaDynamicExecutable DESTINATION bin)
+endif()
 
 # When install is complete, create the AppImage.
 if(BUILD_APPIMAGE)
-install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/AppImage/CreateAppImage.py share/shasta/appimage)")
+  if(NOT SYSTEM_INSTALL)
+    install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/AppImage/CreateAppImage.py shasta-install)")
+  else()
+    install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/AppImage/CreateAppImage.py share/shasta/appimage)")
+  endif()
 endif(BUILD_APPIMAGE)
 

--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -71,10 +71,10 @@ if(BUILD_DEBUG)
 endif(BUILD_DEBUG)
 
 # Install the dynamic executable into the bin directory.
-install(TARGETS shastaDynamicExecutable DESTINATION shasta-install/bin)
+install(TARGETS shastaDynamicExecutable DESTINATION bin)
 
 # When install is complete, create the AppImage.
 if(BUILD_APPIMAGE)
-install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/AppImage/CreateAppImage.py shasta-install)")
+install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/AppImage/CreateAppImage.py share/shasta/appimage)")
 endif(BUILD_APPIMAGE)
 

--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -62,7 +62,7 @@ set_target_properties(shastaDynamicExecutable PROPERTIES OUTPUT_NAME "shastaDyna
 if(NOT SYSTEM_INSTALL)
   set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN")
 else()
-  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 endif()
 
 # Libraries to link with.

--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -95,7 +95,7 @@ else(BUILD_FOR_GPU)
 endif(BUILD_FOR_GPU)
 
 # Install the shared library into the bin directory.
-install(TARGETS shastaDynamicLibrary DESTINATION shasta-install/bin)
+install(TARGETS shastaDynamicLibrary DESTINATION lib)
 
 
 

--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -95,7 +95,11 @@ else(BUILD_FOR_GPU)
 endif(BUILD_FOR_GPU)
 
 # Install the shared library into the bin directory.
-install(TARGETS shastaDynamicLibrary DESTINATION lib)
+if(NOT SYSTEM_INSTALL)
+  install(TARGETS shastaDynamicLibrary DESTINATION shasta-install/bin)
+else()
+  install(TARGETS shastaDynamicLibrary DESTINATION lib)
+endif()
 
 
 

--- a/staticExecutable/CMakeLists.txt
+++ b/staticExecutable/CMakeLists.txt
@@ -89,6 +89,6 @@ if(NOT MACOS)
 endif(NOT MACOS)
 
 # The static executable goes to the bin directory.
-install(TARGETS shastaStaticExecutable DESTINATION shasta-install/bin)
+install(TARGETS shastaStaticExecutable DESTINATION bin)
 
 

--- a/staticExecutable/CMakeLists.txt
+++ b/staticExecutable/CMakeLists.txt
@@ -89,6 +89,10 @@ if(NOT MACOS)
 endif(NOT MACOS)
 
 # The static executable goes to the bin directory.
-install(TARGETS shastaStaticExecutable DESTINATION bin)
+if(NOT SYSTEM_INSTALL)
+  install(TARGETS shastaStaticExecutable DESTINATION shasta-install/bin)
+else()
+  install(TARGETS shastaStaticExecutable DESTINATION bin)
+endif()
 
 

--- a/staticExecutableGpu/CMakeLists.txt
+++ b/staticExecutableGpu/CMakeLists.txt
@@ -74,6 +74,6 @@ target_link_libraries(shastaGpu
     -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 
 # The static executable goes to the bin directory.
-install(TARGETS shastaGpu DESTINATION shasta-install/bin)
+install(TARGETS shastaGpu DESTINATION bin)
 
 

--- a/staticExecutableGpu/CMakeLists.txt
+++ b/staticExecutableGpu/CMakeLists.txt
@@ -74,6 +74,10 @@ target_link_libraries(shastaGpu
     -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 
 # The static executable goes to the bin directory.
-install(TARGETS shastaGpu DESTINATION bin)
+if(NOT SYSTEM_INSTALL)
+  install(TARGETS shastaGpu DESTINATION shasta-install/bin)
+else()
+  install(TARGETS shastaGpu DESTINATION bin)
+endif()
 
 

--- a/staticLibrary/CMakeLists.txt
+++ b/staticLibrary/CMakeLists.txt
@@ -63,7 +63,11 @@ set_target_properties(shastaStaticLibrary PROPERTIES PREFIX "")
 set_target_properties(shastaStaticLibrary PROPERTIES DEFINE_SYMBOL "")
 
 # Install the static library into the bin directory.
-install(TARGETS shastaStaticLibrary DESTINATION lib)
+if(NOT SYSTEM_INSTALL)
+  install(TARGETS shastaStaticLibrary DESTINATION shasta-install/bin)
+else()
+  install(TARGETS shastaStaticLibrary DESTINATION lib)
+endif()
 
 
 

--- a/staticLibrary/CMakeLists.txt
+++ b/staticLibrary/CMakeLists.txt
@@ -63,7 +63,7 @@ set_target_properties(shastaStaticLibrary PROPERTIES PREFIX "")
 set_target_properties(shastaStaticLibrary PROPERTIES DEFINE_SYMBOL "")
 
 # Install the static library into the bin directory.
-install(TARGETS shastaStaticLibrary DESTINATION shasta-install/bin)
+install(TARGETS shastaStaticLibrary DESTINATION lib)
 
 
 


### PR DESCRIPTION
These updates allow shasta to be installed into a typical directory structure rooted in `DESTDIR`.

For instance:

```
# build shasta
cmake -H. -Bbuild && cmake --build build -- -j 4
# install shasta
make DESTDIR=boom install
cd boom
find
```

This yields the following structure:

```
./usr
./usr/local
./usr/local/share
./usr/local/share/shasta
./usr/local/share/shasta/conf
...
./usr/local/share/shasta/docs
...
/usr/local/share/shasta/docker
...
./usr/local/share/shasta/scripts
...
./usr/local/lib
./usr/local/lib/shasta.so
./usr/local/lib/shasta.a
./usr/local/bin
./usr/local/bin/shasta
./usr/local/bin/shastaDynamic
```

This update will make packaging shasta for distributions easier.