### PR TITLE
Alignment configuration table revamp and high level style changes.

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -2035,6 +2035,21 @@ public:
     void exploreMarkerGraphEdge(const vector<string>&, ostream&);
     void exploreMarkerCoverage(const vector<string>&, ostream&);
     void exploreMarkerGraphInducedAlignment(const vector<string>&, ostream&);
+    void renderEditableAlignmentConfig(
+        const int method,
+        const uint64_t maxSkip,
+        const uint64_t maxDrift,
+        const uint32_t maxMarkerFrequency,
+        const uint64_t minAlignedMarkerCount,
+        const double minAlignedFraction,
+        const uint64_t maxTrim,
+        const int matchScore,
+        const int mismatchScore,
+        const int gapScore,
+        const double downsamplingFactor,
+        const uint32_t bandExtend,
+        ostream& html
+    );
 #endif
 
 

--- a/src/AssemblerHttpServer-Reads.cpp
+++ b/src/AssemblerHttpServer-Reads.cpp
@@ -35,7 +35,7 @@ void Assembler::exploreRead(
     // Write the form.
     html <<
         "<form>"
-        "<input type=submit value='Show' style='background-color:dodgerblue;padding:4px'> " <<
+        "<input type=submit value='Show'> " <<
         "read &nbsp" <<
         "<input type=text name=readId required" <<
         (readIdIsPresent ? (" value=" + to_string(readId)) : "") <<

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -152,7 +152,8 @@ void Assembler::writeStyle(ostream& html)
         border-collapse: collapse;
     }
     th, td {
-        border: 2px solid MediumSlateBlue;
+        border: 1px solid #b8b5c7d9;
+        padding: 2px;
     }
     th {
         font-weight: bold;
@@ -166,6 +167,9 @@ void Assembler::writeStyle(ostream& html)
     }
     td.right {
         text-align: right;
+    }
+    td.smaller {
+        font-size: smaller;
     }
     a {
         color: DarkSlateBlue;
@@ -216,7 +220,21 @@ void Assembler::writeStyle(ostream& html)
     
     .navigationMenuEntry:hover .navigationItems {
         display: block;
-}
+    }
+
+    input[type=submit] {
+        background-color: #89bef2;
+        padding: 4px;
+    }
+
+    input[type=button] {
+        padding: 4px;
+    }
+
+    input[type=text], input[type=radio] {
+        background-color: #ecf1f0;
+        border-width: thin;
+    }
 </style>
     )%";
 }
