### PR TITLE
Bump release number. Prepare for release.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -17,8 +17,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta Release 0.4.0" 
+        # cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_NATIVE=OFF -DBUILD_ID="Shasta Release 0.5.0" 
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-20.04
@@ -50,8 +50,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.4.0" 
+        # cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.5.0" 
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-18.04
@@ -80,8 +80,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.4.0"
+        # cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.4.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.5.0"
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-16.04
@@ -113,8 +113,8 @@ jobs:
       run: |
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.14 newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.4.0 for MacOS-10.14"
+        # cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.14 newer than release 0.4.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.5.0 for MacOS-10.14"
         make VERBOSE=1 -j 2 all
         make install/strip
         # See what libraries the executable depends on.
@@ -142,8 +142,8 @@ jobs:
       run: |
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.15 newer than release 0.4.0 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.4.0 for MacOS-10.15"
+        # cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.15 newer than release 0.4.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.5.0 for MacOS-10.15"
         make VERBOSE=1 -j 2 all
         make install/strip
         # See what libraries the executable depends on.

--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -21,13 +21,13 @@ See below for more information, including some small changes required for macOS 
 You can use the following commands to download the executable from the latest release and run an assembly:
 <pre>
 # Download the executable for the latest release.
-curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.4.0/shasta-Linux-0.4.0
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.5.0/shasta-Linux-0.5.0
 
 # Grant necessary permissions.
-chmod ugo+x shasta-Linux-0.4.0
+chmod ugo+x shasta-Linux-0.5.0
 
 # Run an assembly.
-./shasta-Linux-0.4.0 --input input.fasta
+./shasta-Linux-0.5.0 --input input.fasta
 </pre>
 
 You can specify multiple input FASTA files, if necessary.
@@ -66,13 +66,13 @@ to achieve maximum performance.
 
 <pre>
 # Download the executable for the latest release.
-curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.4.0/shasta-macOS-0.4.0
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.5.0/shasta-macOS-0.5.0
 
 # Grant necessary permissions.
-chmod ugo+x shasta-macOS-0.4.0
+chmod ugo+x shasta-macOS-0.5.0
 
 # Run an assembly.
-./shasta-macOS-0.4.0 --input input.fasta
+./shasta-macOS-0.5.0 --input input.fasta
 </pre>
 
 <h2 id="QuickStartWindows">Windows</h2>


### PR DESCRIPTION
Test Plan: Downloaded the `shasta-Linux` asset from Github actions and ran a test assembly on E-Coli.

Once this PR is merged and we put out 0.5.0 I will follow up with another PR that updates the Build.yml file 