### PR TITLE
Minor changes to documentation.

### DIFF
--- a/docs/BuildingFromSource.html
+++ b/docs/BuildingFromSource.html
@@ -59,7 +59,7 @@ Even better, submit a Pull Request with the necessary changes.
 <pre>
 git clone https://github.com/chanzuckerberg/shasta.git
 </pre>
-<li>Install prerequisite packages
+<li>Install <a href="Prerequisites.html">prerequisite packages</a>
 <pre>
 sudo shasta/scripts/InstallPrerequisites-Ubuntu.sh
 

--- a/docs/BuildingFromSource.html
+++ b/docs/BuildingFromSource.html
@@ -46,61 +46,35 @@ To port the Shasta build to a different platform.
 
 <h3>Build platforms</h3>
 <p>
-Building from source is currently only possible on an 
-Ubuntu 16.04 or 18.04 machine.
+Building from source is currently supported for Ubuntu (16.04, 18.04 & 20.04 LTS) and macOS (10.14 & 10.15).
 Porting the build process to other Linux platforms is possible.
 If you are specifically interested in porting to a different Linux
 platorm, please file an Issue on GitHub.
 Even better, submit a Pull Request with the necessary changes.
 
-<p>
-For best performance, the build process described below
-creates binaries optimized for the build machine.
-If you plan on using the build on a different
-machine, see 
-<a href='#Portability'>Build portability</a> below.
-
-
 
 <h3>Build commands</h3>
-<p>
-If you have the necessary 
-<a href=Prerequisites.html>prerequisite packages</a> installed, 
-you can get a local copy of the latest code and build it
-using the following commands: 
+<ol>
+<li>Check out Shasta repository
 <pre>
 git clone https://github.com/chanzuckerberg/shasta.git
-mkdir shasta-build
-cd shasta-build
-cmake ../shasta
-make all
-make install
 </pre>
-
-<p>
-If you are not sure if you have the necessary prerequisite packages installed, 
-you can instead
-use the following commands
-(this assumes that you are authorized to acquire root privileges
-using the <code>sudo</code> command - depending on set up you may be asked 
-to enter your password):
+<li>Install prerequisite packages
 <pre>
-sudo apt install git
-git clone https://github.com/chanzuckerberg/shasta.git
 sudo shasta/scripts/InstallPrerequisites-Ubuntu.sh
+
+# OR
+
+sudo shasta/scripts/InstallPrerequisites-macOS.sh
+</pre>
+<li>Build
+<pre>
 mkdir shasta-build
 cd shasta-build
 cmake ../shasta
-make all
+make all -j
 make install
 </pre>
-
-<p>
-If your build system has more than one processor
-and enough memory, you can speed up the build using the <code>-j</code>
-option in the <code>make all</code> command.
-
-
 
 
 <h3>Build contents</h3>

--- a/docs/BuildingFromSource.html
+++ b/docs/BuildingFromSource.html
@@ -55,7 +55,7 @@ Even better, submit a Pull Request with the necessary changes.
 
 <h3>Build commands</h3>
 <ol>
-<li>Check out Shasta repository
+<li>Check out Shasta repository (You need to have <code>git</code> installed on your machine)
 <pre>
 git clone https://github.com/chanzuckerberg/shasta.git
 </pre>

--- a/docs/BuildingFromSource.html
+++ b/docs/BuildingFromSource.html
@@ -13,16 +13,14 @@
 
 <h2>When is it necessary to build from source?</h2>
 <p>
-In many cases, you don't need to worry about building from source,
+In most cases, you don't need to build from source,
 and instead you can use a release build
 downloaded from the 
-<a href='https://github.com/chanzuckerberg/shasta/releases'>Releases</a> page on GitHub. 
-You only need to build from source in one of the
+<a href='https://github.com/chanzuckerberg/shasta/releases'>Releases</a> page on GitHub.
+(See the <a href="QuickStart.html">quick start</a> page for more information)
+You need to build from source in one of the
 following circumstances:
 <ul>
-<li>
-To maximimize performance. 
-See <a href=Performance.html>here</a> for more information.
 <li>
 To build a version of Shasta for which no release exists.
 For example, if you want to get a recently added feature
@@ -35,10 +33,6 @@ To test, develop, or debug Shasta code.
 <li>
 To port the Shasta build to a different platform.
 </ul>
