### PR TITLE
Minor cleanup of compression/decompression code.

### DIFF
--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -333,9 +333,9 @@ void Assembler::computeAlignments(
 
     cout << timestamp;
     if (data.storeAlignments) {
-        cout << "Cached compressed alignments for potential reuse." << endl;
+        cout << "Storing compressed alignments for potential reuse." << endl;
     } else {
-        cout << "Not caching compressed alignments." << endl;
+        cout << "Not storing compressed alignments." << endl;
     }
 }
 
@@ -349,6 +349,7 @@ void Assembler::computeAlignmentsThreadFunction(size_t threadId)
     AlignmentGraph graph;
     Alignment alignment;
     AlignmentInfo alignmentInfo;
+    string compressedAlignment;
 
     const bool debug = false;
     auto& data = computeAlignmentsData;
@@ -456,23 +457,11 @@ void Assembler::computeAlignmentsThreadFunction(size_t threadId)
 
             // Store the compressed alignment if so configured.
             if (storeAlignments) {
-                string compressed;
-                shasta::compress(alignment, compressed);
-
-                // // Testing code to immediately decompress to verify no loss of information.
-                // // This code should be removed once the task of using compressed alignments
-                // // is complete.
-                // span<const char> compressedSpan(compressed.c_str(), compressed.c_str() + compressed.size());
-                // Alignment decompressedAlignment;
-                // shasta::decompress(compressedSpan, decompressedAlignment);
-
-                // if(alignment.ordinals != decompressedAlignment.ordinals) {
-                //     throw std::runtime_error("Compression failed!");
-                // }
+                shasta::compress(alignment, compressedAlignment);
 
                 thisThreadCompressedAlignments.appendVector(
-                    compressed.c_str(),
-                    compressed.c_str() + compressed.size()
+                    compressedAlignment.c_str(),
+                    compressedAlignment.c_str() + compressedAlignment.size()
                 );
             }
         }


### PR DESCRIPTION
- Avoid creating a new std::string object while compressing alignments. The following run now runs about 10s faster consistently (281s -> 271s) just because of this change.
`./shasta-build/staticExecutable/shasta --input input_data/500.fasta --memoryBacking 2M --memoryMode filesystem --Align.alignMethodForReadGraph 3 --Align.alignMethodForMarkerGraph 3`

- Replace "cache" with "store" in status output because we are storing rather than caching.