### PR TITLE
Use stored alignments if available

### DIFF
--- a/src/Alignment.hpp
+++ b/src/Alignment.hpp
@@ -34,6 +34,10 @@ public:
     // The ordinals in each of the two oriented reads of the
     // markers in the alignment.
     vector< array<uint32_t, 2> > ordinals;
+    
+    void clear() {
+        ordinals.clear();
+    }
 };
 
 

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -333,9 +333,9 @@ void Assembler::computeAlignments(
 
     cout << timestamp;
     if (data.storeAlignments) {
-        cout << "Stored compressed alignments." << endl;
+        cout << "Cached compressed alignments for potential reuse." << endl;
     } else {
-        cout << "Not storing alignments." << endl;
+        cout << "Not caching compressed alignments." << endl;
     }
 }
 

--- a/src/compressAlignment.cpp
+++ b/src/compressAlignment.cpp
@@ -72,6 +72,7 @@ void shasta::compress(const Alignment& alignment, string& s)
 
 void shasta::decompress(span<const char> s, Alignment& alignment)
 {
+    alignment.clear();
     uint32_t ordinal0 = 0;
     uint32_t ordinal1 = 0;
     


### PR DESCRIPTION
Here's the speed up (time saved) for different options. 15.5% time saved across the board and about 18-20% improvement in compute speed.

714s -> 600s. (disk/ssd, filesystem)
633s -> 533s (memory 4k pages, anonymous)
629s -> 533s (memory 2m pages, anonymous)
629s ->  524s (memory 2m pages, filesystem)

333s -> 282s (memory 2m pages, filesystem, alignMethodFor*Graph 3)