### PR TITLE
[HttpServer] exploreAlignment & computeAllAlignments now use the same input form

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -2032,7 +2032,14 @@ public:
         size_t maxDrift;
         uint32_t maxMarkerFrequency;
         size_t minAlignedMarkerCount;
+        double minAlignedFraction;
         size_t maxTrim;
+        int method;
+        int matchScore;
+        int mismatchScore;
+        int gapScore;
+        double downsamplingFactor;
+        uint32_t bandExtend;
         // The alignments found by each thread.
         vector< vector< pair<OrientedReadId, AlignmentInfo> > > threadAlignments;
     };


### PR DESCRIPTION
I've added a couple form fields in the table to `exploreAlignment` as well, so as to keep it consistent with `computeAllAlignments`. If we end up using this form on another page, I will refactor the code to avoid duplication. 

This is how the `computeAllAlignments` page looks now.
![image](https://user-images.githubusercontent.com/858849/81973202-a2801900-95d8-11ea-9328-80ab1ca01c59.png)
