### PR TITLE
Reduce peak memory usage

### DIFF
--- a/scripts/CreateAndCleanupMarkerGraph.py
+++ b/scripts/CreateAndCleanupMarkerGraph.py
@@ -9,25 +9,27 @@ config = GetConfig.getConfig()
 
 # Initialize the assembler and access what we need.
 a = shasta.Assembler()
+a.accessReadFlags()
 a.accessKmers()
 a.accessMarkers()
 a.accessAlignmentData()
 a.accessReadGraph()
-a.accessChimericReadsFlags()
 
 # Create vertices of the marker graph.
 a.createMarkerGraphVertices(
     alignMethod = int(config['Align']['alignMethod']),
     maxMarkerFrequency = int(config['Align']['maxMarkerFrequency']),
     maxSkip = int(config['Align']['maxSkip']),
-    matchScore = int(config['Align']['matchScore']),,
-    mismatchScore = int(config['Align']['mismatchScore']),,
+    maxDrift = int(config['Align']['maxDrift']),
+    matchScore = int(config['Align']['matchScore']),
+    mismatchScore = int(config['Align']['mismatchScore']),
     gapScore = int(config['Align']['gapScore']),
     downsamplingFactor = float(config['Align']['downsamplingFactor']),
     bandExtend = int(config['Align']['bandExtend']),
     readGraphCreationMethod = int(config['ReadGraph']['creationMethod']),
     minCoverage = int(config['MarkerGraph']['minCoverage']),
-    maxCoverage = int(config['MarkerGraph']['maxCoverage']))
+    maxCoverage = int(config['MarkerGraph']['maxCoverage']),
+    minCoveragePerStrand = int(config['MarkerGraph']['minCoveragePerStrand']))
 
 # Create edges of the marker graph.
 a.createMarkerGraphEdges()
@@ -37,7 +39,7 @@ a.transitiveReduction(
     lowCoverageThreshold = int(config['MarkerGraph']['lowCoverageThreshold']),
     highCoverageThreshold = int(config['MarkerGraph']['highCoverageThreshold']),
     maxDistance = int(config['MarkerGraph']['maxDistance']),
-    )
+)
 
 # Prune the strong subgraph of the marker graph.
 a.pruneMarkerGraphStrongSubgraph(

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -1159,6 +1159,7 @@ public:
 private:
     void createMarkerGraphVerticesThreadFunction1(size_t threadId);
     void createMarkerGraphVerticesThreadFunction2(size_t threadId);
+    void createMarkerGraphVerticesThreadFunction21(size_t threadId);
     void createMarkerGraphVerticesThreadFunction3(size_t threadId);
     void createMarkerGraphVerticesThreadFunction4(size_t threadId);
     void createMarkerGraphVerticesThreadFunction5(size_t threadId);
@@ -1186,8 +1187,6 @@ private:
         uint64_t orientedMarkerCount;
 
         // Disjoint sets data structures.
-        // MemoryMapped::Vector< std::atomic<DisjointSets::Aint> > disjointSetsData;
-        MemoryMapped::Vector<DisjointSets::Aint> disjointSetsData;
         shared_ptr<DisjointSets> disjointSetsPointer;
 
         // The disjoint set that each oriented marker was assigned to.

--- a/src/AssemblerMarkerGraphRefine.cpp
+++ b/src/AssemblerMarkerGraphRefine.cpp
@@ -87,8 +87,9 @@ void Assembler::refineMarkerGraph(
         }
     }
 
-
-
+    // Clean up.
+    assemblyGraph.remove();
+    
     // Remove the marker graph vertices we flagged.
     MemoryMapped::Vector<MarkerGraph::VertexId> verticesToBeKept;
     verticesToBeKept.createNew(
@@ -109,7 +110,6 @@ void Assembler::refineMarkerGraph(
 
 
     // Clean up.
-    assemblyGraph.remove();
     isVertexToBeRemoved.remove();
     verticesToBeKept.remove();
 


### PR DESCRIPTION
**DisjointSets** 
`DisjointSets::find` is guaranteed to return the correct set representative. However, it is not guaranteed
that the parent information (lower 64 bits) will have the set representative stored in it when it is done.
This is because the `__sync_bool_compare_and_swap` could fail because of race conditions.
I'm introducing a new data member - `trackParentUpdated`.
When `trackParentUpdated` is set to True, we bump a counter that tracks the number
of entries that don't have the set representative populated in their lower 64 bits.

In a highly parallel environment, where N threads are calling `find` on different
entries in DisjointSets, it is very likely that several entries won't have the
set representative populated as the parent, at the end of the pass.

If we do multiple such passes over all entries, then within a few iterations, the parent
information in all entries (lower 64 bits) will have the correct set representative.
`this->parentUpdated` can be used to track this convergence. 

**createMarkerGraphVertices**
Storing N markers requires 8N bytes (64 bit integers). The DisjointSets data structure requires an additional 64 bits per marker.
We were allocating 16N bytes for DisjointSets and then another 8N bytes to find and store the results from DisjointSets. This seemed wasteful. So now we compact the memory allocated to DisjointSets in-place. For a typical human genome assembly this means we avoid allocating around 145 GB. This lops off the current peak of Shasta's memory usage.

In order to do this, we do multiple passes of calling `find` on each entry in DisjointSets. This is feasible because, we typically need only 2-3 passes and each pass is quite fast.

**Performance Impact**
For `HG002-Guppy-3.6.0`, these changes reduced peak memory usage by _**101 GB (14.11%).**_ at the cost of adding about 3 minutes to the assembly time. This is a fantastic trade-off as Shasta is plenty fast, but constrained by its memory use.

**Test Plan**
Compared the assembly of `HG002-Guppy-3.6.0` reads before and after this change. Used QUAST to verify that assembly quality was unchanged.