@@ -1648,7 +1666,8 @@ void Assembler::exploreAlignment(
     // Write the form.
     html <<
         "<form>"
-        "<input type=submit value='Compute marker alignment'> &nbsp of read &nbsp"
+        "<input type=submit value='Compute marker alignment'>"
+        "&nbsp of read &nbsp"
         "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
         " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
@@ -2225,7 +2244,7 @@ void Assembler::renderEditableAlignmentConfig(
 ) {
     const auto& descriptions = httpServerData.assemblerOptions->allOptionsDescription;
 
-    html << "<p><table>";
+    html << "<p><table >";
 
     html << "<tr><th class=left>[Align]<th class=center>Value<th class=left>Description";
         
@@ -2238,72 +2257,72 @@ void Assembler::renderEditableAlignmentConfig(
         (method==2 ? " checked=checked" : "") << "> 2 (Edlib)<br>"
         "<input type=radio name=method value=3" <<
         (method==3 ? " checked=checked" : "") << "> 3 (SeqAn, banded)"
-        "<td>" << descriptions.find("Align.alignMethod", false).description();
+        "<td class=smaller>" << descriptions.find("Align.alignMethod", false).description();
 
     html << "<tr><th class=left>maxSkip"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=maxSkip size=16 value=" << maxSkip << ">"
-        "<td>" << descriptions.find("Align.maxSkip", false).description();
+            "<input type=text style='text-align:center;border:none' name=maxSkip size=16 value=" << maxSkip << ">"
+        "<td class=smaller>" << descriptions.find("Align.maxSkip", false).description();
 
     html << "<tr>"
         "<th class=left>maxDrift"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=maxDrift size=16 value=" << maxDrift << ">"
-        "<td>" << descriptions.find("Align.maxDrift", false).description();
+            "<input type=text style='text-align:center;border:none' name=maxDrift size=16 value=" << maxDrift << ">"
+        "<td class=smaller>" << descriptions.find("Align.maxDrift", false).description();
 
     html << "<tr>"
         "<th class=left>maxMarkerFrequency"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=maxMarkerFrequency size=16 value=" << maxMarkerFrequency << ">"
-        "<td>" << descriptions.find("Align.maxMarkerFrequency", false).description();
+            "<input type=text style='text-align:center;border:none' name=maxMarkerFrequency size=16 value=" << maxMarkerFrequency << ">"
+        "<td class=smaller>" << descriptions.find("Align.maxMarkerFrequency", false).description();
 
     html << "<tr>"
         "<th class=left>matchScore"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=matchScore size=16 value=" << matchScore << ">"
-        "<td>" << descriptions.find("Align.matchScore", false).description();
+            "<input type=text style='text-align:center;border:none' name=matchScore size=16 value=" << matchScore << ">"
+        "<td class=smaller>" << descriptions.find("Align.matchScore", false).description();
 
     html << "<tr>"
         "<th class=left>mismatchScore "
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=mismatchScore size=16 value=" << mismatchScore << ">"
-        "<td>" << descriptions.find("Align.mismatchScore", false).description();
+            "<input type=text style='text-align:center;border:none' name=mismatchScore size=16 value=" << mismatchScore << ">"
+        "<td class=smaller>" << descriptions.find("Align.mismatchScore", false).description();
 
     html << "<tr>"
         "<th class=left>gapScore"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=gapScore size=16 value=" << gapScore << ">"
-        "<td>" << descriptions.find("Align.gapScore", false).description();
+            "<input type=text style='text-align:center;border:none' name=gapScore size=16 value=" << gapScore << ">"
+        "<td class=smaller>" << descriptions.find("Align.gapScore", false).description();
 
     html << "<tr>"
         "<th class=left>downsamplingFactor"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=downsamplingFactor size=16 value=" << downsamplingFactor << ">"
-        "<td>" << descriptions.find("Align.downsamplingFactor", false).description();
+            "<input type=text style='text-align:center;border:none' name=downsamplingFactor size=16 value=" << downsamplingFactor << ">"
+        "<td class=smaller>" << descriptions.find("Align.downsamplingFactor", false).description();
 
     html << "<tr>"
         "<th class=left>bandExtend"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=bandExtend size=16 value=" << bandExtend << ">"
-        "<td>" << descriptions.find("Align.bandExtend", false).description();
+            "<input type=text style='text-align:center;border:none' name=bandExtend size=16 value=" << bandExtend << ">"
+        "<td class=smaller>" << descriptions.find("Align.bandExtend", false).description();
 
     html << "<tr>"
         "<th class=left>minAlignedMarkers"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=minAlignedMarkerCount size=16 value=" << minAlignedMarkerCount << ">"
-        "<td>" << descriptions.find("Align.minAlignedMarkerCount", false).description();
+            "<input type=text style='text-align:center;border:none' name=minAlignedMarkerCount size=16 value=" << minAlignedMarkerCount << ">"
+        "<td class=smaller>" << descriptions.find("Align.minAlignedMarkerCount", false).description();
 
     html << "<tr>"
         "<th class=left>minAlignedFraction"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=minAlignedFraction size=16 value=" << minAlignedFraction << ">"
-        "<td>" << descriptions.find("Align.minAlignedFraction", false).description();
+            "<input type=text style='text-align:center;border:none' name=minAlignedFraction size=16 value=" << minAlignedFraction << ">"
+        "<td class=smaller>" << descriptions.find("Align.minAlignedFraction", false).description();
 
     html << "<tr>"
         "<th class=left>maxTrim"
         "<td class=centered>"
-            "<input type=text style='text-align:center' name=maxTrim size=16 value=" << maxTrim << ">"
-        "<td>" << descriptions.find("Align.maxTrim", false).description();
+            "<input type=text style='text-align:center;border:none' name=maxTrim size=16 value=" << maxTrim << ">"
+        "<td class=smaller>" << descriptions.find("Align.maxTrim", false).description();
 
     html << "</table>";
 }
@@ -2352,8 +2371,9 @@ void Assembler::computeAllAlignments(
     // Write the form.
     html <<
         "<form>"
-        "<input type=submit value='Compute marker alignments'> of oriented read"
-        " <input type=text name=readId0 required size=8 " <<
+        "<input type=submit value='Compute marker alignments'>"
+        "&nbsp of oriented read &nbsp"
+        "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
         " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
         " on strand ";

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -1647,101 +1647,37 @@ void Assembler::exploreAlignment(
 
     // Write the form.
     html <<
-        "<p>Compute a marker alignment of these two reads:"
         "<form>"
+        "<input type=submit value='Compute marker alignment'> &nbsp of read &nbsp"
         "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
         " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand0", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
     html <<
-         "<br><input type=text name=readId1 required size=8 " <<
-         (readId1IsPresent ? "value="+to_string(readId1) : "") <<
-         " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
+        "&nbsp and read <input type=text name=readId1 required size=8 " <<
+        (readId1IsPresent ? "value="+to_string(readId1) : "") <<
+        " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand1", strand1IsPresent && strand1==0, strand1IsPresent && strand1==1);
 
+    renderEditableAlignmentConfig(
+        method,
+        maxSkip,
+        maxDrift,
+        maxMarkerFrequency,
+        minAlignedMarkerCount,
+        minAlignedFraction,
+        maxTrim,
+        matchScore,
+        mismatchScore,
+        gapScore,
+        downsamplingFactor,
+        bandExtend,
+        html
+    );
 
-    // Write a table with the rest of the form.
-    html <<
-        "<p><table>"
-
-        "<tr><th class=left>Alignment method<td>"
-        "<input type=radio name=method value=0" <<
-        (method==0 ? " checked=checked" : "") << "> 0 (Shasta)<br>"
-        "<input type=radio name=method value=1" <<
-        (method==1 ? " checked=checked" : "") << "> 1 (SeqAn)<br>"
-        "<input type=radio name=method value=2" <<
-        (method==2 ? " checked=checked" : "") << "> 2 (Edlib)<br>"
-        "<input type=radio name=method value=3" <<
-        (method==3 ? " checked=checked" : "") << "> 3 (SeqAn, banded)"
-
-        "<tr title='Used by alignment method 0'><th class=left>"
-        "Maximum ordinal skip<td class=centered>" <<
-        "<input type=text style='text-align:center' "
-        "name=maxSkip size=16 value=" <<
-        maxSkip << ">"
-
-        "<tr title='Used by alignment method 0'>"
-        "<th class=left>Maximum ordinal drift" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=maxDrift size=16 value=" <<
-        maxDrift << ">"
-
-        "<tr title='Used by alignment method 0'>"
-        "<th class=left>"
-        "Maximum k-mer frequency " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=maxMarkerFrequency size=16 value=" <<
-        maxMarkerFrequency << ">"
-
-        "<tr title='Used by alignment methods 1 and 3'><th class=left>Match score" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=matchScore size=16 value=" <<
-        matchScore << ">"
-
-        "<tr title='Used by alignment methods 1 and 3'><th class=left>Mismatch score " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=mismatchScore size=16 value=" <<
-        mismatchScore << ">"
-
-        "<tr title='Used by alignment methods 1 and 3'><th class=left>Gap score" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=gapScore size=16 value=" <<
-        gapScore << ">"
-
-        "<tr title='Used by alignment method 3'><th class=left>Downsampling ratio" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=downsamplingFactor size=16 value=" <<
-        downsamplingFactor << ">"
-
-        "<tr title='Used by alignment method 3'><th class=left>Band extend" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=bandExtend size=16 value=" <<
-        bandExtend << ">"
-
-        "<tr title='Used to filter poor alignments'>"
-        "<th class=left>"
-        "Minimum number of aligned markers " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=minAlignedMarkerCount size=16 value=" <<
-        minAlignedMarkerCount << ">"
-
-        "<tr title='Used to filter poor alignments'>"
-        "<th class=left>"
-        "Minimum fraction of aligned markers " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=minAlignedFraction size=16 value=" <<
-        minAlignedFraction << ">"
-
-        "<tr title='Used to filter alignments'>"
-        "<th class=left>Maximum ordinal trim" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=maxTrim size=16 value=" <<
-        maxTrim << ">"
-
-        "</table><p><input type=submit value='Compute marker alignment'>"
-        "</form>";
+    html << "</form>";
 
 
     // If the readId's or strand's are missing, stop here.
@@ -2272,7 +2208,105 @@ void Assembler::displayAlignmentMatrix(
 #endif
 }
 
+void Assembler::renderEditableAlignmentConfig(
+    const int method,
+    const uint64_t maxSkip,
+    const uint64_t maxDrift,
+    const uint32_t maxMarkerFrequency,
+    const uint64_t minAlignedMarkerCount,
+    const double minAlignedFraction,
+    const uint64_t maxTrim,
+    const int matchScore,
+    const int mismatchScore,
+    const int gapScore,
+    const double downsamplingFactor,
+    const uint32_t bandExtend,
+    ostream& html
+) {
+    const auto& descriptions = httpServerData.assemblerOptions->allOptionsDescription;
 
+    html << "<p><table>";
+
+    html << "<tr><th class=left>[Align]<th class=center>Value<th class=left>Description";
+        
+    html << "<tr><th class=left>alignMethod<td>"
+        "<input type=radio computeAllAlignname=method value=0" <<
+        (method==0 ? " checked=checked" : "") << "> 0 (Shasta)<br>"
+        "<input type=radio name=method value=1" <<
+        (method==1 ? " checked=checked" : "") << "> 1 (SeqAn)<br>"
+        "<input type=radio name=method value=2" <<
+        (method==2 ? " checked=checked" : "") << "> 2 (Edlib)<br>"
+        "<input type=radio name=method value=3" <<
+        (method==3 ? " checked=checked" : "") << "> 3 (SeqAn, banded)"
+        "<td>" << descriptions.find("Align.alignMethod", false).description();
+
+    html << "<tr><th class=left>maxSkip"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=maxSkip size=16 value=" << maxSkip << ">"
+        "<td>" << descriptions.find("Align.maxSkip", false).description();
+
+    html << "<tr>"
+        "<th class=left>maxDrift"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=maxDrift size=16 value=" << maxDrift << ">"
+        "<td>" << descriptions.find("Align.maxDrift", false).description();
+
+    html << "<tr>"
+        "<th class=left>maxMarkerFrequency"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=maxMarkerFrequency size=16 value=" << maxMarkerFrequency << ">"
+        "<td>" << descriptions.find("Align.maxMarkerFrequency", false).description();
+
+    html << "<tr>"
+        "<th class=left>matchScore"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=matchScore size=16 value=" << matchScore << ">"
+        "<td>" << descriptions.find("Align.matchScore", false).description();
+
+    html << "<tr>"
+        "<th class=left>mismatchScore "
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=mismatchScore size=16 value=" << mismatchScore << ">"
+        "<td>" << descriptions.find("Align.mismatchScore", false).description();
+
+    html << "<tr>"
+        "<th class=left>gapScore"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=gapScore size=16 value=" << gapScore << ">"
+        "<td>" << descriptions.find("Align.gapScore", false).description();
+
+    html << "<tr>"
+        "<th class=left>downsamplingFactor"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=downsamplingFactor size=16 value=" << downsamplingFactor << ">"
+        "<td>" << descriptions.find("Align.downsamplingFactor", false).description();
+
+    html << "<tr>"
+        "<th class=left>bandExtend"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=bandExtend size=16 value=" << bandExtend << ">"
+        "<td>" << descriptions.find("Align.bandExtend", false).description();
+
+    html << "<tr>"
+        "<th class=left>minAlignedMarkers"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=minAlignedMarkerCount size=16 value=" << minAlignedMarkerCount << ">"
+        "<td>" << descriptions.find("Align.minAlignedMarkerCount", false).description();
+
+    html << "<tr>"
+        "<th class=left>minAlignedFraction"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=minAlignedFraction size=16 value=" << minAlignedFraction << ">"
+        "<td>" << descriptions.find("Align.minAlignedFraction", false).description();
+
+    html << "<tr>"
+        "<th class=left>maxTrim"
+        "<td class=centered>"
+            "<input type=text style='text-align:center' name=maxTrim size=16 value=" << maxTrim << ">"
+        "<td>" << descriptions.find("Align.maxTrim", false).description();
+
+    html << "</table>";
+}
 
 // Compute alignments on an oriented read against
 // all other oriented reads.
@@ -2325,85 +2359,23 @@ void Assembler::computeAllAlignments(
         " on strand ";
     writeStrandSelection(html, "strand0", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
 
-    html <<
-        "<p><table>"
-
-        "<tr><th class=left>Alignment method<td>"
-        "<input type=radio name=method value=0" <<
-        (computeAllAlignmentsData.method==0 ? " checked=checked" : "") << "> 0 (Shasta)<br>"
-        "<input type=radio name=method value=1" <<
-        (computeAllAlignmentsData.method==1 ? " checked=checked" : "") << "> 1 (SeqAn)<br>"
-        "<input type=radio name=method value=2" <<
-        (computeAllAlignmentsData.method==2 ? " checked=checked" : "") << "> 2 (Edlib)<br>"
-        "<input type=radio name=method value=3" <<
-        (computeAllAlignmentsData.method==3 ? " checked=checked" : "") << "> 3 (SeqAn, banded)"
-
-        "<tr title='Used by alignment method 0'><th class=left>"
-        "Maximum ordinal skip<td class=centered>" <<
-        "<input type=text style='text-align:center' "
-        "name=maxSkip size=16 value=" <<
-        computeAllAlignmentsData.maxSkip << ">"
-
-        "<tr title='Used by alignment method 0'>"
-        "<th class=left>Maximum ordinal drift" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=maxDrift size=16 value=" <<
-        computeAllAlignmentsData.maxDrift << ">"
-
-        "<tr title='Used by alignment method 0'>"
-        "<th class=left>"
-        "Maximum k-mer frequency " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=maxMarkerFrequency size=16 value=" <<
-        computeAllAlignmentsData.maxMarkerFrequency << ">"
-
-        "<tr title='Used by alignment methods 1 and 3'><th class=left>Match score" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=matchScore size=16 value=" <<
-        computeAllAlignmentsData.matchScore << ">"
-
-        "<tr title='Used by alignment methods 1 and 3'><th class=left>Mismatch score " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=mismatchScore size=16 value=" <<
-        computeAllAlignmentsData.mismatchScore << ">"
-
-        "<tr title='Used by alignment methods 1 and 3'><th class=left>Gap score" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=gapScore size=16 value=" <<
-        computeAllAlignmentsData.gapScore << ">"
-
-        "<tr title='Used by alignment method 3'><th class=left>Downsampling ratio" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=downsamplingFactor size=16 value=" <<
-        computeAllAlignmentsData.downsamplingFactor << ">"
-
-        "<tr title='Used by alignment method 3'><th class=left>Band extend" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=bandExtend size=16 value=" <<
-        computeAllAlignmentsData.bandExtend << ">"
-
-        "<tr title='Used to filter poor alignments'>"
-        "<th class=left>"
-        "Minimum number of aligned markers " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=minAlignedMarkerCount size=16 value=" <<
-        computeAllAlignmentsData.minAlignedMarkerCount << ">"
-
-        "<tr title='Used to filter poor alignments'>"
-        "<th class=left>"
-        "Minimum fraction of aligned markers " <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=minAlignedFraction size=16 value=" <<
-        computeAllAlignmentsData.minAlignedFraction << ">"
-
-        "<tr title='Used to filter alignments'>"
-        "<th class=left>Maximum ordinal trim" <<
-        "<td class=centered><input type=text style='text-align:center' "
-        "name=maxTrim size=16 value=" <<
-        computeAllAlignmentsData.maxTrim << ">"
-
-        "</table>"
-        "</form>";
+    renderEditableAlignmentConfig(
+        computeAllAlignmentsData.method,
+        computeAllAlignmentsData.maxSkip,
+        computeAllAlignmentsData.maxDrift,
+        computeAllAlignmentsData.maxMarkerFrequency,
+        computeAllAlignmentsData.minAlignedMarkerCount,
+        computeAllAlignmentsData.minAlignedFraction,
+        computeAllAlignmentsData.maxTrim,
+        computeAllAlignmentsData.matchScore,
+        computeAllAlignmentsData.mismatchScore,
+        computeAllAlignmentsData.gapScore,
+        computeAllAlignmentsData.downsamplingFactor,
+        computeAllAlignmentsData.bandExtend,
+        html
+    );
+    
+    html << "</form>";
 
     
     // If the readId or strand are missing, stop here.

--- a/src/html.cpp
+++ b/src/html.cpp
@@ -46,7 +46,7 @@ void shasta::writeStyle(ostream& html)
         border-collapse: collapse;
     }
     th, td {
-        border: 2px solid MediumSlateBlue;
+        border: 1px dashed #b8b5c7d9;
     }
     th {
         font-weight: bold;


### PR DESCRIPTION
1. `exploreAlignment` & `computeAllAlignments` now have a description for each parameter. The description is pulled from `boost::program_options::options_description`, which is populated from the shasta config file.
2. We now use the actual config param name in the first column. This makes the table look quite similar to the `[Align]` section in the configuration file, thereby reducing the cognitive load of getting started with the HTTP server for debugging. 
3. Redid the style sheet to
- De-emphasize the table borders, so that viewer can focus on the data.
- Created a style for `input`, so that the component looks the same on all pages.

![image](https://user-images.githubusercontent.com/858849/82136972-55629980-97c8-11ea-82c4-677b1dfa2e4b.png)

![image](https://user-images.githubusercontent.com/858849/82136984-6a3f2d00-97c8-11ea-9c59-a285732e5166.png)

![image](https://user-images.githubusercontent.com/858849/82136995-79be7600-97c8-11ea-8663-3d36f04b2bc2.png)
