### PR TITLE
Reuse spoa::AlignmentGraph object to reduce memory allocations.

### DIFF
--- a/scripts/InstallPrerequisites-macOS.sh
+++ b/scripts/InstallPrerequisites-macOS.sh
@@ -29,14 +29,14 @@ echo $tmpDirectoryName
 cd $tmpDirectoryName
 
 # Get the code.
-curl -L https://github.com/rvaser/spoa/releases/download/3.0.0/spoa-v3.0.0.tar.gz \
-    -o spoa-v3.0.0.tar.gz
-tar -xvf spoa-v3.0.0.tar.gz
+curl -L https://github.com/rvaser/spoa/releases/download/3.4.0/spoa-v3.4.0.tar.gz \
+    -o spoa-v3.4.0.tar.gz
+tar -xvf spoa-v3.4.0.tar.gz
 
 # Build the static library.
 mkdir build-static
 cd build-static
-cmake ../spoa-v3.0.0 -DBUILD_SHARED_LIBS=OFF -Dspoa_optimize_for_native=OFF
+cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=OFF
 make -j all
 make install
 cd 

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -29,6 +29,8 @@
 #include "string.hpp"
 #include "tuple.hpp"
 
+// Spoa.
+#include "spoa/spoa.hpp"
 
 namespace shasta {
 
@@ -1547,6 +1549,8 @@ private:
     void computeMarkerGraphEdgeConsensusSequenceUsingSpoa(
         MarkerGraph::EdgeId,
         uint32_t markerGraphEdgeLengthThresholdForConsensus,
+        const std::unique_ptr<spoa::AlignmentEngine>& spoaAlignmentEngine,
+        const std::unique_ptr<spoa::Graph>& spoaAlignmentGraph,
         vector<Base>& sequence,
         vector<uint32_t>& repeatCounts,
         uint8_t& overlappingBaseCount,

--- a/src/AssemblerHttpServer-MarkerGraph.cpp
+++ b/src/AssemblerHttpServer-MarkerGraph.cpp
@@ -822,9 +822,19 @@ void Assembler::exploreMarkerGraphEdge(const vector<string>& request, ostream& h
     vector<uint32_t> spoaRepeatCounts;
     uint8_t spoaOverlappingBaseCount;
     ComputeMarkerGraphEdgeConsensusSequenceUsingSpoaDetail spoaDetail;
+    
+    const spoa::AlignmentType alignmentType = spoa::AlignmentType::kNW;
+    const int8_t match = 1;
+    const int8_t mismatch = -1;
+    const int8_t gap = -1;
+    auto spoaAlignmentEngine = spoa::createAlignmentEngine(alignmentType, match, mismatch, gap);
+    auto spoaAlignmentGraph = spoa::createGraph();
+    
     computeMarkerGraphEdgeConsensusSequenceUsingSpoa(
         edgeId,
         markerGraphEdgeLengthThresholdForConsensus,
+        spoaAlignmentEngine,
+        spoaAlignmentGraph,
         spoaSequence,
         spoaRepeatCounts,
         spoaOverlappingBaseCount,


### PR DESCRIPTION
This results in around **5%** speed up in the **SPOA portion of Shasta code**. _It is a much smaller win in the grand scheme of things_. But the modified code is clean and there's no good reason to turn our backs on an easy win like this.

_Test Plan_: Ran an assembly and the looked at the edge at http://<ip-address>:17100/exploreMarkerGraphEdge?edgeId=<edgeId>. It looks alright. 