### PR TITLE
Unreserve data-structures once they have been populated.

### DIFF
--- a/src/AlignmentCandidates.hpp
+++ b/src/AlignmentCandidates.hpp
@@ -30,6 +30,19 @@ public:
     // This has a vector for each entry in the candidates vector above
     // and is indexed in the same way.
     MemoryMapped::VectorOfVectors< array<uint32_t, 2>, uint64_t> featureOrdinals;
+
+    void unreserve() {
+        candidates.unreserve();
+        // featureOrdinals is not used by LowHash0
+        if (featureOrdinals.isOpenWithWriteAccess()) featureOrdinals.unreserve();
+    }
+
+    void clear() {
+        candidates.clear();
+        // featureOrdinals is not used by LowHash0
+        if (featureOrdinals.isOpenWithWriteAccess()) featureOrdinals.clear();
+        unreserve();
+    }
 };
 
 #endif

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -328,6 +328,10 @@ void Assembler::computeAlignments(
         }
     }
 
+    // Release unused allocated memory.
+    alignmentData.unreserve();
+    compressedAlignments.unreserve();
+
     cout << "Found and stored " << alignmentData.size() << " good alignments." << endl;
     cout << timestamp << "Creating alignment table." << endl;
     computeAlignmentTable();
@@ -501,6 +505,8 @@ void Assembler::computeAlignmentsThreadFunction(size_t threadId)
             }
         }
     }
+
+    thisThreadCompressedAlignments.unreserve();
 }
 
 
@@ -575,6 +581,7 @@ void Assembler::computeAlignmentTable()
         }
     }
 
+    alignmentTable.unreserve();
 
 }
 

--- a/src/AssemblerAssemblyGraph.cpp
+++ b/src/AssemblerAssemblyGraph.cpp
@@ -211,6 +211,9 @@ void Assembler::createAssemblyGraphEdges()
         reverseComplementedChain.clear();
     }
 
+    // Free allocated, unused space.
+    assemblyGraph.edgeLists.unreserve();
+    assemblyGraph.reverseComplementEdge.unreserve();
 
 
     // Check that only and all edges of the cleaned up marker graph
@@ -733,6 +736,8 @@ void Assembler::assembleThreadFunction(size_t threadId)
         }
     }
 
+    sequences.unreserve();
+    repeatCounts.unreserve();
 }
 
 
@@ -927,7 +932,6 @@ void Assembler::writeGfa1(const string& fileName)
     }
 
 
-
     // Write GFA links.
     // For each vertex in the assembly graph there is a link for
     // each combination of in-edges and out-edges.
@@ -998,6 +1002,7 @@ void Assembler::writeGfa1(const string& fileName)
                     cigarString << "\n";
             }
         }
+
     }
     cout << timestamp << "writeGfa1 ends" << endl;
 }
@@ -1079,8 +1084,7 @@ void Assembler::writeGfa1BothStrands(const string& fileName)
         gfa << "\n";
     }
 
-
-
+  
     // Write GFA links.
     // For each vertex in the assembly graph there is a link for
     // each combination of in-edges and out-edges.

--- a/src/AssemblerLowHash.cpp
+++ b/src/AssemblerLowHash.cpp
@@ -50,6 +50,8 @@ void Assembler::findAlignmentCandidatesLowHash0(
         readLowHashStatistics,
         largeDataFileNamePrefix,
         largeDataPageSize);
+
+    alignmentCandidates.unreserve();
 }
 
 
@@ -165,6 +167,8 @@ void Assembler::findAlignmentCandidatesLowHash1(
         alignmentCandidates,
         largeDataFileNamePrefix,
         largeDataPageSize);
+    
+    alignmentCandidates.unreserve();
 }
 
 
@@ -259,5 +263,7 @@ void Assembler::markAlignmentCandidatesAllPairs()
             alignmentCandidates.candidates.push_back(OrientedReadPair(r0, r1, false));
         }
     }
+
+    alignmentCandidates.unreserve();
     cout << "Marked all pairs of reads as alignment candidates on both orientations." << endl;
 }

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -372,6 +372,8 @@ void Assembler::createMarkerGraphVertices(
             markerGraph.vertices().append(markerId);
         }
     }
+    markerGraph.vertices().unreserve();
+
     data.isBadDisjointSet.remove();
     data.workArea.remove();
     data.disjointSetMarkers.remove();
@@ -1979,6 +1981,10 @@ void Assembler::createMarkerGraphEdges(size_t threadCount)
         thisThreadEdges.remove();
         thisThreadEdgeMarkerIntervals.remove();
     }
+
+    markerGraph.edges.unreserve();
+    markerGraph.edgeMarkerIntervals.unreserve();
+    
     SHASTA_ASSERT(markerGraph.edges.size() == markerGraph.edgeMarkerIntervals.size());
     cout << timestamp << "Found " << markerGraph.edges.size();
     cout << " edges for " << markerGraph.vertexCount() << " vertices." << endl;
@@ -2081,6 +2087,8 @@ void Assembler::createMarkerGraphEdgesThreadFunction0(size_t threadId)
         }
     }
 
+    thisThreadEdges.unreserve();
+    thisThreadEdgeMarkerIntervals.unreserve();
 }
 
 
@@ -4255,6 +4263,8 @@ void Assembler::computeMarkerGraphVerticesCoverageData(size_t threadCount)
         markerGraph.vertexCoverageData.appendVector(v.begin(), v.end());
     }
 
