### PR TITLE
Log peak memory usage.

### DIFF
--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -150,3 +150,7 @@ void Assembler::storeAssemblyTime(
     assemblerInfo->averageCpuUtilization = averageCpuUtilization;
 }
 
+void Assembler::storePeakMemoryUsage(const string& peakMemoryUsage) {
+    assemblerInfo->peakMemoryUsage = peakMemoryUsage;
+}
+

--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -150,7 +150,7 @@ void Assembler::storeAssemblyTime(
     assemblerInfo->averageCpuUtilization = averageCpuUtilization;
 }
 
-void Assembler::storePeakMemoryUsage(const string& peakMemoryUsage) {
+void Assembler::storePeakMemoryUsage(const uint64_t peakMemoryUsage) {
     assemblerInfo->peakMemoryUsage = peakMemoryUsage;
 }
 

--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -150,7 +150,7 @@ void Assembler::storeAssemblyTime(
     assemblerInfo->averageCpuUtilization = averageCpuUtilization;
 }
 
-void Assembler::storePeakMemoryUsage(const uint64_t peakMemoryUsage) {
+void Assembler::storePeakMemoryUsage(uint64_t peakMemoryUsage) {
     assemblerInfo->peakMemoryUsage = peakMemoryUsage;
 }
 

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -128,6 +128,9 @@ public:
     double averageCpuUtilization;
     uint64_t peakMemoryUsage = 0ULL;
 
+    inline string peakMemoryUsageForSummaryStats() {
+        return peakMemoryUsage > 0 ? to_string(peakMemoryUsage) : "Not determined.";
+    }
 };
 
 
@@ -2061,7 +2064,7 @@ public:
         double elapsedTimeSeconds,
         double averageCpuUtilization);
 
-    void storePeakMemoryUsage(const uint64_t peakMemoryUsage);
+    void storePeakMemoryUsage(uint64_t peakMemoryUsage);
 
     // Functions and data used by the http server
     // for display of the local assembly graph.

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -126,6 +126,7 @@ public:
     // Performance statistics.
     double assemblyElapsedTimeSeconds = 0.;
     double averageCpuUtilization;
+    string peakMemoryUsage = "";
 
 };
 
@@ -2060,7 +2061,7 @@ public:
         double elapsedTimeSeconds,
         double averageCpuUtilization);
 
-
+    void storePeakMemoryUsage(const string& peakMemoryUsage);
 
     // Functions and data used by the http server
     // for display of the local assembly graph.

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -126,7 +126,7 @@ public:
     // Performance statistics.
     double assemblyElapsedTimeSeconds = 0.;
     double averageCpuUtilization;
-    string peakMemoryUsage = "";
+    uint64_t peakMemoryUsage = 0ULL;
 
 };
 
@@ -2061,7 +2061,7 @@ public:
         double elapsedTimeSeconds,
         double averageCpuUtilization);
 
-    void storePeakMemoryUsage(const string& peakMemoryUsage);
+    void storePeakMemoryUsage(const uint64_t peakMemoryUsage);
 
     // Functions and data used by the http server
     // for display of the local assembly graph.

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -840,7 +840,8 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Average CPU utilization"
         "<td class=right>" << assemblerInfo->averageCpuUtilization <<
         "<tr><td>Peak Memory utilization (bytes)"
-        "<td class=right>" << assemblerInfo->peakMemoryUsage <<
+        "<td class=right>" <<
+	assemblerInfo->peakMemoryUsageForSummaryStats() <<
         "</table>"
         ;
 }
@@ -1050,7 +1051,9 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Elapsed time (minutes)\": " << assemblerInfo->assemblyElapsedTimeSeconds/60. << ",\n"
         "    \"Elapsed time (hours)\": " << assemblerInfo->assemblyElapsedTimeSeconds/3600. << ",\n"
         "    \"Average CPU utilization\": " << assemblerInfo->averageCpuUtilization << ",\n"
-        "    \"Peak Memory utilization (bytes)\": " << assemblerInfo->peakMemoryUsage << "\n"
+        "    \"Peak Memory utilization (bytes)\": " <<
+	assemblerInfo->peakMemoryUsageForSummaryStats() <<
+	"\n"
         "  }\n"
 
 

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -839,7 +839,7 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<td class=right>" << assemblerInfo->assemblyElapsedTimeSeconds/3600. <<
         "<tr><td>Average CPU utilization"
         "<td class=right>" << assemblerInfo->averageCpuUtilization <<
-        "<tr><td>Peak Memory utilization"
+        "<tr><td>Peak Memory utilization (bytes)"
         "<td class=right>" << assemblerInfo->peakMemoryUsage <<
         "</table>"
         ;
@@ -1049,8 +1049,8 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Elapsed time (seconds)\": " << assemblerInfo->assemblyElapsedTimeSeconds << ",\n"
         "    \"Elapsed time (minutes)\": " << assemblerInfo->assemblyElapsedTimeSeconds/60. << ",\n"
         "    \"Elapsed time (hours)\": " << assemblerInfo->assemblyElapsedTimeSeconds/3600. << ",\n"
-        "    \"Average CPU utilization\": " << assemblerInfo->averageCpuUtilization << "\n"
-        "    \"Peak Memory utilization\": \"" << assemblerInfo->peakMemoryUsage << "\"\n"
+        "    \"Average CPU utilization\": " << assemblerInfo->averageCpuUtilization << ",\n"
+        "    \"Peak Memory utilization (bytes)\": " << assemblerInfo->peakMemoryUsage << "\n"
         "  }\n"
 
 

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -839,6 +839,8 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<td class=right>" << assemblerInfo->assemblyElapsedTimeSeconds/3600. <<
         "<tr><td>Average CPU utilization"
         "<td class=right>" << assemblerInfo->averageCpuUtilization <<
