### PR TITLE
Link to portable version of SPOA library. Build a portable version of Shasta by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,7 @@ message(STATUS "BUILD_APPIMAGE is " ${BUILD_APPIMAGE})
 
 
 # Option to build with -march=native.
-if(MACOS)
-    option(BUILD_NATIVE "Build with -march=native." OFF)
-else(MACOS)
-    option(BUILD_NATIVE "Build with -march=native." ON)
-endif(MACOS)
+option(BUILD_NATIVE "Build with -march=native." OFF)
 message(STATUS "BUILD_NATIVE is " ${BUILD_NATIVE})
 
 

--- a/scripts/InstallPrerequisites-Ubuntu.sh
+++ b/scripts/InstallPrerequisites-Ubuntu.sh
@@ -44,7 +44,7 @@ tar -xvf spoa-v3.0.0.tar.gz
 # Build the shared library.
 mkdir build
 cd build
-cmake ../spoa-v3.0.0 -DBUILD_SHARED_LIBS=ON
+cmake ../spoa-v3.0.0 -DBUILD_SHARED_LIBS=ON -Dspoa_optimize_for_native=OFF
 make -j all
 make install
 


### PR DESCRIPTION
Portable version of Shasta is near-as-makes-no-difference as performant as the native one. Same is true for the SPOA library. Any wins from using special instruction sets only seem to appear for longer sequences, which is not how Shasta uses SPOA.