### PR TITLE
Build on Ubuntu 20.04 LTS

### DIFF
--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -74,9 +74,20 @@ set_target_properties(shastaDynamicLibrary PROPERTIES DEFINE_SYMBOL "")
 # Python 3 and pybind11.
 # I was not able to get find_package to work with pybind11 as installed by pip3.
 # The code below creates include paths for both Python 3 and pybind11.
+
+# Python 3.8 requires the `--embed` flag to be passed in.
+# find_python cmake module was introduced in v3.12, which isn't available for installation
+# via `apt` on Ubuntu 18.04 LTS. So I am not using it. 
+execute_process(COMMAND /usr/bin/python3-config --embed --libs OUTPUT_VARIABLE
+SHASTA_PYTHON_LIBRARIES RESULT_VARIABLE COMMAND_RESULT)
+if(${COMMAND_RESULT} EQUAL 0)
+    # Python3 version is >= 3.8.0. So the --embed flag worked. Otherwise the command
+    # would have failed with a non-zero exit code.
+else()
+    execute_process(COMMAND /usr/bin/python3-config --libs OUTPUT_VARIABLE SHASTA_PYTHON_LIBRARIES)
+endif()
 execute_process(COMMAND python3 -m pybind11 --includes OUTPUT_VARIABLE SHASTA_PYTHON_INCLUDES)
 add_definitions(${SHASTA_PYTHON_INCLUDES})
-execute_process(COMMAND /usr/bin/python3-config --libs OUTPUT_VARIABLE SHASTA_PYTHON_LIBRARIES)
 string(STRIP ${SHASTA_PYTHON_LIBRARIES} SHASTA_PYTHON_LIBRARIES)
 SET(CMAKE_LINKER_FLAGS  "${CMAKE_LINKER_FLAGS} ${SHASTA_PYTHON_LIBRARIES}")
 

--- a/src/AssemblerHttpServer-AssemblyGraph.cpp
+++ b/src/AssemblerHttpServer-AssemblyGraph.cpp
@@ -490,7 +490,7 @@ void Assembler::exploreAssemblyGraphEdgesSupport(
         AssemblyGraph::EdgeId edgeId;
         try {
             edgeId = boost::lexical_cast<AssemblyGraph::EdgeId>(edgeString);
-        } catch(boost::bad_lexical_cast) {
+        } catch(const boost::bad_lexical_cast&) {
             html << "<br>Invalid assembly graph edge id " << token;
             return;
         }

--- a/src/AssemblerHttpServer-DirectedReadGraph.cpp
+++ b/src/AssemblerHttpServer-DirectedReadGraph.cpp
@@ -337,7 +337,7 @@ void Assembler::exploreDirectedReadGraph(
             try {
                 readId0 = boost::lexical_cast<ReadId>(tokens2[0]);
                 strand0 = boost::lexical_cast<ReadId>(tokens2[1]);
-            } catch(boost::bad_lexical_cast) {
+            } catch(const boost::bad_lexical_cast&) {
                 continue;
             }
             if(strand0 > 1) {

--- a/src/MultithreadedObject.hpp
+++ b/src/MultithreadedObject.hpp
@@ -225,7 +225,7 @@ template<class T> inline void shasta::MultithreadedObject<T>::startThreads(
                 std::ref(t),
                 f,
                 threadId)));
-        } catch(std::exception e) {
+        } catch(const std::exception& e) {
             throw runtime_error(
                 "The following error occurred while attempting to start thread " +
                 to_string(threadId) + ":\n" + e.what() + "\n" +


### PR DESCRIPTION
Ubuntu 20.04 LTS ships with gcc v9.3.0, which throws a warning where we don't catch
exceptions by reference. Fixed three such occurrences.

On Ubuntu 20.04 LTS
`apt install cmake` installs version 3.16.3 (as of today).
`apt install python3` installs version 3.8.2 (as of today).

So I had to modify a cmake input file to deal with the changes in the way python is embedded
into an application. See
https://docs.python.org/3.8/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build for
more details.

Test Plan: Spun up an ec2 instance with an Ubuntu 20.04 LTS AMI. Applied these changes. Built
successfully and ran a small assembly. It works. Same for Ubuntu 18.04 LTS to verify that these
changes are backward compatible.