-
-
-
-
 
 
 

--- a/docs/Prerequisites.html
+++ b/docs/Prerequisites.html
@@ -14,7 +14,7 @@
 
 <p>
 To download, build and run the <code>shasta</code> software on a
-ubuntu 16.04 or 18.04 machine, the following packages are required:
+Ubuntu (16.04, 18.04, 20.04) or macOS (10.14, 10.15) machine, the following packages are required:
 
 <table>
 <tr>
@@ -112,16 +112,16 @@ ubuntu 16.04 or 18.04 machine, the following packages are required:
 <td style='text-align:center'>&#x2714;
 <td>
 <td>
-<td>See <code>InstallPrerequisites-Ubuntu.sh</code> for installation from GitHub.
+<td>See <code>InstallPrerequisites-Ubuntu.sh</code> & <code>InstallPrerequisites-macOS.sh</code> for installation from GitHub.
 
+<tr>
+<td>SPOA 3.4.0
+<td>
+<td style='text-align:center'>&#x2714;
+<td>
+<td>
+<td>See <code>InstallPrerequisites-Ubuntu.sh</code> & <code>InstallPrerequisites-macOS.sh</code> for installation from GitHub.
 </table>
-
-<p>
-Script <code>shasta/scripts/InstallPrerequisites-Ubuntu.sh</code>
-can be used to install these prerequisites. 
-It must be run with root privileges.
-After building the code, this script is also available as
-<code>shasta-install/bin/InstallPrerequisites-Ubuntu.sh</code>.
 
 <div class="goto-index"><a href="index.html">Table of contents</a></div>
 </main>

--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -21,21 +21,15 @@ See below for more information, including some small changes required for macOS 
 You can use the following commands to download the executable from the latest release and run an assembly:
 <pre>
 # Get the latest release version.
-TAG=$(curl -s https://api.github.com/repos/chanzuckerberg/shasta/releases/latest \
-    | grep '"tag_name":' \
-    | tr -d ' ' \
-    | cut -f4 -d '"')
- 
-echo "Latest release is v$TAG."
 
 # Download the executable for the latest release.
-curl -O -L  https://github.com/chanzuckerberg/shasta/releases/download/$TAG/shasta-Linux-$TAG
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.4.0/shasta-Linux-0.4.0
 
 # Grant necessary permissions.
-chmod ugo+x shasta-Linux-$TAG
+chmod ugo+x shasta-Linux-0.4.0
 
 # Run an assembly.
-./shasta-Linux-$TAG --input input.fasta
+./shasta-Linux-0.4.0 --input input.fasta
 </pre>
 
 You can specify multiple input FASTA files, if necessary.
@@ -75,22 +69,14 @@ to achieve maximum performance.
 <h2>macOS</h2>
 
 <pre>
-# Get the latest release version.
-TAG=$(curl -s https://api.github.com/repos/chanzuckerberg/shasta/releases/latest \
-    | grep '"tag_name":' \
-    | tr -d ' ' \
-    | cut -f4 -d '"')
- 
-echo "Latest release is v$TAG."
- 
 # Download the executable for the latest release.
-curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/$TAG/shasta-macOS-$TAG
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.4.0/shasta-macOS-0.4.0
 
 # Grant necessary permissions.
-chmod ugo+x shasta-macOS-$TAG
+chmod ugo+x shasta-macOS-0.4.0
 
 # Run an assembly.
-./shasta-macOS-$TAG --input input.fasta
+./shasta-macOS-0.4.0 --input input.fasta
 </pre>
 
 <h2>Windows</h2>

--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -11,52 +11,47 @@
 <div class="goto-index"><a href="index.html">Table of contents</a></div>
 <h1>Quick start</h1>
 
-
-<h2>Summary</h2>
-<p>
-You can use the following commands to download the executable and run an assembly:
-<pre>
-wget https://github.com/chanzuckerberg/shasta/releases/download/0.1.0/shasta-Linux-0.1.0
-chmod ugo+x shasta-Linux-0.1.0
-./shasta-Linux-0.1.0 --input input.fasta
-</pre>
-
-
-<p>
 Note that the Shasta executable has no dependencies and requires no installation
 or set up, except for setting its execute permission.
 See below for more information, including some small changes required for macOS and Windows.
 
 
 <h2>Linux</h2>
