### PR TITLE
Adding a configuration option to skip flagging of Palindromic reads.

### DIFF
--- a/conf/shasta.conf
+++ b/conf/shasta.conf
@@ -29,6 +29,7 @@ noCache = False
 
 # Parameters for flagPalindromicReads.
 # See the code for their meaning.
+palindromicReads.skipFlagging = False
 palindromicReads.maxSkip = 100
 palindromicReads.maxMarkerFrequency = 10
 palindromicReads.alignedFractionThreshold = 0.1

--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -364,7 +364,7 @@ Can help performance, but only use it if you know you will not
 need to access the input files again soon.
 
 <tr id='Reads.palindromicReads.skipFlagging'>
-<td><code>--Reads.palindromicReads.skipFlaging</code><td class=centered><code>False</code><td>
+<td><code>--Reads.palindromicReads.skipFlagging</code><td class=centered><code>False</code><td>
 Skip flagging palindromic reads. Oxford Nanopore reads should be flagged for better results.
 
 <tr id='Reads.palindromicReads.maxSkip'>

--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -363,6 +363,10 @@ Implemented for Linux only (uses the <a href='http://man7.org/linux/man-pages/ma
 Can help performance, but only use it if you know you will not 
 need to access the input files again soon.
 
+<tr id='Reads.palindromicReads.skipFlagging'>
+<td><code>--Reads.palindromicReads.skipFlaging</code><td class=centered><code>False</code><td>
+Skip flagging palindromic reads. Oxford Nanopore reads should be flagged for better results.
+
 <tr id='Reads.palindromicReads.maxSkip'>
 <td><code>--Reads.palindromicReads.maxSkip</code><td class=centered><code>100</code><td>
 Used for palindromic read detection.

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -208,6 +208,11 @@ void AssemblerOptions::addConfigurableOptions()
         "This is done by specifying the O_DIRECT flag when opening "
         "input files containing reads.")
 
+        ("Reads.palindromicReads.skipFlagging",
+        bool_switch(&readsOptions.palindromicReads.skipFlagging)->
+        default_value(false),
+        "Skip flagging palindromic reads. Oxford Nanopore reads should be flagged for better results.")
+
         ("Reads.palindromicReads.maxSkip",
         value<int>(&readsOptions.palindromicReads.maxSkip)->
         default_value(100),
@@ -558,6 +563,7 @@ void AssemblerOptions::addConfigurableOptions()
 
 void AssemblerOptions::ReadsOptions::PalindromicReadOptions::write(ostream& s) const
 {
+    s << "palindromicReads.skipFlagging = " << skipFlagging << "\n";
     s << "palindromicReads.maxSkip = " << maxSkip << "\n";
     s << "palindromicReads.maxDrift = " << maxDrift << "\n";
     s << "palindromicReads.maxMarkerFrequency = " << maxMarkerFrequency << "\n";

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -563,7 +563,7 @@ void AssemblerOptions::addConfigurableOptions()
 
 void AssemblerOptions::ReadsOptions::PalindromicReadOptions::write(ostream& s) const
 {
-    s << "palindromicReads.skipFlagging = " << skipFlagging << "\n";
+    s << "palindromicReads.skipFlagging = " << convertBoolToPythonString(skipFlagging) << "\n";
     s << "palindromicReads.maxSkip = " << maxSkip << "\n";
     s << "palindromicReads.maxDrift = " << maxDrift << "\n";
     s << "palindromicReads.maxMarkerFrequency = " << maxMarkerFrequency << "\n";

--- a/src/AssemblerOptions.hpp
+++ b/src/AssemblerOptions.hpp
@@ -108,6 +108,7 @@ public:
         bool noCache;
         class PalindromicReadOptions {
         public:
+            bool skipFlagging;
             int maxSkip;
             int maxDrift;
             int maxMarkerFrequency;

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -559,17 +559,18 @@ void shasta::main::assemble(
     // Find the markers in the reads.
     assembler.findMarkers(0);
 
-    // Flag palindromic reads.
-    // These will be excluded from further processing.
-    assembler.flagPalindromicReads(
-        assemblerOptions.readsOptions.palindromicReads.maxSkip,
-        assemblerOptions.readsOptions.palindromicReads.maxDrift,
-        assemblerOptions.readsOptions.palindromicReads.maxMarkerFrequency,
-        assemblerOptions.readsOptions.palindromicReads.alignedFractionThreshold,
-        assemblerOptions.readsOptions.palindromicReads.nearDiagonalFractionThreshold,
-        assemblerOptions.readsOptions.palindromicReads.deltaThreshold,
-        threadCount);
-
+    if(!assemblerOptions.readsOptions.palindromicReads.skipFlagging) {
+        // Flag palindromic reads.
+        // These will be excluded from further processing.
+        assembler.flagPalindromicReads(
+            assemblerOptions.readsOptions.palindromicReads.maxSkip,
+            assemblerOptions.readsOptions.palindromicReads.maxDrift,
+            assemblerOptions.readsOptions.palindromicReads.maxMarkerFrequency,
+            assemblerOptions.readsOptions.palindromicReads.alignedFractionThreshold,
+            assemblerOptions.readsOptions.palindromicReads.nearDiagonalFractionThreshold,
+            assemblerOptions.readsOptions.palindromicReads.deltaThreshold,
+            threadCount);
+    }
 
 
     // Find alignment candidates.


### PR DESCRIPTION
Verfied that passing a boolean switch command line option `--Reads.palindromicReads.skipFlagging` skips that step. 