### PR TITLE
Added PeakFinder and integrated into Assembler

### DIFF
--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -230,6 +230,7 @@ void Assembler::createMarkerGraphVertices(
             shasta::PeakFinder p;
             p.findPeaks(histogram);
             minCoverage = p.findXCutoff(histogram);
+            cout << "Marker.minCoverage inferred during run time: " << minCoverage << '\n';
         }
     }
 

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -3,6 +3,7 @@
 #include "AlignmentGraph.hpp"
 #include "ConsensusCaller.hpp"
 #include "compressAlignment.hpp"
+#include "PeakFinder.hpp"
 #ifdef SHASTA_HTTP_SERVER
 #include "LocalMarkerGraph.hpp"
 #endif
@@ -223,6 +224,12 @@ void Assembler::createMarkerGraphVertices(
             if(frequency) {
                 csv << coverage << "," << frequency << "\n";
             }
+        }
+
+        if (minCoverage == 0) {
+            shasta::PeakFinder p;
+            p.findPeaks(histogram);
+            minCoverage = p.findXCutoff(histogram);
         }
     }
 

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -227,10 +227,15 @@ void Assembler::createMarkerGraphVertices(
         }
 
         if (minCoverage == 0) {
-            shasta::PeakFinder p;
-            p.findPeaks(histogram);
-            minCoverage = p.findXCutoff(histogram);
-            cout << "Marker.minCoverage inferred during run time: " << minCoverage << '\n';
+            try {
+                shasta::PeakFinder p;
+                p.findPeaks(histogram);
+                minCoverage = p.findXCutoff(histogram);
+                cout << "MarkerGraph.minCoverage inferred during run time: " << minCoverage << '\n';
+            }
+            catch (PeakFinderException){
+                throw runtime_error("ERROR: No significant cutoff found in distribution");
+            }
         }
     }
 

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -2,8 +2,6 @@
 #include <algorithm>
 
 using namespace shasta;
-using std::sort;
-using std::cerr;
 
 
 PeakFinder::Peak::Peak(uint64_t start):

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -6,6 +6,16 @@ using std::sort;
 using std::cerr;
 
 
