### PR TITLE
Name the Ubuntu-20-04 artifact shasta-Linux-Beta

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -64,10 +64,6 @@ jobs:
         ls -l ShastaRun/Assembly.fasta
     - uses: actions/upload-artifact@master
       with:
-        name: shasta-Linux
-        path: shasta-build/shasta-Ubuntu-18.04/bin/shasta
-    - uses: actions/upload-artifact@master
-      with:
         name: shasta-Ubuntu-18.04.tar
         path: shasta-build/shasta-Ubuntu-18.04.tar
 


### PR DESCRIPTION
...  to distinguish it from shasta-Linux which is built on Ubuntu 18.04. 