### PR TITLE
Clean up docs and Build files.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,8 +19,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta Release 0.4.0" 
+        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
+        # cmake .. -DBUILD_ID="Shasta Release 0.4.0" 
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-18.04
@@ -55,8 +55,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta Release 0.4.0"
+        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
+        # cmake .. -DBUILD_ID="Shasta Release 0.4.0"
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-16.04
@@ -90,8 +90,8 @@ jobs:
       run: |
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta unreleased test build for MacOS-10.14 newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta Release 0.4.0 for MacOS-10.14"
+        cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.14 newer than release 0.4.0 at commit "$GITHUB_SHA
+        # cmake .. -DBUILD_ID="Shasta Release 0.4.0 for MacOS-10.14"
         make VERBOSE=1 -j 2 all
         make install/strip
         # See what libraries the executable depends on.
@@ -121,8 +121,8 @@ jobs:
       run: |
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta unreleased test build for MacOS-10.15 newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta Release 0.4.0 for MacOS-10.15"
+        cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.15 newer than release 0.4.0 at commit "$GITHUB_SHA
+        # cmake .. -DBUILD_ID="Shasta Release 0.4.0 for MacOS-10.15"
         make VERBOSE=1 -j 2 all
         make install/strip
         # See what libraries the executable depends on.

--- a/docs/BuildingFromSource.html
+++ b/docs/BuildingFromSource.html
@@ -167,43 +167,6 @@ build directory.
 
 
 
-<h3 id=Portability>Build portability</h3>
-<p>
-For best assembly performance, the build process described above
-creates binaries that use the full instruction set
-available on the build machine (via gcc option <code>-march=native</code>).
-This gives the best possible runtime performance on the build machine,
-but <b>creates a build that is not necessarily portable across machines</b>.
-If you run the build created in this way on a different machine
-with a smaller instruction set, you may get a crash with an 
-<code>Illegal instruction</code> signal.
-
-<p>
-To create a build that is portable but less performant,
-add the following to your <code>cmake</code> command:
-<pre>
--DBUILD_NATIVE=OFF
-</pre>
-<p>
-This generates a build that only uses instructions
-available on all <code>x64_86</code> machines.
-Release builds use this option for portability.
-For this reason, it is best not to use release builds
-for large runs where performance is important.
-See <a href=Performance.html>here</a>
-for other tips to improve performance.
-
-<p>
-If you want to build a more performant but non-portable version of
-a release build for your machine,
-make sure to use the following command (while in the <code>shasta</code> directory) before running
-the <code>cmake</code> command, replacing <code>0.1.0</code> with the desired release number.
-<pre>
-git checkout 0.1.0
-</pre>
-
-
-
 <h2 id="DownloadTestBuild">An alternative to building from source: downloading a test build</h2>
 <p>
 Shasta uses 

--- a/docs/MakeRelease.html
+++ b/docs/MakeRelease.html
@@ -48,8 +48,6 @@
     <main>
 <h1>Creating a new release</h1>
 
-
-<h2>Current procedure</h2>
 <ul>
 <li>Make sure there are no outstanding commits or
 pull requests that should be in the new release.
@@ -92,69 +90,6 @@ change the build id to
 in 4 places for future GitHub Actions builds.
 </ul>
 
