### PR TITLE
New Reads page is now the main reads page.

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -1812,7 +1812,7 @@ public:
     void writeMakeAllTablesSelectable(ostream&) const;
     void exploreSummary(const vector<string>&, ostream&);
     void exploreRead(const vector<string>&, ostream&);
-    void exploreReadExperimental(const vector<string>&, ostream&);
+    void exploreReadOld(const vector<string>&, ostream&);
     void blastRead(const vector<string>&, ostream&);
     void exploreAlignments(const vector<string>&, ostream&);
     void exploreAlignment(const vector<string>&, ostream&);

--- a/src/AssemblerHttpServer-Reads.cpp
+++ b/src/AssemblerHttpServer-Reads.cpp
@@ -4,7 +4,7 @@
 using namespace shasta;
 
 
-void Assembler::exploreReadExperimental(
+void Assembler::exploreRead(
     const vector<string>& request,
     ostream& html)
 {
@@ -690,7 +690,7 @@ void Assembler::exploreReadExperimental(
 
 }
 
-void Assembler::exploreRead(
+void Assembler::exploreReadOld(
     const vector<string>& request,
     ostream& html)
 {

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -48,7 +48,7 @@ void Assembler::fillServerFunctionTable()
 
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreSummary);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreRead);
-    SHASTA_ADD_TO_FUNCTION_TABLE(exploreReadExperimental);
+    SHASTA_ADD_TO_FUNCTION_TABLE(exploreReadOld);
     SHASTA_ADD_TO_FUNCTION_TABLE(blastRead);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignments);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignment);
@@ -304,7 +304,7 @@ void Assembler::writeNavigation(ostream& html) const
         });
     writeNavigation(html, "Reads", {
         {"Reads", "exploreRead"},
-        {"Reads (Experimental)", "exploreReadExperimental"},
+        {"Reads (Old)", "exploreReadOld"},
         });
     writeNavigation(html, "Alignments", {
         {"Stored alignments", "exploreAlignments"},


### PR DESCRIPTION
Old references should just work now that the new page sits at /exploreRead.