### PR TITLE
Support building Shasta on ARM64 along with X86_64.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,20 @@ project(shasta)
 # building the dynamic executable use
 # cmake -DBUILD_DYNAMIC_EXECUTABLE=OFF
 
-
+set(X86_64 OFF)
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "x86_64")
+    set(X86_64 ON)
+endif()
 
 # Figure out if we are on macOS.
 set(MACOS OFF)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOS ON)
 endif()
+
+message(STATUS "Processor architecture is " ${CMAKE_HOST_SYSTEM_PROCESSOR})
 message(STATUS "CMAKE_SYSTEM_NAME is " ${CMAKE_SYSTEM_NAME})
 message(STATUS "MACOS is " ${MACOS})
-
 
 
 # Decide what we want to build.

--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -20,8 +20,11 @@ else(BUILD_DEBUG)
 endif(BUILD_DEBUG)
 
 # 16-byte compare and swap.
-# This is required by dset64.hpp/dset64-gccAtomic.hpp".
-add_definitions(-mcx16)
+# This is recommended for dset64.hpp/dset64-gccAtomic.hpp".
+# It's available only on x86 architectures.
+if(X86_64)
+  add_definitions(-mcx16)
+endif()
 
 # Native build.
 if(BUILD_NATIVE)
@@ -54,17 +57,17 @@ set_target_properties(shastaDynamicExecutable PROPERTIES OUTPUT_NAME "shastaDyna
 set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN")
 
 # Libraries to link with.
-if(BUILD_USE_SPOA_WITH_CPU_DISPATCH)
+if(X86_64 AND BUILD_USE_SPOA_WITH_CPU_DISPATCH)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
         atomic boost_system boost_program_options boost_chrono spoa cpu_features png z pthread)
-else(BUILD_USE_SPOA_WITH_CPU_DISPATCH)
+else(X86_64 AND BUILD_USE_SPOA_WITH_CPU_DISPATCH)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
         atomic boost_system boost_program_options boost_chrono spoa png z pthread)
-endif(BUILD_USE_SPOA_WITH_CPU_DISPATCH)
+endif(X86_64 AND BUILD_USE_SPOA_WITH_CPU_DISPATCH)
 
 if(BUILD_DEBUG) 
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")

--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -21,8 +21,11 @@ else(BUILD_DEBUG)
 endif(BUILD_DEBUG)
 
 # 16-byte compare and swap.
-# This is required by dset64.hpp/dset64-gccAtomic.hpp".
-add_definitions(-mcx16)
+# This is recommended for dset64.hpp/dset64-gccAtomic.hpp".
+# It's available only on x86 architectures.
+if(X86_64)
+  add_definitions(-mcx16)
+endif(X86_64)
 
 # Native build.
 if(BUILD_NATIVE)

--- a/scripts/InstallPrerequisites-Ubuntu.sh
+++ b/scripts/InstallPrerequisites-Ubuntu.sh
@@ -3,6 +3,39 @@
 # This installs all packages needed to build Shasta or to run
 # the dynamic executable. The static executable has no prerequisites.
 
+ubuntuPrettyName=$(cat /etc/os-release | grep PRETTY_NAME | cut -f2 -d'=')
+ubuntuVersion=$(cat /etc/os-release | grep VERSION_ID | cut -f2 -d'=')
+arch=$(uname -p)
+echo "Detected $ubuntuPrettyName running on $arch."
+
+isLatestOS=false
+if [ $ubuntuVersion == "\"20.04\"" ] ; then
+    isLatestOS=true
+fi
+
+isOldOS=false
+if [ $ubuntuVersion \< "\"18.04\"" ] ; then
+    isOldOS=true
+fi
+
+isX86=false
+isArm=false
+if [ $arch == "aarch64" ]; then
+    isArm=true
+fi
+if [ $arch == "x86_64" ]; then
+    isX86=true
+fi
+if [[ "$isX86" == false && "$isArm" == false ]]; then
+    echo "Unsupported architecture. Only 'x86_64' and 'aarch64' are supported."
+    exit 1
+fi
+
+if [[ "$isArm" == true && "$isLatestOS" == false ]]; then
+    echo "Unsupported architecture & OS combination. Compiling on ARM requires Ubuntu 20.04 LTS or later."
+    exit 1
+fi
+
 apt-get update
 apt install -y git
 apt install -y g++
@@ -17,15 +50,19 @@ apt install -y python3-pip
 pip3 install pybind11
 
 