-
-<h2>Procedure used for release 0.1.0</h2>
-<ul>
-<li>Make sure there are no outstanding commits or
-pull requests that should be in the new release.
-<li>Do some testing.
-<li>Pick a release number <code>X.Y.Z</code>. 
-To stay consistent with
-<a href='https://semver.org'>Semantic Versioning</a>,
-for now stay with <code>X=0</code>.
-Increment <code>Z</code> by one if only bug fixes were made, and otherwise 
-increment <code>Y</code> by one and reset <code>Z</code> to zero.
-<li>Create the release on GitHub and write some release notes.
-
-<li>On Ubuntu 16.04, with the prerequisites installed:
-<ul>
-<li>Use the following commands to create the tar file:
-<pre>
-git clone https://github.com/chanzuckerberg/shasta.git
-mkdir shasta-build
-cd shasta-build
-cmake ../shasta -DBUILD_ID="Shasta Release X.Y.Z" -DBUILD_NATIVE=OFF
-make -j install/strip
-mv shasta-install shasta-Ubuntu-16.04-X.Y.Z
-tar -cvf shasta-Ubuntu-16.04-X.Y.Z.tar shasta-Ubuntu-16.04-X.Y.Z</pre>
-<li>Upload <code>shasta-Ubuntu-16.04-X.Y.Z.tar</code> to the GitHub page for the release.
-<li>Rename <code>shasta-install/bin/shasta</code> to <code>shasta-Linux-X.Y.Z</code>
-and upload it to the GitHub page for the release.
-</ul>
-
-
-<li>On Ubuntu 18.04, with the prerequisites installed:
-<ul>
-<li>Use the following commands to create the tar file:
-<pre>
-git clone https://github.com/chanzuckerberg/shasta.git
-mkdir shasta-build
-cd shasta-build
-cmake ../shasta -DBUILD_ID="Shasta Release X.Y.Z" -DBUILD_NATIVE=OFF
-make -j install/strip
-mv shasta-install shasta-Ubuntu-18.04-X.Y.Z
-tar -cvf shasta-Ubuntu-18.04-X.Y.Z.tar shasta-Ubuntu-18.04-X.Y.Z</pre>
-<li>Upload <code>shasta-Ubuntu-18.04-X.Y.Z.tar</code> to the GitHub page for the release.
-</ul>
-
-
-<li>On macOS, with the prerequisites installed:
-<ul>
-<li>Use the following commands to create the tar file:
-<pre>
-git clone https://github.com/chanzuckerberg/shasta.git
-mkdir shasta-build
-cd shasta-build
-cmake ../shasta -DBUILD_ID="Shasta Release X.Y.Z" -DBUILD_NATIVE=OFF
-make -j install/strip
-mv shasta-install/bin/shasta shasta-macOS-X.Y.Z
-</pre>
-<li>Upload <code>shasta-install/bin/shasta-macOS-X.Y.Z</code> to the GitHub page for the release.
-</ul>
-
-<li>Publish the release on GitHub.
-<li>After the release has been published it should not be modified or deleted.
-</ul>
 
 </main>
 </body>

--- a/docs/Performance.html
+++ b/docs/Performance.html
@@ -68,32 +68,6 @@ Don't use macOS or Windows. Use a 64-bit Linux system instead.
 The Shasta executable runs on most current 64-bit Linux distributions
 and requires no set up or installation.
 
-<li>
-Do not use a release build downloaded from the 
-<a href='https://github.com/chanzuckerberg/shasta/releases'>Releases</a> page on GitHub.
-Instead build Shasta from source as 
-described <a href=BuildingFromSource.html>here</a>,
-using for the build the same machine where it will run.
-This will limit you to Ubuntu 16.04 or Ubuntu 18.04.
-The reason for this is that, 
-except for release builds, Shasta code is compiled using
-gcc option <code>-march=native</code>, which instructs
-the compiler to use the entire instruction 
-set available on the machine that does the compilation.
-This generally results in better performance on that machine. 
-However,
-the build may fail with an <code>Illegal instruction</code>
-signal if transported to a different machine with a
-less powerful instruction set. 
-To disable the <code>-march=native</code> option
-and build portable but less performing code,
-specify <code>-DBUILD_NATIVE=OFF</code> when running <code>cmake</code>
-(release builds do this).
-See <a href=BuildingFromSource.html>here</a>
-for more information on how to build from source.
-
-
-
 </ul>
 </main>
 </body>


### PR DESCRIPTION
cmake is now configured to generate a portable binary by default. Cleaning up the docs to reflect that.