### PR TITLE
[Bugfix] Conditional storage and usage of compressed alignments.

### DIFF
--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -302,8 +302,11 @@ void Assembler::computeAlignments(
     // Store alignmentInfos found by each thread in the global alignmentInfos.
     cout << timestamp << "Storing the alignment info objects." << endl;
     alignmentData.createNew(largeDataName("AlignmentData"), largeDataPageSize);
-    compressedAlignments.createNew(largeDataName("CompressedAlignments"), largeDataPageSize);
-
+    
+    if (data.storeAlignments) {
+        compressedAlignments.createNew(largeDataName("CompressedAlignments"), largeDataPageSize);
+    }
+    
     for(size_t threadId=0; threadId<threadCount; threadId++) {
         const vector<AlignmentData>& threadAlignmentData = data.threadAlignmentData[threadId];
         for(const AlignmentData& ad: threadAlignmentData) {
@@ -377,10 +380,13 @@ void Assembler::computeAlignmentsThreadFunction(size_t threadId)
         make_shared< MemoryMapped::VectorOfVectors<char, uint64_t> >();
     data.threadCompressedAlignments[threadId] = thisThreadCompressedAlignmentsPointer;
     auto& thisThreadCompressedAlignments = *thisThreadCompressedAlignmentsPointer;
-    thisThreadCompressedAlignments.createNew(
-        largeDataName("tmp-ThreadGlobalCompressedAlignments-" + to_string(threadId)),
-        largeDataPageSize);
-    
+
+    if (storeAlignments) {
+        thisThreadCompressedAlignments.createNew(
+            largeDataName("tmp-ThreadGlobalCompressedAlignments-" + to_string(threadId)),
+            largeDataPageSize);
+    }
+
     uint64_t begin, end;
     while(getNextBatch(begin, end)) {
         if((begin % 1000000) == 0){

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -495,8 +495,10 @@ void Assembler::createMarkerGraphVerticesThreadFunction1(size_t threadId)
                 throw runtime_error("Invalid read graph creation method " + to_string(readGraphCreationMethod));
             }
 
-            if(storedAlignments.isOpen() > 0) {
+            if(storedAlignments.isOpen() && readGraphCreationMethod == 0) {
                 // Reuse stored alignments if available.
+                // Stored alignments need to be processed for them to work with
+                // readGraphCreationMethod == 1. That's not implemented yet. 
                 span<const char> compressedAlignment = storedAlignments[alignmentId];
                 shasta::decompress(compressedAlignment, alignment);
             } else {


### PR DESCRIPTION
Compressed (Stored) alignments don't work directly with `readGraphCreationMethod == 1`. So instead of crashing, let's fall back to recomputing the alignments. 