-
-# SeqAn 2.4.0 is not available in the Ubuntu repository.
-# Download it from GitHub, then install it.
-apt install -y curl
-curl -L https://github.com/seqan/seqan/releases/download/seqan-v2.4.0/seqan-library-2.4.0.deb \
-    -o /dev/shm/seqan-library-2.4.0.deb
-apt install /dev/shm/seqan-library-2.4.0.deb
-rm /dev/shm/seqan-library-2.4.0.deb
-
+if [[ "$isLatestOS" == true ]]; then
+    echo "Installing seqan v2.4.0 from Ubuntu repository."
+    apt install -y libseqan2-dev
+else
+    # SeqAn 2.4.0 is not available in the older Ubuntu repositories.
+    # Download it from GitHub, then install it.
+    echo "Installing seqan 2.4.0 from Github."
+    apt install -y curl
+    curl -L https://github.com/seqan/seqan/releases/download/seqan-v2.4.0/seqan-library-2.4.0.deb \
+        -o /dev/shm/seqan-library-2.4.0.deb
+    apt install /dev/shm/seqan-library-2.4.0.deb
+    rm /dev/shm/seqan-library-2.4.0.deb
+fi
 
 
 # The spoa library is not available in the stable Ubuntu repository yet.
@@ -41,17 +78,15 @@ curl -L https://github.com/rvaser/spoa/releases/download/3.4.0/spoa-v3.4.0.tar.g
     -o spoa-v3.4.0.tar.gz
 tar -xvf spoa-v3.4.0.tar.gz
 
-ubuntuVersion=$(cat /etc/os-release | grep VERSION_ID | cut -f2 -d'=')
+spoaBuildFlags="-Dspoa_generate_dispatch=ON"
+if [[ "$isOldOS" == true || "$isArm" == true ]]; then
+    spoaBuildFlags="-Dspoa_generate_dispatch=OFF -Dspoa_optimize_for_portability=OFF -Dspoa_optimize_for_native=OFF"
+fi
 
 # Build the shared library.
 mkdir build
 cd build
-if [ $ubuntuVersion \< "\"18.04\"" ] ; then
-    # SPOA's cpu dispatching code is tested on newer Linux versions.
-    cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=ON -Dspoa_generate_dispatch=OFF -Dspoa_optimize_for_portability=ON
-else
-    cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=ON -Dspoa_generate_dispatch=ON
-fi
+cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=ON $spoaBuildFlags
 make -j all
 make install
 
@@ -59,12 +94,7 @@ make install
 cd ..
 mkdir build-static
 cd build-static
-if [ $ubuntuVersion \< "\"18.04\"" ] ; then
-    # SPOA's cpu dispatching code is tested on newer Linux versions.
-    cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=OFF -Dspoa_generate_dispatch=OFF -Dspoa_optimize_for_portability=ON
-else
-    cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=OFF -Dspoa_generate_dispatch=ON
-fi
+cmake ../spoa-v3.4.0 -DBUILD_SHARED_LIBS=OFF $spoaBuildFlags
 make -j all
 make install
 cd 

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -61,9 +61,9 @@ namespace shasta {
 }
 
 
-// Sanity check that we are compiling on x86_64.
-#if !__x86_64__
-#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD)"
+// Sanity check that we are compiling on x86_64 or aarch64
+#if !__x86_64__ && !__aarch64__
+#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD) or an ARM64 machine. "
 #endif
 
 

--- a/src/Uint.hpp
+++ b/src/Uint.hpp
@@ -13,9 +13,9 @@
 #include <cstring>
 #include <type_traits>
 
