### PR TITLE
Shasta compiles with SeqAn on MacOS.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shasta-Ubuntu-18.04/bin/shasta --input tests/TinyTest.fasta
+        shasta-build/shasta-Ubuntu-18.04/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta
         ls -l ShastaRun/Assembly.fasta
     - uses: actions/upload-artifact@master
       with:
@@ -67,7 +67,7 @@ jobs:
       run: |
         sudo apt install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shastaGpu-Ubuntu-18.04/bin/shastaGpu --input tests/TinyTest.fasta
+        shasta-build/shastaGpu-Ubuntu-18.04/bin/shastaGpu --Align.alignMethod 3 --input tests/TinyTest.fasta
         ls -l ShastaRun/Assembly.fasta
     - uses: actions/upload-artifact@master
       with:
@@ -103,7 +103,7 @@ jobs:
       run: |
         sudo apt install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shasta-Ubuntu-16.04/bin/shasta --input tests/TinyTest.fasta
+        shasta-build/shasta-Ubuntu-16.04/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta
         ls -l ShastaRun/Assembly.fasta
     - uses: actions/upload-artifact@master
       with:
@@ -138,7 +138,7 @@ jobs:
       run: |
         brew install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shasta-install/bin/shasta --input tests/TinyTest.fasta
+        shasta-build/shasta-install/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta
         ls -l ShastaRun/Assembly.fasta
     - uses: actions/upload-artifact@master
       with:
@@ -169,7 +169,7 @@ jobs:
       run: |
         brew install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shasta-install/bin/shasta --input tests/TinyTest.fasta
+        shasta-build/shasta-install/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta
         ls -l ShastaRun/Assembly.fasta
     - uses: actions/upload-artifact@master
       with:

--- a/scripts/InstallPrerequisites-macOS.sh
+++ b/scripts/InstallPrerequisites-macOS.sh
@@ -18,6 +18,9 @@ brew install libpng
 # Assume zlib is always available.
 # brew install zlib 
 