-
-<ul>
-<li>Download the Linux static executable <code>shasta-Linux-X.Y.Z</code> for your selected release. 
-You can use your browser or the following command, replacing <code>X.Y.Z</code> with 
-the release you want to use:
+<p>
+You can use the following commands to download the executable from the latest release and run an assembly:
 <pre>
-wget https://github.com/chanzuckerberg/shasta/releases/download/X.Y.Z/shasta-Linux-X.Y.Z
+# Get the latest release version.
+TAG=$(curl -s https://api.github.com/repos/chanzuckerberg/shasta/releases/latest \
+    | grep '"tag_name":' \
+    | tr -d ' ' \
+    | cut -f4 -d '"')
+ 
+echo "Latest release is v$TAG."
+
+# Download the executable for the latest release.
+curl -O -L  https://github.com/chanzuckerberg/shasta/releases/download/$TAG/shasta-Linux-$TAG
+
+# Grant necessary permissions.
+chmod ugo+x shasta-Linux-$TAG
+
+# Run an assembly.
+./shasta-Linux-$TAG --input input.fasta
 </pre>
-<li>Use this command to set its permission bits: 
-<pre>chmod ugo+x shasta-Linux-X.Y.Z</pre>
-<li>Use this command to run your assembly, making sure to specify
-the correct path to the location where you stored the executable,
-or to add that location to your <code>PATH</code>
-environment variable:
-<pre>./shasta-Linux-X.Y.Z --input input.fasta</pre>
+
 You can specify multiple input FASTA files, if necessary.
 On a typical laptop, this will run in minutes for a bacterial genome.
 For a human size assembly, AWS instance type <code>x1.32xlarge</code>
 is recommended. It is usually available at a cost around $4/hour
 on the AWS spot market and should complete the human size assembly
 in a few hours, at coverage around 60x.
-<li>Assembly output will be created in a new directory named
+<p>
+Assembly output will be created in a new directory named
 <code>ShastaRun</code>. 
 Output includes the assembly in FASTA and GFA 1.0 formats in files:
 <ul>
 <li><code>ShastaRun/Assembly.fasta</code>
 <li><code>ShastaRun/Assembly.gfa</code>
-</ul>
+<li><code>ShastaRun/Assembly-BothStrands.gfa</code>
 </ul>
 This will work on most current 64 bit Linux distributions. 
 It was tested on at least the following Linux distributions for the 
@@ -64,11 +59,9 @@ It was tested on at least the following Linux distributions for the
 that it will run on any Linux distribution for <code>x86_64</code>
 that uses a current kernel.
 <ul>
-<li>Ubuntu 16.04 and 18.04
-<li>Linux Mint 18.3
-<li>CentOS 7.6
-<li>Debian 9
-<li>Fedora 29
+<li>Ubuntu 16.04 LTS
+<li>Ubuntu 18.04 LTS
+<li>Ubuntu 20.04 LTS
 </ul>
 
 <p>
@@ -80,14 +73,25 @@ to achieve maximum performance.
 
 
 <h2>macOS</h2>
-Use the Linux directions, but instead download the mac executable with
-<pre><code>
-curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/X.Y.Z/shasta-macOS-X.Y.Z
-</code></pre>
 
-Make sure to change the name of the executable from
-<code>shasta-Linux-X.Y.Z</code> to <code>shasta-macOS-X.Y.Z</code> in
-later steps.
+<pre>
+# Get the latest release version.
+TAG=$(curl -s https://api.github.com/repos/chanzuckerberg/shasta/releases/latest \
+    | grep '"tag_name":' \
+    | tr -d ' ' \
+    | cut -f4 -d '"')
+ 
+echo "Latest release is v$TAG."
+ 
+# Download the executable for the latest release.
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/$TAG/shasta-macOS-$TAG
+
+# Grant necessary permissions.
+chmod ugo+x shasta-macOS-$TAG
+
+# Run an assembly.
+./shasta-macOS-$TAG --input input.fasta
+</pre>
 
 <h2>Windows</h2>
 <ul>
@@ -98,18 +102,16 @@ Windows Subsystem for Linux (WSL)</a>.
 <li>Working in a Linux shell created using WSL, follow the directions for Linux above.
 </ul>
 
-
+<br/>
 <h2 id=demo>Quick test and demonstration</h2>
 <p>
 You can use the following commands to run a quick test and demonstration
 of the Shasta assembler:
 <pre>