+        "<tr><td>Peak Memory utilization"
+        "<td class=right>" << assemblerInfo->peakMemoryUsage <<
         "</table>"
         ;
 }
@@ -1048,6 +1050,7 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Elapsed time (minutes)\": " << assemblerInfo->assemblyElapsedTimeSeconds/60. << ",\n"
         "    \"Elapsed time (hours)\": " << assemblerInfo->assemblyElapsedTimeSeconds/3600. << ",\n"
         "    \"Average CPU utilization\": " << assemblerInfo->averageCpuUtilization << "\n"
+        "    \"Peak Memory utilization\": \"" << assemblerInfo->peakMemoryUsage << "\"\n"
         "  }\n"
 
 

--- a/src/platformDependent.cpp
+++ b/src/platformDependent.cpp
@@ -1,6 +1,7 @@
 #include "platformDependent.hpp"
 #ifdef __linux__
 #include <stdlib.h>
+#include "fstream.hpp"
 #endif
 
 // Return the path to a usable temporary directory, including the final "/".
@@ -34,4 +35,29 @@ std::string shasta::timeoutCommand()
     
 #endif
     
+}
+
+uint64_t shasta::getPeakMemoryUsage() {
+    uint64_t peakMemoryUsage = 0ULL;
+#ifdef __linux__
+    ifstream procStats("/proc/self/status");
+    if (procStats) {
+        string line;
+        while (std::getline(procStats, line)) {
+            if (string::npos == line.find("VmPeak")) {
+                continue;
+            }
+            size_t pos = line.find(":");
+            while (pos < line.size() && !isdigit(line[pos])) {
+                pos++;
+            }
+            char* end;
+            peakMemoryUsage = std::strtoull(line.c_str() + pos, &end, 10);
+            // Convert from kB to bytes.
+            peakMemoryUsage *= 1024;
+            break;
+        }
+    }
+#endif
+    return(peakMemoryUsage);
 }

--- a/src/platformDependent.cpp
+++ b/src/platformDependent.cpp
@@ -59,5 +59,5 @@ uint64_t shasta::getPeakMemoryUsage() {
         }
     }
 #endif
-    return(peakMemoryUsage);
+    return peakMemoryUsage;
 }

--- a/src/platformDependent.hpp
+++ b/src/platformDependent.hpp
@@ -10,6 +10,8 @@ namespace shasta {
     
     // Return the name of a timeout command or equivalent.
     string timeoutCommand();
+
+    uint64_t getPeakMemoryUsage();
 }
 
 #endif

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -839,6 +839,24 @@ void shasta::main::assemble(
         assembler.writeOrientedReadsByAssemblyGraphEdge();
     }
 
+    string peakMemoryUsage;
+    ifstream procStats("/proc/self/status");
+    if (procStats) {
+        string line;
+        while (std::getline(procStats, line)) {
+            if (string::npos == line.find("VmPeak")) {
+                continue;
+            }
+            size_t pos = line.find(":");
+            while (pos < line.size() && !isdigit(line[pos])) {
+                pos++;
+            }
+            peakMemoryUsage = line.substr(pos);
+            break;
+        }
+        assembler.storePeakMemoryUsage(peakMemoryUsage);
+    }
+
     // Write the assembly summary.
     ofstream html("AssemblySummary.html");
     assembler.writeAssemblySummary(html);
@@ -856,6 +874,7 @@ void shasta::main::assemble(
         "    Elapsed minutes: " << elapsedTime/60. << "\n"
         "    Elapsed hours:   " << elapsedTime/3600. << "\n";
     cout << "Average CPU utilization: " << averageCpuUtilization << endl;
+    cout << "Peak Memory usage: " << peakMemoryUsage << endl;
 }
 
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -10,6 +10,8 @@
 #include "buildId.hpp"
 #include "filesystem.hpp"
 #include "timestamp.hpp"
+#include "platformDependent.hpp"
+
 namespace shasta {
     namespace main {
 
@@ -839,24 +841,9 @@ void shasta::main::assemble(
         assembler.writeOrientedReadsByAssemblyGraphEdge();
     }
 
-    string peakMemoryUsage;
-    ifstream procStats("/proc/self/status");
-    if (procStats) {
-        string line;
-        while (std::getline(procStats, line)) {
-            if (string::npos == line.find("VmPeak")) {
-                continue;
-            }
-            size_t pos = line.find(":");
-            while (pos < line.size() && !isdigit(line[pos])) {
-                pos++;
-            }
-            peakMemoryUsage = line.substr(pos);
-            break;
-        }
-        assembler.storePeakMemoryUsage(peakMemoryUsage);
-    }
-
+    uint64_t peakMemoryUsage = shasta::getPeakMemoryUsage();
+    assembler.storePeakMemoryUsage(peakMemoryUsage);
+   
     // Write the assembly summary.
     ofstream html("AssemblySummary.html");
     assembler.writeAssemblySummary(html);
@@ -874,7 +861,7 @@ void shasta::main::assemble(
         "    Elapsed minutes: " << elapsedTime/60. << "\n"
         "    Elapsed hours:   " << elapsedTime/3600. << "\n";
     cout << "Average CPU utilization: " << averageCpuUtilization << endl;
-    cout << "Peak Memory usage: " << peakMemoryUsage << endl;
+    cout << "Peak Memory usage (bytes): " << peakMemoryUsage << endl;
 }
 
 


### PR DESCRIPTION
If `/proc/self/status` does not exist (macOS) then it is not captured. This is fine since our goal is to use this to minimize peak memory usage for big assemblies (Linux). 

Test Plan: Looked at the stdout log for test assemblies on Github actions. Saw the value on Ubuntu, but not on macOS.