### PR TITLE
Use alignment.clear() instead of alignment.ordinals.clear()

### DIFF
--- a/src/AlignmentGraph.cpp
+++ b/src/AlignmentGraph.cpp
@@ -104,7 +104,7 @@ void AlignmentGraph::create(
     // Look for the shortest path between vStart and vFinish.
     findShortestPath(*this, vStart, vFinish, shortestPath, queue);
     if(shortestPath.empty()) {
-        alignment.ordinals.clear();
+        alignment.clear();
         if(debug) {
             cout << "The shortest path is empty." << endl;
         }
@@ -117,7 +117,7 @@ void AlignmentGraph::create(
     }
 
     // Store the alignment.
-    alignment.ordinals.clear();
+    alignment.clear();
     for(const vertex_descriptor v: shortestPath) {
         if(v==vStart || v==vFinish) {
             continue;

--- a/src/AssemblerAlign1.cpp
+++ b/src/AssemblerAlign1.cpp
@@ -174,7 +174,7 @@ void Assembler::alignOrientedReads1(
 
 
     // Fill in the alignment.
-    alignment.ordinals.clear();
+    alignment.clear();
     uint32_t ordinal0 = 0;
     uint32_t ordinal1 = 0;
     for(int i=0;

--- a/src/AssemblerAlign2.cpp
+++ b/src/AssemblerAlign2.cpp
@@ -98,7 +98,7 @@ void Assembler::alignOrientedReads2(
     SHASTA_ASSERT(result.startLocations[0] == 0);
 
     // Fill in the alignment.
-    alignment.ordinals.clear();
+    alignment.clear();
     uint32_t ordinal0 = begin0;
     uint32_t ordinal1 = begin1;
     for(int i=0; i<result.alignmentLength; i++) {

--- a/src/AssemblerAlign3.cpp
+++ b/src/AssemblerAlign3.cpp
@@ -196,7 +196,7 @@ void Assembler::alignOrientedReads3(
     // If the downsampled alignment is empty, just return an empty alignment.
     if(uint64_t(downsampledAlignmentLength) ==
         downsampledMarkers[0].size() + downsampledMarkers[1].size()) {
-        alignment.ordinals.clear();
+        alignment.clear();
         alignmentInfo.create(
             alignment, uint32_t(allMarkers[0].size()), uint32_t(allMarkers[1].size()));
         return;
@@ -273,7 +273,7 @@ void Assembler::alignOrientedReads3(
 
 
     // Fill in the alignment.
-    alignment.ordinals.clear();
+    alignment.clear();
     uint32_t ordinal0 = 0;
     uint32_t ordinal1 = 0;
     for(int i=0;

--- a/src/gpu/AssemblerAlign-gpu.cpp
+++ b/src/gpu/AssemblerAlign-gpu.cpp
@@ -285,7 +285,7 @@ void Assembler::computeAlignmentsThreadFunctionGPU(size_t threadId)
             // Evaluate alignments and push good alignments
             for (size_t i=first; i<last; i++) {
                 auto candidate = alignmentCandidates.candidates[i];
-                alignment.ordinals.clear();
+                alignment.clear();
                 size_t last_addr = (i-first)*2+2;
                 if (h_num_traceback[i-first] >= 2) {
                     {

--- a/src/gpu/AssemblerMarkerGraphGpu.cpp
+++ b/src/gpu/AssemblerMarkerGraphGpu.cpp
@@ -564,7 +564,7 @@ void Assembler::createMarkerGraphVerticesThreadFunction1Gpu(size_t threadId)
 
             for (size_t i=0; i<alignCount; i++) {
                 auto edgeId = currAlignmentEdgesId[i];
-                alignment.ordinals.clear();
+                alignment.clear();
                 size_t last_addr = i*SHASTA_MAX_TB+h_num_traceback[i];
                 for (size_t j=1; j<=h_num_traceback[i]; j++) {
                     uint32_t v = h_alignments[last_addr-j];


### PR DESCRIPTION
Hides the implementation detail of what clearing an alignment does. I added the `clear` public method to Alignment.hpp in an earlier commit. This commit migrates all existing calls to `alignment.ordinals.clear()` to `alignment.clear()`.