+    markerGraph.vertexCoverageData.unreserve();
+    
     // Remove the results computed by each thread.
     for(size_t threadId=0; threadId!=threadCount; threadId++) {
         computeMarkerGraphVerticesCoverageDataData.threadVertexIds[threadId]->remove();
@@ -4351,6 +4361,9 @@ void Assembler::computeMarkerGraphVerticesCoverageDataThreadFunction(size_t thre
             }
         }
     }
+
+    threadVertexIds.unreserve();
+    threadCoverageData.unreserve();
 
 }
 
@@ -4604,6 +4617,10 @@ void Assembler::assembleMarkerGraphEdgesThreadFunction(size_t threadId)
 
         }
     }
+    
+    edgeIds.unreserve();
+    consensus.unreserve();
+    overlappingBaseCountVector.unreserve();
 }
 
 

--- a/src/AssemblerReadGraph.cpp
+++ b/src/AssemblerReadGraph.cpp
@@ -102,7 +102,8 @@ void Assembler::createReadGraph(
         readGraph.edges.push_back(edge);
     }
 
-
+    // Release unused allocated memory
+    readGraph.unreserve();
 
     // Create read graph connectivity.
     readGraph.connectivity.createNew(largeDataName("ReadGraphConnectivity"), largeDataPageSize);
@@ -118,8 +119,6 @@ void Assembler::createReadGraph(
         readGraph.connectivity.store(edge.orientedReadIds[1].getValue(), uint32_t(i));
     }
     readGraph.connectivity.endPass2();
-
-
 
     // Count the number of isolated reads and their bases.
     uint64_t isolatedReadCount = 0;

--- a/src/LongBaseSequence.cpp
+++ b/src/LongBaseSequence.cpp
@@ -66,6 +66,11 @@ void LongBaseSequences::clear()
     data.clear();
 }
 
+void LongBaseSequences::unreserve() {
+    baseCount.unreserve();
+    data.unreserve();
+}
+
 // Append a new sequence at the end.
 void LongBaseSequences::append(const LongBaseSequenceView& s)
 {

--- a/src/LongBaseSequence.hpp
+++ b/src/LongBaseSequence.hpp
@@ -240,6 +240,7 @@ public:
     void clear();
     void remove();
     void close();
+    void unreserve();
 
     bool isOpen() const
     {

--- a/src/MarkerFinder.cpp
+++ b/src/MarkerFinder.cpp
@@ -43,6 +43,7 @@ MarkerFinder::MarkerFinder(
     pass = 2;
     runThreads(&MarkerFinder::threadFunction, threadCount);
 
+    markers.unreserve();
     // Final message.
     const auto tEnd = std::chrono::steady_clock::now();
     const double tTotal = 1.e-9 * double((std::chrono::duration_cast<std::chrono::nanoseconds>(tEnd - tBegin)).count());

--- a/src/MemoryMappedVector.hpp
+++ b/src/MemoryMappedVector.hpp
@@ -358,8 +358,7 @@ template<class T> inline void shasta::MemoryMapped::Vector<T>::push_back(const T
 }
 
 
-
-// Default constructor.
+// Destructor.
 template<class T> inline shasta::MemoryMapped::Vector<T>::~Vector()
 {
     if(isOpen) {
@@ -378,7 +377,8 @@ template<class T> inline shasta::MemoryMapped::Vector<T>::~Vector()
     }
 }
 
-// Destructor.
+
+// Default constructor.
 template<class T> inline shasta::MemoryMapped::Vector<T>::Vector() :
     header(0),
     data(0),

--- a/src/MemoryMappedVectorOfVectors.hpp
+++ b/src/MemoryMappedVectorOfVectors.hpp
@@ -254,6 +254,15 @@ public:
     void storeMultithreaded(Int index, const T&);            // Called during pass 2.
     void endPass2(bool check = true, bool free=true);
 
+    // Free up unused allocated memory.
+    void unreserve() {
+        toc.unreserve();
+        data.unreserve();
+        if(count.isOpen) {
+            count.unreserve();
+        }
+    }
+
     // Touch the memory in order to cause the
     // supporting pages of virtual memory to be loaded in real memory.
     size_t touchMemory() const

--- a/src/ReadGraph.cpp
+++ b/src/ReadGraph.cpp
@@ -8,7 +8,10 @@ using namespace shasta;
 
 const uint32_t ReadGraph::infiniteDistance = std::numeric_limits<uint32_t>::max();
 
-
+void ReadGraph::unreserve() {
+    if (edges.isOpenWithWriteAccess) edges.unreserve();
+    if (connectivity.isOpenWithWriteAccess()) connectivity.unreserve();
+}
 
 // Compute a shortest path, disregarding edges flagged as cross-strand edges.
 void ReadGraph::computeShortPath(

--- a/src/ReadGraph.hpp
+++ b/src/ReadGraph.hpp
@@ -89,7 +89,10 @@ public:
         vector<OrientedReadId>& reachedVertices,   // For which distance is not infiniteDistance.
         vector<uint32_t>& parentEdges  // One per vertex
 
-        );
+    );
+
+    void unreserve();
+    
     static const uint32_t infiniteDistance;
 };
 

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -759,5 +759,10 @@ void ReadLoader::storeReads()
     threadReads.clear();
     threadReadRepeatCounts.clear();
 
+    // Free up unused allocated memory.
+    readNames.unreserve();
+    readMetaData.unreserve();
+    readRepeatCounts.unreserve();
+    reads.unreserve();
 }
 


### PR DESCRIPTION
Ran a full human genome assembly with `HG002-Guppy-3.6.0.fasta` using `Nanopore-Jun2020.conf` config both before and after this change.

Peak Memory Usage dropped by **5.125 %**.
There was no significant change in assembly time or the generated assembly (based on the stats in AssemblySummary.json).