### PR TITLE
Compress and store good alignments.

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -1100,7 +1100,7 @@ private:
         vector< vector<AlignmentData> > threadAlignmentData;
 
         // Compressed alignments corresponding to the AlignmentInfo found by each thread.
-        vector< vector<string> > threadCompressedAlignments;
+        vector< shared_ptr< MemoryMapped::VectorOfVectors<char, uint64_t> > > threadCompressedAlignments;
     };
     ComputeAlignmentsData computeAlignmentsData;
 

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -256,6 +256,9 @@ public:
         // If true, discard containment alignments.
         bool suppressContainments,
 
+        // If true, store good alignments in a compressed format.
+        bool storeAlignments,
+
         // Number of threads. If zero, a number of threads equal to
         // the number of virtual processors is used.
         size_t threadCount
@@ -1050,7 +1053,10 @@ private:
 
     // The good alignments we found.
     // They are stored with readId0<readId1 and with strand0==0.
+    // The order in compressedAlignments matches that in alignmentData.
     MemoryMapped::Vector<AlignmentData> alignmentData;
+    MemoryMapped::VectorOfVectors<char, uint64_t> compressedAlignments;
+    
     void checkAlignmentDataAreOpen();
 
     // The alignment table stores the AlignmentData that each oriented read is involved in.
@@ -1083,6 +1089,7 @@ private:
         double downsamplingFactor;
         int bandExtend;
         bool suppressContainments;
+        bool storeAlignments;
 #ifdef SHASTA_BUILD_FOR_GPU
         int nDevices;
         size_t gpuBatchSize;
@@ -1091,6 +1098,9 @@ private:
 
         // The AlignmentInfo found by each thread.
         vector< vector<AlignmentData> > threadAlignmentData;
+
+        // Compressed alignments corresponding to the AlignmentInfo found by each thread.
+        vector< vector<string> > threadCompressedAlignments;
     };
     ComputeAlignmentsData computeAlignmentsData;
 

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -314,7 +314,7 @@ void Assembler::computeAlignments(
             const auto threadCompressedAlignments = data.threadCompressedAlignments[threadId];
             const auto size = threadCompressedAlignments->size();
             for(size_t i=0; i<size; i++) {
-                compressedAlignments.appendList(
+                compressedAlignments.appendVector(
                     (*threadCompressedAlignments)[i].begin(),
                     (*threadCompressedAlignments)[i].end()
                 );
@@ -458,7 +458,19 @@ void Assembler::computeAlignmentsThreadFunction(size_t threadId)
             if (storeAlignments) {
                 string compressed;
                 shasta::compress(alignment, compressed);
-                thisThreadCompressedAlignments.appendList(
+
+                // // Testing code to immediately decompress to verify no loss of information.
+                // // This code should be removed once the task of using compressed alignments
+                // // is complete.
+                // span<const char> compressedSpan(compressed.c_str(), compressed.c_str() + compressed.size());
+                // Alignment decompressedAlignment;
+                // shasta::decompress(compressedSpan, decompressedAlignment);
+
+                // if(alignment.ordinals != decompressedAlignment.ordinals) {
+                //     throw std::runtime_error("Compression failed!");
+                // }
+
+                thisThreadCompressedAlignments.appendVector(
                     compressed.c_str(),
                     compressed.c_str() + compressed.size()
                 );

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -259,6 +259,7 @@ PYBIND11_MODULE(shasta, module)
             arg("downsamplingFactor"),
             arg("bandExtend"),
             arg("suppressContainments"),
+            arg("storeAlignments"),
             arg("threadCount") = 0)
 #ifdef SHASTA_BUILD_FOR_GPU
         .def("computeAlignmentsGpu",

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -658,6 +658,7 @@ void shasta::main::assemble(
             assemblerOptions.alignOptions.downsamplingFactor,
             assemblerOptions.alignOptions.bandExtend,
             assemblerOptions.alignOptions.suppressContainments,
+            true, // Store good alignments in a compressed format.
             threadCount);
     }
 


### PR DESCRIPTION
On tested data sets, a compression of about 11.23X was observed. 