+# Install SeqAn 2.4.0
+brew install brewsci/bio/seqan@2
+
 # Build the spoa library (static library only).
 
 # Create a temporary directory and cd to it.

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -414,13 +414,9 @@ void Assembler::computeAlignmentsThreadFunction(size_t threadId)
                         maxSkip, maxDrift, maxMarkerFrequency, debug, graph, alignment, alignmentInfo);
 
                 } else if(alignmentMethod == 1) {
-#ifdef __linux__
                     alignOrientedReads1(orientedReadIds[0], orientedReadIds[1],
                         matchScore, mismatchScore, gapScore,
                         alignment, alignmentInfo);
-#else
-                    throw runtime_error("Align method 1 is not supported on macOS.");
-#endif
                 } else if(alignmentMethod == 2) {
                     alignOrientedReads2(orientedReadIds[0], orientedReadIds[1],
                         alignment, alignmentInfo);

--- a/src/AssemblerAlign1.cpp
+++ b/src/AssemblerAlign1.cpp
@@ -6,27 +6,7 @@ using namespace shasta;
 #include "chrono.hpp"
 
 // Seqan.
-#ifdef __linux__
 #include <seqan/align.h>
-#endif
-
-
-
-#ifndef __linux__
-
-// For macOS we don't have SeqAn, so we can't do any of this.
-void Assembler::alignOrientedReads1(
-    ReadId readId0, Strand strand0,
-    ReadId readId1, Strand strand1,
-    int matchScore,
-    int mismatchScore,
-    int gapScore)
-{
-    throw runtime_error("alignOrientedReads1 is not available on macOS.");
-}
-
-#else
-
 
 
 void Assembler::alignOrientedReads1(
@@ -239,7 +219,4 @@ void Assembler::alignOrientedReads1(
 #endif
 
 }
-
-#endif
-
 

--- a/src/AssemblerAlign3.cpp
+++ b/src/AssemblerAlign3.cpp
@@ -6,33 +6,9 @@ using namespace shasta;
 
 
 // Seqan.
-#ifdef __linux__
 #include <seqan/align.h>
-#endif
 
 #include <numeric>
-
-
-
-#ifndef __linux__
-
-// For macOS we don't have SeqAn, so we can't do any of this.
-void Assembler::alignOrientedReads3(
-    OrientedReadId orientedReadId0,
-    OrientedReadId orientedReadId1,
-    int matchScore,
-    int mismatchScore,
-    int gapScore,
-    double downsamplingFactor,  // The fraction of markers to keep in the first step.
-    int bandExtend,             // How much to extend the band computed in the first step.
-    Alignment& alignment,
-    AlignmentInfo& alignmentInfo)
-{
-    throw runtime_error("alignOrientedReads3 is not available on macOS.");
-}
-
-#else
-
 
 
 // Align two oriented reads using SeqAn banded alignment.
@@ -309,4 +285,3 @@ void Assembler::alignOrientedReads3(
 
 }
 
-#endif

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -20,9 +20,7 @@ using namespace shasta;
 
 // Seqan
 #ifdef SHASTA_HTTP_SERVER
-#ifdef __linux__
 #include <seqan/align.h>
-#endif
 #endif
 
 
@@ -1782,14 +1780,9 @@ void Assembler::exploreAlignment(
             return;
         }
     } else if(method == 1) {
-#ifdef __linux__
         alignOrientedReads1(
             orientedReadId0, orientedReadId1,
             matchScore, mismatchScore, gapScore, alignment, alignmentInfo);
-#else
-        html << "<p>Alignment method 1 is not available on macOS.";
-        return;
-#endif
     } else if(method == 2) {
         alignOrientedReads2(
             orientedReadId0, orientedReadId1,
@@ -2411,13 +2404,6 @@ void Assembler::computeAllAlignments(
         return;
     }
  
-#ifndef __linux__
-    if (computeAllAlignmentsData.method == 1) {
-        html << "Alignment method 1 is not supported on macOS.";
-        return;
-    }
-#endif
- 
     const OrientedReadId orientedReadId0(readId0, strand0);
 
     // Vectors to contain markers sorted by kmerId.
@@ -2597,13 +2583,9 @@ void Assembler::computeAllAlignmentsThreadFunction(size_t threadId)
                         markersSortedByKmerId,
                         maxSkip, maxDrift, maxMarkerFrequency, debug, graph, alignment, alignmentInfo);
                 } else if (method == 1) {
-#ifdef __linux__
                     alignOrientedReads1(
                         orientedReadId0, orientedReadId1,
                         matchScore, mismatchScore, gapScore, alignment, alignmentInfo);
-#else
-                    continue;
-#endif
                 } else if (method == 2) {
                     alignOrientedReads2(
                         orientedReadId0, orientedReadId1,

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -508,15 +508,11 @@ void Assembler::createMarkerGraphVerticesThreadFunction1(size_t threadId)
                         markersSortedByKmerId,
                         maxSkip, maxDrift, maxMarkerFrequency, debug, graph, alignment, alignmentInfo);
                 } else if(alignMethod == 1) {
-    #ifdef __linux__
                     alignOrientedReads1(
                         orientedReadIds[0], orientedReadIds[1],
                         matchScore, mismatchScore, gapScore,
                         alignment, alignmentInfo
                     );
-    #else
-                    throw runtime_error("Alignment method 1 is not supported on macOS.");
-    #endif
                 } else if(alignMethod == 2) {
                     alignOrientedReads2(
                         orientedReadIds[0], orientedReadIds[1],


### PR DESCRIPTION
Test Plan: MacOS build plans succeed in Github actions. Looking at the logs, verified that it installed Seqan v2.4.0. There's no way to specify the exact version - the best I can do is `seqan@2`. It should be fine though because SeqAn 3 is out and I don't expect there to be many more 2.* releases.