-wget https://s3-us-west-2.amazonaws.com/lc2019/shasta/ecoli_test/r94_ec_rad2.181119.60x-10kb.fasta.gz
+curl -O -L https://s3-us-west-2.amazonaws.com/lc2019/shasta/ecoli_test/r94_ec_rad2.181119.60x-10kb.fasta.gz
 gunzip r94_ec_rad2.181119.60x-10kb.fasta.gz
-./shasta-Linux-0.1.0 --input r94_ec_rad2.181119.60x-10kb.fasta
+/path/to/shasta_executable --input r94_ec_rad2.181119.60x-10kb.fasta
 </pre>
-This assumes that <code>shasta-Linux-0.1.0</code> was downloaded
-to the current directory and made executable as described at the top of this page.
 The first two commands download and decompress an input fasta file 
 containing Oxford Nanopore reads for <i>E. coli</i>.
 The last command runs a Shasta assembly, which should complete in a few minutes

--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -16,7 +16,7 @@ or set up, except for setting its execute permission.
 See below for more information, including some small changes required for macOS and Windows.
 
 
-<h2>Linux</h2>
+<h2 id="QuickStartLinux">Linux</h2>
 <p>
 You can use the following commands to download the executable from the latest release and run an assembly:
 <pre>
@@ -66,7 +66,7 @@ Those non-default options are, however, necessary
 to achieve maximum performance.
 
 
-<h2>macOS</h2>
+<h2 id="QuickStartMacOS">macOS</h2>
 
 <pre>
 # Download the executable for the latest release.
@@ -79,7 +79,7 @@ chmod ugo+x shasta-macOS-0.4.0
 ./shasta-macOS-0.4.0 --input input.fasta
 </pre>
 
-<h2>Windows</h2>
+<h2 id="QuickStartWindows">Windows</h2>
 <ul>
 <li>
 Install 

--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -20,8 +20,6 @@ See below for more information, including some small changes required for macOS 
 <p>
 You can use the following commands to download the executable from the latest release and run an assembly:
 <pre>
-# Get the latest release version.
-
 # Download the executable for the latest release.
 curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.4.0/shasta-Linux-0.4.0
 
@@ -49,9 +47,7 @@ Output includes the assembly in FASTA and GFA 1.0 formats in files:
 </ul>
 This will work on most current 64 bit Linux distributions. 
 It was tested on at least the following Linux distributions for the 
-<code>x86_64</code> architecture, but it is likely
-that it will run on any Linux distribution for <code>x86_64</code>
-that uses a current kernel.
+<code>x86_64</code> architecture.
 <ul>
 <li>Ubuntu 16.04 LTS
 <li>Ubuntu 18.04 LTS
@@ -89,7 +85,7 @@ Windows Subsystem for Linux (WSL)</a>.
 </ul>
 
 <br/>
-<h2 id=demo>Quick test and demonstration</h2>
+<h2 id=QuickDemo>Quick test and demonstration</h2>
 <p>
 You can use the following commands to run a quick test and demonstration
 of the Shasta assembler:

--- a/docs/Running.html
+++ b/docs/Running.html
@@ -28,16 +28,8 @@ executable is <code>shasta-install/bin/shasta</code>.
 <p>
 The Shasta executable requires no installation or set up, 
 and has no dependencies. The Linux version, which is statically linked,
-runs on most current 64-bit Linux distributions, including
-at least the following:
+runs on most current 64-bit Linux distributions.
 
-<ul>
-<li>Ubuntu 16.04 and 18.04
-<li>Linux Mint 18.3
-<li>CentOS 7.6
-<li>Debian 9
-<li>Fedora 29
-</ul>
 
 <p>
 If you downloaded the executable from GitHub,

--- a/docs/Running.html
+++ b/docs/Running.html
@@ -12,39 +12,10 @@
 <h1>Running an assembly</h1>
 
 <p>
-For quick start information, see <a href=QuickStart.html>here</a>.
-This section provides additional background information.
+Refer the <a href="QuickStart.html">quick start</a> guide to download an executable or
+<a href="BuildingFromSource.html">build</a> one from the source code.
 