+shasta::Peak::Peak(uint64_t start):
+        start(start),
+        stop(0),
+        left(start),
+        right(start),
+        isMerged(false),
+        persistence(0)
+{}
+
+
 void PeakFinder::findPeaks(vector<uint64_t>& y){
     size_t xSize = y.size();
 

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -153,6 +153,11 @@ uint64_t PeakFinder::calculateArea(const vector<uint64_t>& y, uint64_t xMin, uin
 
 
 uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
+    // First check that there is at least one peak (beyond the expected error peak at x=1)
+    if (peaks.size() < 2) {
+        throw PeakFinderException();
+    }
+
     sortByPersistence();
 
     // find the total AUC

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -16,7 +16,7 @@ shasta::Peak::Peak(uint64_t start):
 {}
 
 
-void PeakFinder::findPeaks(vector<uint64_t>& y){
+void PeakFinder::findPeaks(const vector<uint64_t>& y){
     size_t xSize = y.size();
 
     // Create a vector of values, in which each value can be used to fetch the parent peak for that position in the
@@ -140,7 +140,7 @@ void PeakFinder::sortByPersistence(){
 }
 
 
-uint64_t PeakFinder::calculateArea(vector<uint64_t>& y, uint64_t x_min, uint64_t x_max){
+uint64_t PeakFinder::calculateArea(const vector<uint64_t>& y, uint64_t x_min, uint64_t x_max){
     uint64_t total = 0;
 
     for (size_t i=x_min; i<=x_max; i++){
@@ -151,7 +151,7 @@ uint64_t PeakFinder::calculateArea(vector<uint64_t>& y, uint64_t x_min, uint64_t
 }
 
 
-uint64_t PeakFinder::findXCutoff(vector<uint64_t>& y){
+uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
     sortByPersistence();
 
     // find the total AUC

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -6,7 +6,7 @@ using std::sort;
 using std::cerr;
 
 
-shasta::Peak::Peak(uint64_t start):
+PeakFinder::Peak::Peak(uint64_t start):
         start(start),
         stop(0),
         left(start),
@@ -140,10 +140,10 @@ void PeakFinder::sortByPersistence(){
 }
 
 
-uint64_t PeakFinder::calculateArea(const vector<uint64_t>& y, uint64_t x_min, uint64_t x_max){
+uint64_t PeakFinder::calculateArea(const vector<uint64_t>& y, uint64_t xMin, uint64_t xMax){
     uint64_t total = 0;
 
-    for (size_t i=x_min; i<=x_max; i++){
+    for (size_t i=xMin; i <= xMax; i++){
         total += y[i];
     }
 
@@ -155,7 +155,7 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
     sortByPersistence();
 
     // find the total AUC
-    uint64_t total_area = calculateArea(y, 1, y.size() - 1);
+    uint64_t totalArea = calculateArea(y, 1, y.size() - 1);
 
     // Second most prominent peak
     Peak& p = peaks[1];
@@ -163,18 +163,18 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
     // Find the AUC inside the bounds of the peak (from y=0 and up)
     uint64_t peakArea = calculateArea(y, p.left, p.right);
 
-    double percentArea = 100 * (double(peakArea) / double(total_area));
+    double percentArea = 100 * (double(peakArea) / double(totalArea));
 
-    uint64_t x_cutoff;
+    uint64_t xCutoff;
 
     // Check if second most prominent peak is reasonable size (not a false peak)
     if (percentArea > 1){   //TODO: readjust this proportion for histograms with 0=0 frequency
-        x_cutoff = p.left;
+        xCutoff = p.left;
     }
     else{
         throw runtime_error("ERROR: No significant cutoff found in marker frequency histogram");
     }
 
-    return x_cutoff;
+    return xCutoff;
 }
 

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -1,0 +1,170 @@
+#include "PeakFinder.hpp"
+#include <algorithm>
+
+using namespace shasta;
+using std::sort;
+using std::cerr;
+
+
+void PeakFinder::findPeaks(vector<uint64_t>& y){
+    size_t xSize = y.size();
+
+    // Create a vector of values, in which each value can be used to fetch the parent peak for that position in the
+    // y. If that position does not yet belong to a peak, it has index -1
+    vector<int64_t> peakIndex(xSize, -1);
+
+    // Create a vector of x values which point to y values
+    vector<size_t> indexes(xSize, 0);
+    for (size_t i=0; i<indexes.size() ; i++) {
+        indexes[i] = i;
+    }
+
+    // Sort the x values based on their corresponding y
+    sort(indexes.begin(), indexes.end(),
+         [&](const size_t& a, const size_t& b) {
+             // Equal y values are sorted by lowest x value
+             if (y[a] == y[b]){
+                 return (a < b);
+             }
+             else {
+                 return (y[a] > y[b]);
+             }
+         }
+    );
+
+    // Merge peaks
+    for (auto& i: indexes){
+        bool hasLeftPeak = false;
+        if (i > 0){
+            hasLeftPeak = (peakIndex[i - 1] >= 0);
+        }
+
+        bool hasRightPeak = false;
+        if (i < xSize - 1){
+            hasRightPeak = (peakIndex[i + 1] >= 0);
+        }
+
+        // No adjacent peaks
+        if (not hasLeftPeak and not hasRightPeak){
+            Peak p(i);
+            peaks.push_back(p);
+            peakIndex[i] = int64_t(peaks.size() - 1);
+        }
+        // Left side is peak
+        else if (hasLeftPeak and not hasRightPeak){
+            Peak& leftPeak = peaks[size_t(peakIndex[i - 1])];
+            leftPeak.right = i;
+            peakIndex[i] = peakIndex[i - 1];
+        }
+        // Right side is peak
+        else if (not hasLeftPeak and hasRightPeak){
+            Peak& rightPeak = peaks[size_t(peakIndex[i + 1])];
+            rightPeak.left = i;
+            peakIndex[i] = peakIndex[i + 1];
+        }
+        // Both sides are peaks
+        else{
+            Peak& leftPeak = peaks[size_t(peakIndex[i - 1])];
+            uint64_t xLeft = leftPeak.start;
+            uint64_t yLeft = y[xLeft];
+
+            Peak& rightPeak = peaks[size_t(peakIndex[i + 1])];
+            uint64_t xRight = rightPeak.start;
+            uint64_t yRight = y[xRight];
+
+            // Right peak is bigger
+            if (yRight > yLeft){
+                rightPeak.left = leftPeak.left;
+                peakIndex[i] = peakIndex[i + 1];
+
+                // Update the bounds of the dead peak so it stops (inclusive) at the merge point
+                leftPeak.right = i;
+
+                // Update boundary peak index
+                peakIndex[leftPeak.left] = peakIndex[i + 1];
+                peakIndex[leftPeak.right] = peakIndex[i + 1];
+
+                // Update the weaker peak to reflect that is has terminated
+                leftPeak.stop = i;
+                leftPeak.isMerged = true;
+                leftPeak.persistence = y[rightPeak.start] - y[i];
+            }
+            // Left peak is bigger, or same size
+            else{
+                leftPeak.right = rightPeak.right;
+                peakIndex[i] = peakIndex[i - 1];
+
+                // Update the bounds of the dead peak so it stops (inclusive) at the merge point
+                rightPeak.left = i;
+
+                // Update boundary peak index
+                peakIndex[rightPeak.right] = peakIndex[i - 1];
+                peakIndex[rightPeak.left] = peakIndex[i - 1];
+
+                // Update the weaker peak to reflect that is has terminated
+                rightPeak.stop = i;
+                rightPeak.isMerged = true;
+                rightPeak.persistence = y[rightPeak.start] - y[i];
+            }
+        }
+    }
+
+    // Set the persistence for the tallest peak as its total height from 0
+    peaks[0].persistence = y[peaks[0].start];
+}
+
+
+void PeakFinder::sortByPersistence(){
+    // Sort the peaks based on their persistence
+    sort(peaks.begin(), peaks.end(),
+         [&](const Peak& a, const Peak& b) {
+             // Equal values are sorted by lowest x value
+             if (a.persistence == b.persistence){
+                 return (a.start < b.start);
+             }
+             else {
+                 return (a.persistence > b.persistence);
+             }
+         }
+    );
+}
+
+
+uint64_t PeakFinder::calculateArea(vector<uint64_t>& y, uint64_t x_min, uint64_t x_max){
+    uint64_t total = 0;
+
+    for (size_t i=x_min; i<=x_max; i++){
+        total += y[i];
+    }
+
+    return total;
+}
+
+
+uint64_t PeakFinder::findXCutoff(vector<uint64_t>& y){
+    sortByPersistence();
+
+    // find the total AUC
+    uint64_t total_area = calculateArea(y, 1, y.size() - 1);
+
+    // Second most prominent peak
+    Peak& p = peaks[1];
+
+    // Find the AUC inside the bounds of the peak (from y=0 and up)
+    uint64_t peakArea = calculateArea(y, p.left, p.right);
+
+    double percentArea = 100 * (double(peakArea) / double(total_area));
+
+    uint64_t x_cutoff;
+
+    // Check if second most prominent peak is reasonable size (not a false peak)
+    if (percentArea > 1){   //TODO: readjust this proportion for histograms with 0=0 frequency
+        x_cutoff = p.left;
+    }
+    else{
+        throw runtime_error("ERROR: No significant cutoff found in marker frequency histogram");
+    }
+
+    return x_cutoff;
+}
+

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -16,6 +16,7 @@ PeakFinder::Peak::Peak(uint64_t start):
 {}
 
 
+
 void PeakFinder::findPeaks(const vector<uint64_t>& y){
     size_t xSize = y.size();
 
@@ -168,11 +169,11 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
     uint64_t xCutoff;
 
     // Check if second most prominent peak is reasonable size (not a false peak)
-    if (percentArea > 1){   //TODO: readjust this proportion for histograms with 0=0 frequency
+    if (percentArea > 1){
         xCutoff = p.left;
     }
     else{
-        throw runtime_error("ERROR: No significant cutoff found in marker frequency histogram");
+        throw PeakFinderException();
     }
 
     return xCutoff;

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -15,19 +15,37 @@ using std::string;
 using std::cout;
 
 namespace shasta {
-    class Peak;
     class PeakFinder;
 }
 
 
-ostream& operator<<(ostream& o, shasta::Peak& peak){
-    o << peak.start << ',' << peak.stop << ',' << peak.isMerged << ',' << peak.left << ',' << peak.right << ',' << peak.persistence;
-
-    return o;
-}
-
-
 class shasta::PeakFinder {
+private:
+    class Peak {
+    public:
+        /// Attributes ///
+
+        // Start is the x value corresponding to the highest point in the peak
+        uint64_t start;
+
+        // Stop is the x value corresponding to lowest point in the peak before it was merged.
+        uint64_t stop;
+
+        // During iteration, left and right are the x bounds of each growing peak
+        uint64_t left;
+        uint64_t right;
+
+        // Has this peak been taken over by a taller adjacent peak?
+        bool isMerged;
+
+        // Persistence is the height from the top of the peak to its base, where it was merged with another peak
+        uint64_t persistence;
+
+        /// Methods ///
+        Peak(uint64_t start);
+    };
+
+
 public:
     /// Attributes ///
 
@@ -42,7 +60,8 @@ public:
 
     void sortByPersistence();
     uint64_t findXCutoff(const vector<uint64_t>& y);
-    uint64_t calculateArea(const vector<uint64_t>& y, uint64_t x_min, uint64_t x_max);
+    uint64_t calculateArea(const vector<uint64_t>& y, uint64_t xMin, uint64_t xMax);
+
 };
 
 

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -55,12 +55,6 @@
 #include "utility.hpp"
 #include "vector.hpp"
 
-using std::runtime_error;
-using std::ostream;
-using std::pair;
-using std::vector;
-using std::string;
-using std::cout;
 
 namespace shasta {
     class PeakFinder;

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -1,15 +1,12 @@
-#ifndef SHASTA_PEAKFINDER_HPP
-#define SHASTA_PEAKFINDER_HPP
+#ifndef SHASTA_PEAK_FINDER_HPP
+#define SHASTA_PEAK_FINDER_HPP
 
 
-#include <experimental/filesystem>
-#include <stdexcept>
-#include <iostream>
-#include <utility>
-#include <vector>
+#include "stdexcept.hpp"
+#include "iostream.hpp"
+#include "utility.hpp"
+#include "vector.hpp"
 
-using std::experimental::filesystem::create_directories;
-using std::experimental::filesystem::path;
 using std::runtime_error;
 using std::ostream;
 using std::pair;
@@ -83,4 +80,4 @@ public:
 
 
 
-#endif //SHASTA_PEAKFINDER_HPP
+#endif //SHASTA_PEAK_FINDER_HPP

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -2,6 +2,54 @@
 #define SHASTA_PEAK_FINDER_HPP
 
 
+/***********************************************************************************************************************
+
+ PeakFinder uses topographic prominence define peaks as sets of adjacent points surrounding a local maximum. During
+ iteration, PeakFinder generates a hierarchy of peaks, for which each peak is a subpeak of the nearest taller peak.
+ The global maximum becomes the parent peak of all local maximums.
+
+
+ Peak domains:
+ 1  2  3
+ ----------
+ O        - ########################################  *
+ X        - #####################
+ X        - ###########
+ X        - #######
+ X        - #####
+ X  X     - ####
+ X  X  X  - ######
+ X  X  O  - ########  *
+ X  X  X  - ######
+ X  X     - ########
+ X  X     - ##########
+ X  X     - ############
+ X  O     - #############  *
+ X  X     - #############
+ X  X     - ###########
+ X  X     - #########
+ X  X     - #####
+ X        - ##
+ X        - #
+ X        - #
+
+
+ In shasta, the marker coverage distribution has a guaranteed global maximum at 1, and any number of smaller maxima
+ afterwards. The 1 max is the collection of markers that contain errors, for which no or few adjacent reads had an
+ identical marker. The second most prominent peak is expected to be the true distribution of coverage inside the
+ marker graph, usually falling around 20-30 for a 60X dataset. The valley between the error peak and the true
+ coverage peak is the target cutoff for this algorithm.
+
+ Because there may be noise in the distribution, local minima in this valley must be ignored, which is the motivation
+ for using topographic prominence. Note how the domain of the true coverage peak (2) in the diagram contains the
+ domain of peak 3, which is noise. The left boundary of peak 2's domain is the target cutoff.
+
+ The implementation is based on this page: https://www.sthu.org/blog/13-perstopology-peakdetection/index.html
+ The complexity for annotating all points in the distribution is O(N) + the cost of sorting.
+
+***********************************************************************************************************************/
+
+
 #include "stdexcept.hpp"
 #include "iostream.hpp"
 #include "utility.hpp"

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -64,7 +64,11 @@ using std::cout;
 
 namespace shasta {
     class PeakFinder;
+    class PeakFinderException;
 }
+
+
+class shasta::PeakFinderException{};
 
 
 class shasta::PeakFinder {

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -19,6 +19,7 @@ namespace shasta {
     class PeakFinder;
 }
 
+
 class shasta::Peak {
 public:
     /// Attributes ///
@@ -48,15 +49,6 @@ ostream& operator<<(ostream& o, shasta::Peak& peak){
     o << peak.start << ',' << peak.stop << ',' << peak.isMerged << ',' << peak.left << ',' << peak.right << ',' << peak.persistence;
 
     return o;
-}
-
-
-shasta::Peak::Peak(uint64_t start){
-    this->left = start;
-    this->right = start;
-    this->start = start;
-    this->stop = 0;
-    this->isMerged = false;
 }
 
 

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -1,0 +1,86 @@
+#ifndef SHASTA_PEAKFINDER_HPP
+#define SHASTA_PEAKFINDER_HPP
+
+
+#include <experimental/filesystem>
+#include <stdexcept>
+#include <iostream>
+#include <utility>
+#include <vector>
+
+using std::experimental::filesystem::create_directories;
+using std::experimental::filesystem::path;
+using std::runtime_error;
+using std::ostream;
+using std::pair;
+using std::vector;
+using std::string;
+using std::cout;
+
+namespace shasta {
+    class Peak;
+    class PeakFinder;
+}
+
+class shasta::Peak {
+public:
+    /// Attributes ///
+
+    // Start is the x value corresponding to the highest point in the peak
+    uint64_t start;
+
+    // Stop is the x value corresponding to lowest point in the peak before it was merged.
+    uint64_t stop;
+
+    // During iteration, left and right are the x bounds of each growing peak
+    uint64_t left;
+    uint64_t right;
+
+    // Has this peak been taken over by a taller adjacent peak?
+    bool isMerged;
+
+    // Persistence is the height from the top of the peak to its base, where it was merged with another peak
+    uint64_t persistence;
+
+    /// Methods ///
+    Peak(uint64_t start);
+};
+
+
+ostream& operator<<(ostream& o, shasta::Peak& peak){
+    o << peak.start << ',' << peak.stop << ',' << peak.isMerged << ',' << peak.left << ',' << peak.right << ',' << peak.persistence;
+
+    return o;
+}
+
+
+shasta::Peak::Peak(uint64_t start){
+    this->left = start;
+    this->right = start;
+    this->start = start;
+    this->stop = 0;
+    this->isMerged = false;
+}
+
+
+class shasta::PeakFinder {
+public:
+    /// Attributes ///
+
+    // This vector will be filled with peaks during iteration
+    vector<Peak> peaks;
+
+
+    /// Methods ///
+
+    // Iterate the y values and identify all the peaks/valleys
+    void findPeaks(vector<uint64_t>& y);
+
+    void sortByPersistence();
+    uint64_t findXCutoff(vector<uint64_t>& y);
+    uint64_t calculateArea(vector<uint64_t>& y, uint64_t x_min, uint64_t x_max);
+};
+
+
+
+#endif //SHASTA_PEAKFINDER_HPP

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -20,31 +20,6 @@ namespace shasta {
 }
 
 
-class shasta::Peak {
-public:
-    /// Attributes ///
-
-    // Start is the x value corresponding to the highest point in the peak
-    uint64_t start;
-
-    // Stop is the x value corresponding to lowest point in the peak before it was merged.
-    uint64_t stop;
-
-    // During iteration, left and right are the x bounds of each growing peak
-    uint64_t left;
-    uint64_t right;
-
-    // Has this peak been taken over by a taller adjacent peak?
-    bool isMerged;
-
-    // Persistence is the height from the top of the peak to its base, where it was merged with another peak
-    uint64_t persistence;
-
-    /// Methods ///
-    Peak(uint64_t start);
-};
-
-
 ostream& operator<<(ostream& o, shasta::Peak& peak){
     o << peak.start << ',' << peak.stop << ',' << peak.isMerged << ',' << peak.left << ',' << peak.right << ',' << peak.persistence;
 
@@ -63,11 +38,11 @@ public:
     /// Methods ///
 
     // Iterate the y values and identify all the peaks/valleys
-    void findPeaks(vector<uint64_t>& y);
+    void findPeaks(const vector<uint64_t>& y);
 
     void sortByPersistence();
-    uint64_t findXCutoff(vector<uint64_t>& y);
-    uint64_t calculateArea(vector<uint64_t>& y, uint64_t x_min, uint64_t x_max);
+    uint64_t findXCutoff(const vector<uint64_t>& y);
+    uint64_t calculateArea(const vector<uint64_t>& y, uint64_t x_min, uint64_t x_max);
 };
 
 


### PR DESCRIPTION
This adds a method for dynamically selecting a Marker.minCoverage cutoff, using the distribution of coverages from the marker disjoint set object during runtime. 

So far it passes all test cases I could generate, but I am going to spend a bit more time evaluating the no-peak cases, so it shouldn't be merged until then. 