### PR TITLE
Write suppressed alignment candidates to a csv file.

### DIFF
--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -1121,6 +1121,9 @@ void Assembler::suppressAlignmentCandidates(
     setupLoadBalancing(alignmentCandidates.candidates.size(), batchSize);
     runThreads(&Assembler::suppressAlignmentCandidatesThreadFunction, threadCount);
 
+    ofstream csv("SuppressedAlignmentCandidates.csv");
+    csv << "ReadId0,ReadId1,SameStrand,Name0,Name1,MetaData0,MetaData1" << endl;
+
     // Suppress the alignment candidates we flagged.
     cout << "Number of alignment candidates before suppression is " << candidateCount << endl;
     uint64_t j = 0;
@@ -1130,12 +1133,10 @@ void Assembler::suppressAlignmentCandidates(
             ++suppressCount;
             const ReadId readId0 = alignmentCandidates.candidates[i].readIds[0];
             const ReadId readId1 = alignmentCandidates.candidates[i].readIds[1];
-            cout << "Suppressing alignment candidate " <<
-                readId0 << " " <<
-                readId1 << " " <<
-                int(alignmentCandidates.candidates[i].isSameStrand) << endl;
-            cout << readId0 << " " << readNames[readId0] << " " << readMetaData[readId0] << endl;
-            cout << readId1 << " " << readNames[readId1] << " " << readMetaData[readId1] << endl;
+            csv << readId0 << "," << readId1 << ","
+                << (alignmentCandidates.candidates[i].isSameStrand ? "Yes" : "No") << ","
+                << readNames[readId0] << "," << readNames[readId1] << ","
+                << readMetaData[readId0] << "," << readMetaData[readId1] << endl;
         } else {
             alignmentCandidates.candidates[j++] =
                 alignmentCandidates.candidates[i];

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -1145,7 +1145,7 @@ void Assembler::suppressAlignmentCandidates(
     SHASTA_ASSERT(j + suppressCount == candidateCount);
     alignmentCandidates.candidates.resize(j);
     cout << "Suppressed " << suppressCount << " alignment candidates." << endl;
-    cout << "Number of alignment candidates after suppression is " << candidateCount << endl;
+    cout << "Number of alignment candidates after suppression is " << j << endl;
 
 
     // Clean up.

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -1114,6 +1114,10 @@ void Assembler::writeAssemblyIndex(ostream& html) const
     <td><a href='ReadLengthHistogram.csv'>ReadLengthHistogram.csv</a>
     <td>Detailed read length distribution.
 
+    <tr>
+    <td><a href='SuppressedAlignmentCandidates.csv'>SuppressedAlignmentCandidates.csv</a>
+    <td>Details of suppressed alignment candidates.
+
     </table>
     </body>
 )ABCDE";


### PR DESCRIPTION
Tested on `HG002-Guppy-3.6.0-run1/20.fasta` with the following configuration ...

```
/path/to/shasta --input /path/to/input/file --memoryMode filesystem --memoryBacking 2M --Align.alignMethod 3 --Align.sameChannelReadAlignment.suppressDeltaThreshold 100
```
Verfied that logging to CSV file works as expected. 