-<h2 id=ShastaExecutable>The Shasta executable</h2>
-<p>
-The Shasta executable provides the most convenient way of running
-an assembly. If you downloaded it as a single file from a release on GitHub, the
-executable is named <code>shasta-Linux-X.Y.Z</code> for Linux
-or <code>shasta-macOS-X.Y.Z</code> for macOS. 
-Here, <code>X.Y.Z</code> identifies the release.
-If you build the code from source yourself, the
-executable is <code>shasta-install/bin/shasta</code>.
-
-<p>
-The Shasta executable requires no installation or set up, 
-and has no dependencies. The Linux version, which is statically linked,
-runs on most current 64-bit Linux distributions.
-
-
-<p>
-If you downloaded the executable from GitHub,
-you will have to set execute permissions before running it
-(the browser will not do that for you, for security reasons).
-This can be done as follows:
-
-<pre>
-chmod ugo+x shasta-Linux-X.Y.Z
-</pre>
-or
-<pre>
-chmod ugo+x shasta-macOS-X.Y.Z
-</pre>
-
+<h2 id=Configuration>Configuration</h2>
 <p>
 You can invoke the Shasta executable without options or with
 <code>--help</code> to get a description of the options.
@@ -97,7 +68,7 @@ this works out to around
 
 <p>
 Machine with 1 to 4 TB of memory have become available
-at reasonably prices in the last few years, and they are widely available
+at reasonable prices in the last few years, and they are widely available
 on cloud computing platforms. 
 For example, for human assemblies using Shasta, we have routinely
 been using AWS <code>x1.32xlarge</code> instances with
@@ -148,7 +119,7 @@ for more information on these options.
 <h2 id=MemoryModes>Memory modes</h2>
 
 <p>
-(This section does not apply to macOS).
+<i>(This section does not apply to macOS).</i>
 
 <p>
 For performance, the Shasta executable operates in memory,
@@ -321,7 +292,7 @@ See
 select these options.
 
 
-<h2 id=ScriptedApproaches>Scripted approaches  to running an assembly</h2>
+<h2 id=ScriptedApproaches>Scripted approaches to running an assembly</h2>
 <p>
 The Shasta assembler provides a
 <a href=Python.html>Python API</a> that can be used for scripting.

--- a/docs/SupportedPlatforms.html
+++ b/docs/SupportedPlatforms.html
@@ -45,19 +45,9 @@ See <a href=Running.html>here</a> for more information.
 <h2>Extended functionality</h2>
 <p>
 Extended Shasta functionality (http server, Python API)
-is only available on Ubuntu 16.04 and Ubuntu 18.04.
+is only available on Ubuntu 16.04, Ubuntu 18.04 and Ubuntu 20.04 LTS.
 Porting to other Linux platforms is possible.
 
-
-
-<h2>Building the code from source</h2>
-<p>
-The code can be 
-<a href=BuildingFromSource.html>built from source</a> only on
-Ubuntu 16.04 and Ubuntu 18.04,
-except for the macOS version of the Shasta 
-executable which is built under macOS.
-Porting to other Linux platforms is possible.
 
 <div class="goto-index"><a href="index.html">Table of contents</a></div>
 </main>

--- a/docs/SupportedPlatforms.html
+++ b/docs/SupportedPlatforms.html
@@ -23,11 +23,9 @@ Most current 64-bit Linux distributions for the
 <code>x86_64</code> architecture, including the following
 on which it was actually tested:
 <ul>
-<li>Ubuntu 16.04 and 18.04
-<li>Linux Mint 18.3
-<li>CentOS 7.6
-<li>Debian 9
-<li>Fedora 29
+<li>Ubuntu 16.04 LTS
+<li>Ubuntu 18.04 LTS
+<li>Ubuntu 20.04 LTS
 </ul>
 
 <li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,23 +16,23 @@
 <li><a href=QuickStart.html#QuickStartLinux>On Linux</a></li>
 <li><a href=QuickStart.html#QuickStartMacOS>On macOS</a></li>
 <li><a href=QuickStart.html#QuickStartWindows>On Windows</a></li>
+<li><a href=QuickStart.html#QuickDemo>Test/Demo</a></li>
 </ul>
 <li><a href=CommandLineOptions.html>Command line options</a></li>
 <li><a href=SupportedPlatforms.html>Supported platforms</a></li>
-<li><a href=Running.html>Run an assembly</a></li>
+<li><a href=Running.html>Running an assembly</a></li>
 <ul>
