### PR TITLE
Collapse alignMethodForReadGraph & alignMethodForMarkerGraph into a single alignMethod config option.

### DIFF
--- a/conf/RemoveConflicts.conf
+++ b/conf/RemoveConflicts.conf
@@ -38,8 +38,7 @@ minAlignedFraction = 0.4
 suppressContainments = True
 
 # Use SeqAn banded alignments.
-alignMethodForReadGraph = 3
-alignMethodForMarkerGraph = 3
+alignMethod = 3
 matchScore = 6
 
 

--- a/conf/shasta.conf
+++ b/conf/shasta.conf
@@ -108,13 +108,9 @@ minFrequency = 2
 # This section contains parameters that control the alignment of
 # oriented reads using an alignment graph.
 
-# The alignment method to be used to create the read graph.
+# The alignment method to be used to create the read graph & marker graph.
 # Values other than 0 are experimental. 
-alignMethodForReadGraph = 0
-
-# The alignment method to be used to create the marker graph.
-# Values other than 0 are experimental. 
-alignMethodForMarkerGraph = 0
+alignMethod = 0
 
 # The maximum number of markers that an alignment is allowed
 # to skip on either of the oriented reads being aligned.

--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -481,14 +481,9 @@ Instead, all possible read pairs are marked as alignment candidates, on both
 relative orientations. This should only be used for very small test
 assemblies as it can become prohibitively slow for large assemblies.
 
-<tr id='Align.alignMethodForReadGraph'>
-<td><code>--Align.alignMethodForReadGraph</code><td class=centered><code>0</code><td>
-The alignment method to be used to create the read graph. 
-Values other than 0 are experimental.
-
-<tr id='Align.alignMethodForMarkerGraph'>
-<td><code>--Align.alignMethodForMarkerGraph</code><td class=centered><code>0</code><td>
-The alignment method to be used to create the marker graph. 
+<tr id='Align.alignMethod'>
+<td><code>--Align.alignMethod</code><td class=centered><code>0</code><td>
+The alignment method to be used to create the read graph and the marker graph. 
 Values other than 0 are experimental.
 
 <tr id='Align.maxSkip'>

--- a/scripts/ComputeAlignments.py
+++ b/scripts/ComputeAlignments.py
@@ -16,7 +16,7 @@ a.accessAlignmentCandidates()
 
 # Do the computation.
 a.computeAlignments(
-    alignmentMethod = int(config['Align']['alignMethodForReadGraph']),
+    alignmentMethod = int(config['Align']['alignMethod']),
     maxMarkerFrequency = int(config['Align']['maxMarkerFrequency']),
     maxSkip = int(config['Align']['maxSkip']),
     maxDrift = int(config['Align']['maxDrift']),

--- a/scripts/CreateAndCleanupMarkerGraph.py
+++ b/scripts/CreateAndCleanupMarkerGraph.py
@@ -17,7 +17,7 @@ a.accessChimericReadsFlags()
 
 # Create vertices of the marker graph.
 a.createMarkerGraphVertices(
-    alignMethod = int(config['Align']['alignMethodForMarkerGraph']),
+    alignMethod = int(config['Align']['alignMethod']),
     maxMarkerFrequency = int(config['Align']['maxMarkerFrequency']),
     maxSkip = int(config['Align']['maxSkip']),
     matchScore = int(config['Align']['matchScore']),,

--- a/scripts/CreateMarkerGraphVertices.py
+++ b/scripts/CreateMarkerGraphVertices.py
@@ -17,7 +17,7 @@ a.accessReadFlags()
 
 # Do the computation.
 a.createMarkerGraphVertices(
-    alignMethod = int(config['Align']['alignMethodForMarkerGraph']),
+    alignMethod = int(config['Align']['alignMethod']),
     maxMarkerFrequency = int(config['Align']['maxMarkerFrequency']),
     maxSkip = int(config['Align']['maxSkip']),
     matchScore = int(config['Align']['matchScore']),,

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -333,16 +333,10 @@ void AssemblerOptions::addConfigurableOptions()
         "candidates with both orientation. This should only be used for experimentation "
         "on very small runs because it is very time consuming.")
 
-        ("Align.alignMethodForReadGraph",
-        value<int>(&alignOptions.alignMethodForReadGraph)->
+        ("Align.alignMethod",
+        value<int>(&alignOptions.alignMethod)->
         default_value(0),
-        "The alignment method to be used to create the read graph. "
-        "Values other than 0 are experimental.")
-
-        ("Align.alignMethodForMarkerGraph",
-        value<int>(&alignOptions.alignMethodForMarkerGraph)->
-        default_value(0),
-        "The alignment method to be used to create the marker graph. "
+        "The alignment method to be used to create the read graph & the marker graph. "
         "Values other than 0 are experimental.")
 
         ("Align.maxSkip",
@@ -614,8 +608,7 @@ void AssemblerOptions::MinHashOptions::write(ostream& s) const
 void AssemblerOptions::AlignOptions::write(ostream& s) const
 {
     s << "[Align]\n";
-    s << "alignMethodForReadGraph = " << alignMethodForReadGraph << "\n";
-    s << "alignMethodForMarkerGraph = " << alignMethodForMarkerGraph << "\n";
+    s << "alignMethod = " << alignMethod << "\n";
     s << "maxSkip = " << maxSkip << "\n";
     s << "maxDrift = " << maxDrift << "\n";
     s << "maxTrim = " << maxTrim << "\n";

--- a/src/AssemblerOptions.hpp
+++ b/src/AssemblerOptions.hpp
@@ -166,8 +166,7 @@ public:
     // beginning with "Align.".
     class AlignOptions {
     public:
-        int alignMethodForReadGraph;
-        int alignMethodForMarkerGraph;
+        int alignMethod;
         int maxSkip;
         int maxDrift;
         int maxTrim;

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -202,8 +202,7 @@ void shasta::main::assemble(
 
     // MacOS does not support alignment method 1.
 #ifndef __linux__
-    if( (assemblerOptions.alignOptions.alignMethodForReadGraph == 1) or
-        (assemblerOptions.alignOptions.alignMethodForMarkerGraph == 1)) {
+    if(assemblerOptions.alignOptions.alignMethod == 1) {
         throw runtime_error("Align method 1 is not supported on macOS.");
     }
 
@@ -645,7 +644,7 @@ void shasta::main::assemble(
 #endif
     } else {
         assembler.computeAlignments(
-            assemblerOptions.alignOptions.alignMethodForReadGraph,
+            assemblerOptions.alignOptions.alignMethod,
             assemblerOptions.alignOptions.maxMarkerFrequency,
             assemblerOptions.alignOptions.maxSkip,
             assemblerOptions.alignOptions.maxDrift,
@@ -876,7 +875,7 @@ void shasta::main::createMarkerGraphVertices(
 
         // Create marker graph vertices: mainstream code.
         assembler.createMarkerGraphVertices(
-            assemblerOptions.alignOptions.alignMethodForMarkerGraph,
+            assemblerOptions.alignOptions.alignMethod,
             assemblerOptions.alignOptions.maxMarkerFrequency,
             assemblerOptions.alignOptions.maxSkip,
             assemblerOptions.alignOptions.maxDrift,


### PR DESCRIPTION
We can't have two separate options now since we reuse computed alignments.

Tested by running the following ....

`sudo ./shasta-build/staticExecutable/shasta --input input_data/500.fasta --memoryBacking 2M --memoryMode filesystem --Align.alignMethod 3`