-// Sanity check that we are compiling on x86_64.
-#if !__x86_64__
-#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD)"
+// Sanity check that we are compiling on x86_64 or aarch64
+#if !__x86_64__ && !__aarch64__
+#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD) or an ARM64 machine. "
 #endif
 
 namespace shasta {

--- a/src/cstdint.hpp
+++ b/src/cstdint.hpp
@@ -3,9 +3,9 @@
 
 #include <cstdint>
 
-// Sanity check that we are compiling on x86_64.
-#if !__x86_64__
-#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD)"
+// Sanity check that we are compiling on x86_64 or aarch64
+#if !__x86_64__ && !__aarch64__
+#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD) or an ARM64 machine. "
 #endif
 
 

--- a/src/dset64-gccAtomic.hpp
+++ b/src/dset64-gccAtomic.hpp
@@ -55,15 +55,15 @@
  * and results in optimal speed.
  *
  * The CMPXCHG16B instruction is available on most modern 64-bit x86 processors.
- * Some older processors that don't implement this instruction
- * will crash with an "Illegal instruction" error
- * upon attempting to run this code.
+ * If it is not available, and compilation is done without -mcx16, then gcc
+ * generates slower code. Use of the gcc primitive __sync_bool_compare_and_swap
+ * ensures that the code will execute on both x86_64 and aarch64.
  *
  */
 
-// Sanity check that we are compiling on x86_64.
-#if !__x86_64__
-#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD)"
+// Sanity check that we are compiling on x86_64 or aarch64
+#if !__x86_64__ && !__aarch64__
+#error "Shasta can only be built on an x86_64 machine (64-bit Intel/AMD) or an ARM64 machine. "
 #endif
 
 

--- a/staticExecutable/CMakeLists.txt
+++ b/staticExecutable/CMakeLists.txt
@@ -21,8 +21,11 @@ else(BUILD_DEBUG)
 endif(BUILD_DEBUG)
 
 # 16-byte compare and swap.
-# This is required by dset64.hpp/dset64-gccAtomic.hpp".
-add_definitions(-mcx16)
+# This is recommended for dset64.hpp/dset64-gccAtomic.hpp".
+# It's available only on x86 architectures.
+if(X86_64)
+    add_definitions(-mcx16)
+endif(X86_64)
 
 # Native build.
 if(BUILD_NATIVE)
@@ -74,19 +77,19 @@ if(MACOS)
 else(MACOS)
     # For arcane reasons, statically linking with the pthread
     # library on Linux requires "--whole-archive".
-    if(BUILD_USE_SPOA_WITH_CPU_DISPATCH)
+    if(X86_64 AND BUILD_USE_SPOA_WITH_CPU_DISPATCH)
         target_link_libraries(
             shastaStaticExecutable
             shastaStaticLibrary
             atomic boost_system boost_program_options boost_chrono spoa cpu_features png z
             -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
-    else(BUILD_USE_SPOA_WITH_CPU_DISPATCH)
+    else(X86_64 AND BUILD_USE_SPOA_WITH_CPU_DISPATCH)
         target_link_libraries(
             shastaStaticExecutable
             shastaStaticLibrary
             atomic boost_system boost_program_options boost_chrono spoa png z
             -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
-    endif(BUILD_USE_SPOA_WITH_CPU_DISPATCH) 
+    endif(X86_64 AND BUILD_USE_SPOA_WITH_CPU_DISPATCH) 
     
 endif(MACOS)
   

--- a/staticLibrary/CMakeLists.txt
+++ b/staticLibrary/CMakeLists.txt
@@ -21,8 +21,11 @@ else(BUILD_DEBUG)
 endif(BUILD_DEBUG)
 
 # 16-byte compare and swap.
-# This is required by dset64.hpp/dset64-gccAtomic.hpp".
-add_definitions(-mcx16)
+# This is recommended for dset64.hpp/dset64-gccAtomic.hpp".
+# It's available only on x86 architectures.
+if(X86_64)
+  add_definitions(-mcx16)
+endif(X86_64)
 
 # Native build.
 if(BUILD_NATIVE)


### PR DESCRIPTION
The seqan-2.4.0 deb package in their Github release does not work on ARM. `libseqan2-dev` is available in the default Ubuntu repository starting with Ubuntu 20.04 LTS. This package can be used for both X86 and ARM. So here's what I have done ...

- Ubuntu versions older than 20.04 LTS are now deemed "old OS".
- Building on ARM64 & "old OS" is not supported. The `InstallPrerequisites-Ubuntu.sh` script will complain and bail.
- ARM64
  - Uses portable SPOA
  - Compiles Shasta without the `-mcx16` flag resulting in a sub-optimal implementation of `__sync_bool_compare_and_swap`
- X86
  - Uses SPOA with CPU dispatch for Ubuntu 20.04 LTS. Uses portable SPOA for "old OS".
  - Compiles Shasta with the `-mcx16` flag for optimal implementation of `__sync_bool_compare_and_swap`

These choices seem reasonable because `shasta-Linux` is generated on Ubuntu 20.04 LTS. The only _regression_ here will be for Ubuntu 18.04 LTS users, who will have to use the portable version of SPOA when they build from source. 

Test Plan:
- Github actions ran regression tests on x86_64.
- I was able to build from source on a Graviton instance in AWS (on `aarch64`).