-<li><a href=Running.html#Configuration>Configuration</a></li>
-<li><a href=Running.html#MemoryRequirements>Memory Requirements</a></li>
-<li><a href=Running.html#MemoryModes>Memory Modes</a></li>
+<li><a href=Running.html#Configuration>Configuring an assembly</a></li>
+<li><a href=Running.html#MemoryRequirements>Understanding memory requirements</a></li>
+<li><a href=Running.html#MemoryModes>Understanding memory modes</a></li>
 <li><a href=Running.html#ScriptedApproaches>Scripting with Python</a></li>
+<li><a href=Docker.html>Running an assembly in Docker</a></li>
 </ul>
-<li><a href=Docker.html>Run an assembly in Docker</a></li>
-<li><a href=Performance.html>Maximize assembly performance</a></li>
-<li><a href=BuildingFromSource.html>Build the code from source</a></li>
-<li><a href=InspectingResults.html>Explore assembly results</a></li>
-<li><a href=Contributing.html>Contribute to Shasta</a></li>
-<li><a href=ReportingBugs.html>Report problems or ask questions</a></li>
-
+<li><a href=InspectingResults.html>Exploring assembly results</a></li>
+<li><a href=Performance.html>Maximizing assembly performance</a></li>
+<li><a href=BuildingFromSource.html>Building from source</a></li>
+<li><a href=Contributing.html>Contributing to Shasta</a></li>
+<li><a href=ReportingBugs.html>Reporting problems or asking questions</a></li>
 <li><a href=Acknowledgments.html>Acknowledgments</a></li>
 <li><a href=ComputationalMethods.html>Computational methods</a></li>
 <li><a href=Compatibility.html>Compatibility across releases</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,18 +12,26 @@
 <ul>
 <li><a href=Introduction.html>Introduction</a></li>
 <li><a href=QuickStart.html>Quick start</a></li>
+<ul>
+<li><a href=QuickStart.html#QuickStartLinux>On Linux</a></li>
+<li><a href=QuickStart.html#QuickStartMacOS>On macOS</a></li>
+<li><a href=QuickStart.html#QuickStartWindows>On Windows</a></li>
+</ul>
 <li><a href=CommandLineOptions.html>Command line options</a></li>
 <li><a href=SupportedPlatforms.html>Supported platforms</a></li>
-<li> How to</li>
+<li><a href=Running.html>Run an assembly</a></li>
 <ul>
-	<li><a href=Running.html>Run an assembly</a></li>
-	<li><a href=Docker.html>Run an assembly in Docker</a></li>
-	<li><a href=Performance.html>Maximize assembly performance</a></li>
-	<li><a href=BuildingFromSource.html>Build the code from source</a></li>
-	<li><a href=InspectingResults.html>Explore assembly results</a></li>
-	<li><a href=Contributing.html>Contribute to Shasta</a></li>
-	<li><a href=ReportingBugs.html>Report problems or ask questions</a></li>
+<li><a href=Running.html#Configuration>Configuration</a></li>
+<li><a href=Running.html#MemoryRequirements>Memory Requirements</a></li>
+<li><a href=Running.html#MemoryModes>Memory Modes</a></li>
+<li><a href=Running.html#ScriptedApproaches>Scripting with Python</a></li>
 </ul>
+<li><a href=Docker.html>Run an assembly in Docker</a></li>
+<li><a href=Performance.html>Maximize assembly performance</a></li>
+<li><a href=BuildingFromSource.html>Build the code from source</a></li>
+<li><a href=InspectingResults.html>Explore assembly results</a></li>
+<li><a href=Contributing.html>Contribute to Shasta</a></li>
+<li><a href=ReportingBugs.html>Report problems or ask questions</a></li>
 
 <li><a href=Acknowledgments.html>Acknowledgments</a></li>
 <li><a href=ComputationalMethods.html>Computational methods</a></li>


### PR DESCRIPTION
I rewrote the QuickStart, BuildingFromSource and SupportedPlatforms documentation.

You can see it at https://bagashe.github.io/shasta/QuickStart.html. I wanted to avoid using hard-coded version names in the documentation. I also wanted to provide a list of commands that users can copy-paste and have it work without having to install any of those commands first. MacOS doesn't come with `wget` pre-installed. So I use `curl` instead. 

We do support building on macOS 10.14 and 10.15. So I have updated BuildingFromSource.html to reflect that. 