### PR TITLE
New page for browser: Assess alignments

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -2087,7 +2087,10 @@ public:
     );
 #endif
 
+    // Do bulk sampling of reads and accumulate stats about their alignments
     void assessAlignments(const vector<string>& request, ostream& html);
+    void sampleReads(vector<OrientedReadId>& sample, uint64_t n);
+    void sampleReads(vector<OrientedReadId>& sample, uint64_t n, uint64_t minLength, uint64_t maxLength);
 
 
     // Compute all alignments for a given read.

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -2087,6 +2087,7 @@ public:
     );
 #endif
 
+    void assessAlignments(const vector<string>& request, ostream& html);
 
 
     // Compute all alignments for a given read.

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1427,7 +1427,7 @@ void Assembler::assessAlignments(
     markerCountHistogram.writeToHtml(html, histogramSize);
     html << "<br><strong>Aligned Fraction Distribution</strong>";
     alignedFractionHistogram.writeToHtml(html, histogramSize);
-    html << "<br><strong>Alignment Quantity Distribution</strong>";
+    html << "<br><strong>Number of Alignments Found per Read</strong>";
     nAlignmentsHistogram.writeToHtml(html, histogramSize);
     html << "<br><strong>Ratio of stored to found alignments</strong>";
     html << "<br>" << double(allStoredAlignments.size())/double(allAlignments.size());

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1272,8 +1272,9 @@ void Assembler::assessAlignments(
     getParameterValue(request, "bandExtend", computeAllAlignmentsData.bandExtend);
 
     html << "<h1>Alignment statistics</h1>";
-    html << "<p>This page enables sampling from the pool of reads and computing alignments for each read in the"
-            "sample. Once alignment finishes, stats can be generated and used to evaluate Shasta parameters."
+    html << "<p>This page enables sampling from the pool of reads and computing alignments for each read in the sample "
+            "against all other reads in this assembly. This can be slow. Once alignment finishes, stats can be "
+            "generated and used to evaluate Shasta parameters."
             "<br>";
 
     // Write the form.
@@ -1339,18 +1340,21 @@ void Assembler::assessAlignments(
     }
 
     // Initialize histograms
-    IterativeHistogram alignedFractionHistogram(0,1,20);
-    IterativeHistogram markerCountHistogram(0,3000,120);
-    IterativeHistogram nAlignmentsHistogram(0,200,20);
+    Histogram2 alignedFractionHistogram(0, 1, 20);
+    Histogram2 markerCountHistogram(0, 3000, 120);
+    Histogram2 nAlignmentsHistogram(0, 200, 20);
 
     vector<pair<OrientedReadId, AlignmentInfo> > allAlignments;
     vector<pair<OrientedReadId, AlignmentInfo> > allStoredAlignments;
 
     for (auto& orientedReadId: sampledReads) {
-        // Vectors to contain markers sorted by kmerId.
-        vector<MarkerWithOrdinal> markers0SortedByKmerId;
-        vector<MarkerWithOrdinal> markers1SortedByKmerId;
-        getMarkersSortedByKmerId(orientedReadId, markers0SortedByKmerId);
+
+        if (computeAllAlignmentsData.method == 0) {
+            // Vectors to contain markers sorted by kmerId. (only needed for align method 0)
+            vector<MarkerWithOrdinal> markers0SortedByKmerId;
+            vector<MarkerWithOrdinal> markers1SortedByKmerId;
+            getMarkersSortedByKmerId(orientedReadId, markers0SortedByKmerId);
+        }
 
         // Compute the alignments in parallel.
         computeAllAlignmentsData.orientedReadId0 = orientedReadId;

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1412,7 +1412,7 @@ void Assembler::assessAlignments(
     }
 
     for (auto& item: allAlignments){
-        auto alignment = item.second;
+        const auto alignment = item.second;
 
         // Increment histograms
         markerCountHistogram.update(alignment.markerCount);
@@ -1420,7 +1420,7 @@ void Assembler::assessAlignments(
     }
 
     // Pixel width of histogram display
-    uint64_t histogramSize = 500;
+    const uint64_t histogramSize = 500;
 
     html << "<br><br>";
     html << "<br><strong>Marker Count Distribution</strong>";

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1188,14 +1188,12 @@ void Assembler::sampleReads(vector<OrientedReadId>& sample, uint64_t n){
 
     while (sample.size() < n) {
         // Randomly select a read in the read set
-        uint16_t readId = uint16_t(rand() % reads.size());
+        const ReadId readId = uint32_t(rand() % reads.size());
 
         // Randomly select an orientation
-        uint16_t strand = uint16_t(rand() % 2);
+        const Strand strand = uint32_t(rand() % 2);
 
-        const OrientedReadId r(readId, strand);
-
-        sample.push_back(r);
+        sample.push_back(OrientedReadId(readId, strand));
     }
 }
 
@@ -1205,10 +1203,10 @@ void Assembler::sampleReads(vector<OrientedReadId>& sample, uint64_t n, uint64_t
 
     while (sample.size() < n) {
         // Randomly select a read in the read set
-        uint16_t readId = uint16_t(rand() % reads.size());
+        const ReadId readId = uint32_t(rand() % reads.size());
 
         // Randomly select an orientation
-        uint16_t strand = uint16_t(rand() % 2);
+        const Strand strand = uint32_t(rand() % 2);
 
         const OrientedReadId r(readId, strand);
 

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1352,7 +1352,7 @@ void Assembler::assessAlignments(
         computeAllAlignmentsData.orientedReadId0 = orientedReadId;
         const size_t threadCount = std::thread::hardware_concurrency();
         computeAllAlignmentsData.threadAlignments.resize(threadCount);
-        const size_t batchSize = 1000;
+        const size_t batchSize = 1;
         setupLoadBalancing(reads.size(), batchSize);
         const auto t0 = std::chrono::steady_clock::now();
         runThreads(&Assembler::computeAllAlignmentsThreadFunction, threadCount);

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -15,6 +15,8 @@ using namespace shasta;
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
 
 // Seqan
 #ifdef SHASTA_HTTP_SERVER
@@ -23,6 +25,17 @@ using namespace shasta;
 
 #ifdef SHASTA_HTTP_SERVER
 
+using namespace boost::accumulators;
+
+
+typedef boost::iterator_range< std::vector <std::pair <double, double> >::iterator> densityIterator;
+
+typedef accumulator_set <double, features
+        <tag::density,
+        tag::count,
+        tag::min,
+        tag::max> >
+        densityAccumulator;
 
 
 void Assembler::exploreAlignments(
@@ -1225,6 +1238,45 @@ void Assembler::sampleReads(vector<OrientedReadId>& sample, uint64_t n, uint64_t
 }
 
 
+void writeDensityAccumulatorToHtml(ostream& html, densityAccumulator& accumulator, uint64_t sizePx){
+    html << "<table style='margin-top: 1em; margin-bottom: 1em'>";
+    html << "<tr>"
+            "<th class='centered'>Left edge"
+            "<th class='centered'>Right edge"
+            "<th class='centered'>Count"
+            "<th class='centered'>Density"
+            "<th class='centered'>Plot";
+
+    double maxCount = boost::accumulators::max(accumulator);
+
+    // Determine the scaling factor for the histogram bars
+    double scale = double(sizePx)/double(maxCount);
+
+    // Initialize an iterator for the "density" portion of the accumulator
+    densityIterator histogram = density(accumulator);
+
+    // Find out the bin size from the first 2 entries
+    double binSize = histogram[1].first - histogram[0].first;
+
+    for (size_t i=0; i<histogram.size(); i++){
+        const double leftBound = histogram[i].first;
+        const double rightBound = leftBound + binSize;
+        const double y = histogram[i].second;
+
+        html << std::fixed << std::setprecision(2) <<
+            "<tr>"
+            "<td class=centered>" << leftBound <<
+            "<td class=centered>" << rightBound <<
+            "<td class=centered>" << y*maxCount <<
+            "<td class=centered>" << y <<
+            "<td>"
+            "<div class=sketch title='alignedFractionHistogram' style='display:inline-block;margin:0px;padding:0px;"
+            "background-color:blue;height:6px;width:" << double(y)*maxCount*scale << "px;'></div>";
+    }
+    html << "</table>";
+}
+
+
 // Compute alignments on an oriented read against
 // all other oriented reads, using a sampling of reads.
 // Display some useful stats for these alignments.
@@ -1339,9 +1391,22 @@ void Assembler::assessAlignments(
     }
 
     // Initialize histograms
-    IterativeHistogram alignedFractionHistogram(0,1,20);
-    IterativeHistogram markerCountHistogram(0,3000,100);
-    IterativeHistogram nAlignmentsHistogram(0,200,20);
+//    IterativeHistogram alignedFractionHistogram(0,1,20);
+//    IterativeHistogram markerCountHistogram(0,3000,100);
+//    IterativeHistogram nAlignmentsHistogram(0,200,20);
+
+    densityAccumulator alignedFractionAccumulator(
+            tag::density::cache_size=100,
+            tag::density::num_bins=100);
+
+    densityAccumulator markerCountAccumulator(
+            tag::density::cache_size=100,
+            tag::density::num_bins=100);
+
+    densityAccumulator nAlignmentsAccumulator(
+            tag::density::cache_size=100,
+            tag::density::num_bins=100);
+
 
     vector<pair<OrientedReadId, AlignmentInfo> > allAlignments;
     vector<pair<OrientedReadId, AlignmentInfo> > allStoredAlignments;
@@ -1408,15 +1473,18 @@ void Assembler::assessAlignments(
         for (auto& a: alignments){
             allAlignments.push_back(a);
         }
-        nAlignmentsHistogram.update(double(alignments.size()));
+//        nAlignmentsHistogram.update(double(alignments.size()));
+        alignedFractionAccumulator(double(alignments.size()));
     }
 
     for (auto& item: allAlignments){
         auto alignment = item.second;
 
         // Increment histograms
-        markerCountHistogram.update(alignment.markerCount);
-        alignedFractionHistogram.update(alignment.minAlignedFraction());
+//        markerCountHistogram.update(alignment.markerCount);
+        markerCountAccumulator(alignment.markerCount);
+//        alignedFractionHistogram.update(alignment.minAlignedFraction());
+        nAlignmentsAccumulator(alignment.minAlignedFraction());
     }
 
     // Pixel width of histogram display
@@ -1424,11 +1492,14 @@ void Assembler::assessAlignments(
 
     html << "<br><br>";
     html << "<br><strong>Marker Count Distribution</strong>";
-    markerCountHistogram.writeToHtml(html, histogramSize);
+//    markerCountHistogram.writeToHtml(html, histogramSize);
+    writeDensityAccumulatorToHtml(html, markerCountAccumulator, histogramSize);
     html << "<br><strong>Aligned Fraction Distribution</strong>";
-    alignedFractionHistogram.writeToHtml(html, histogramSize);
+//    alignedFractionHistogram.writeToHtml(html, histogramSize);
+    writeDensityAccumulatorToHtml(html, alignedFractionAccumulator, histogramSize);
     html << "<br><strong>Alignment Quantity Distribution</strong>";
-    nAlignmentsHistogram.writeToHtml(html, histogramSize);
+//    nAlignmentsHistogram.writeToHtml(html, histogramSize);
+    writeDensityAccumulatorToHtml(html, nAlignmentsAccumulator, histogramSize);
     html << "<br><strong>Ratio of stored to found alignments</strong>";
     html << "<br>" << double(allStoredAlignments.size())/double(allAlignments.size());
     html << "<br";

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1424,13 +1424,18 @@ void Assembler::assessAlignments(
 
     html << "<br><br>";
     html << "<br><strong>Marker Count Distribution</strong>";
+    html << "<br>Histogram of the number of aligned markers observed per alignment";
     markerCountHistogram.writeToHtml(html, histogramSize);
     html << "<br><strong>Aligned Fraction Distribution</strong>";
+    html << "<br>Histogram of 'aligned fraction' per alignment. Aligned fraction is the portion of matching markers"
+            " used in the alignment, within the overlapping region between reads";
     alignedFractionHistogram.writeToHtml(html, histogramSize);
     html << "<br><strong>Number of Alignments Found per Read</strong>";
+    html << "<br>For each query read, how many passing alignments were found in one-to-all alignment";
     nAlignmentsHistogram.writeToHtml(html, histogramSize);
     html << "<br><strong>Ratio of stored to found alignments</strong>";
-    html << "<br>" << double(allStoredAlignments.size())/double(allAlignments.size());
+    html << "<br>" << std::fixed << std::setprecision(3) <<
+    double(allStoredAlignments.size())/double(allAlignments.size());
     html << "<br";
 }
 

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1340,7 +1340,7 @@ void Assembler::assessAlignments(
 
     // Initialize histograms
     IterativeHistogram alignedFractionHistogram(0,1,20);
-    IterativeHistogram markerCountHistogram(0,3000,100);
+    IterativeHistogram markerCountHistogram(0,3000,120);
     IterativeHistogram nAlignmentsHistogram(0,200,20);
 
     vector<pair<OrientedReadId, AlignmentInfo> > allAlignments;

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1271,6 +1271,10 @@ void Assembler::assessAlignments(
     computeAllAlignmentsData.bandExtend = httpServerData.assemblerOptions->alignOptions.bandExtend;
     getParameterValue(request, "bandExtend", computeAllAlignmentsData.bandExtend);
 
+    html << "<h1>Alignment statistics</h1>";
+    html << "<p>This page enables sampling from the pool of reads and computing alignments for each read in the"
+            "sample. Once alignment finishes, stats can be generated and used to evaluate Shasta parameters."
+            "<br>";
 
     // Write the form.
     html <<
@@ -1284,12 +1288,12 @@ void Assembler::assessAlignments(
         (samplesIsPresent ? "value="+to_string(samples) : "") <<
         " title='Enter any number'>"
         "<tr>"
-        "<td>Minimum length (default=0): "
+        "<td>Minimum number of raw bases in read (default=0): "
         "<td><input type=text name=minLength size=8 " <<
         (minLengthIsPresent ? "value="+to_string(minLength) : "") <<
         " title='Enter any number'>"
         "<tr>"
-        "<td>Maximum length (default=inf): "
+        "<td>Maximum number of raw bases in read (default=inf): "
         "<td><input type=text name=maxLength size=8 " <<
         (maxLengthIsPresent ? "value="+to_string(maxLength) : "") <<
         " title='Enter any number'>"

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -31,6 +31,7 @@ void Assembler::fillServerFunctionTable()
     SHASTA_ADD_TO_FUNCTION_TABLE(computeAllAlignments);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignmentGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(displayAlignmentMatrix);
+    SHASTA_ADD_TO_FUNCTION_TABLE(assessAlignments);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreReadGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreMarkerGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreMarkerGraphVertex);
@@ -306,6 +307,7 @@ void Assembler::writeNavigation(ostream& html) const
         {"Align one read with all", "computeAllAlignments"},
         {"Alignment graph", "exploreAlignmentGraph"},
         {"Alignment matrix", "displayAlignmentMatrix"},
+        {"Assess alignments", "assessAlignments"},
         });
     writeNavigation(html, "Read graph", {
         {"Read graph", "exploreReadGraph"},

--- a/src/Histogram.cpp
+++ b/src/Histogram.cpp
@@ -1,0 +1,229 @@
+#include "Histogram.hpp"
+#include <iostream>
+#include <cmath>
+
+using namespace shasta;
+
+shasta::IterativeHistogram::IterativeHistogram(
+        double start,
+        double stop,
+        size_t nBins,
+        bool unboundedLeft,
+        bool unboundedRight):
+    start(start),
+    stop(stop),
+    nBins(nBins),
+    binSize((stop-start)/double(nBins)),
+    histogram(nBins,0),
+    unboundedLeft(unboundedLeft),
+    unboundedRight(unboundedRight)
+{}
+
+
+int64_t shasta::IterativeHistogram::findIndex(double x){
+    /// Find index of bin by normalizing the value w.r.t. bin edges.
+    /// If the value does not fit in the range of the histogram, this function returns -1
+    /// If the user wants to accumulate values outside the bounds defined, then any value out of bounds will result in
+    /// the boundary bins being incremented
+    auto index = int64_t(floor((x - start) / binSize));
+
+    if (x < start){
+        if(unboundedLeft) {
+            index = 0;
+        }
+        else{
+            index = -1;
+        }
+    }
+
+    if (x >= stop) {
+        if (unboundedRight) {
+            index = int64_t(nBins) - 1;
+        }
+        else{
+            index = -1;
+        }
+    }
+
+    return index;
+}
+
+
+void shasta::IterativeHistogram::update(double x) {
+    auto index = findIndex(x);
+
+    if (index >= 0) {
+        histogram[size_t(index)]++;
+    }
+    else {
+        // Do nothing. Print warning?
+//        std::cerr << "Value " << x << " ignored because index is " << index << ". Size: " << histogram.size() << '\n';
+    }
+}
+
+
+void shasta::IterativeHistogram::getNormalizedHistogram(vector<double>& normalizedHistogram){
+    uint64_t sum = 0;
+    for (auto& e: histogram){
+        sum += e;
+    }
+
+    for (auto& e: histogram){
+        normalizedHistogram.push_back(double(e)/double(sum));
+    }
+}
+
+
+void shasta::IterativeHistogram::writeToHtml(ostream& html, uint64_t sizePx){
+    uint64_t max = 0;
+    for (auto& e: histogram){
+        if (e > max){
+            max = e;
+        }
+    }
+
+    double scale = double(sizePx)/double(max);
+
+    html << "<table style='margin-top: 2em; margin-bottom: 2em'>";
+
+    for (size_t i=0; i<histogram.size(); i++){
+        html <<
+             "<tr>"
+             "<td class=centered>" << std::fixed << double(i)*(binSize) <<
+             "<td class=centered>" << histogram[i] <<
+             "<td>"
+             "<div class=sketch title='alignedFractionHistogram' style='display:inline-block;margin:0px;padding:0px;"
+             "background-color:blue;height:6px;width:" << double(histogram[i])*scale << "px;'></div>";
+    }
+    html << "</table>";
+    html << "<table style='margin-top: 2em; margin-bottom: 2em'>";
+
+}
+
+
+void shasta::testIterativeHistogram(){
+    /// Test the iterative histogram
+
+    std::cout << "\nTESTING IterativeHistogram case 1\n";
+
+    IterativeHistogram h0(0, 10, 10);
+    h0.update(0);        // 1
+    h0.update(-1);       // None
+    h0.update(10);       // None
+    h0.update(9.99999);  // 10
+    h0.update(10.0001);  // None
+    h0.update(0.5);      // 1
+    h0.update(1.5);      // 2
+    h0.update(1.0);      // 2
+    h0.update(1.99999);  // 2
+
+    // ^ expect [2,3,0,0,0,0,0,0,0,1]
+
+    for (auto& e: h0.histogram) {
+        std::cout << e << ",";
+    }
+    std::cout << '\n';
+
+    std::cout << "\nTESTING IterativeHistogram case 2\n";
+
+    IterativeHistogram h1(0, 1.0, 10);
+    h1.update(0);         // 1
+    h1.update(-0.1);      // None
+    h1.update(1.0);       // None
+    h1.update(0.999999);  // 10
+    h1.update(1.00001);   // None
+    h1.update(0.05);      // 1
+    h1.update(0.15);      // 2
+    h1.update(0.10);      // 2
+    h1.update(0.199999);  // 2
+
+    // ^ expect [2,3,0,0,0,0,0,0,0,1]
+
+    for (auto& e: h1.histogram) {
+        std::cout << e << ",";
+    }
+    std::cout << '\n';
+
+    std::cout << "\nTESTING IterativeHistogram case 3\n";
+
+    IterativeHistogram h2(1, 2.0, 10);
+    h2.update(1 + 0);         // 1
+    h2.update(1 + -0.1);      // None
+    h2.update(1 + 1.0);       // None
+    h2.update(1 + 0.999999);  // 10
+    h2.update(1 + 1.00001);   // None
+    h2.update(1 + 0.05);      // 1
+    h2.update(1 + 0.15);      // 2
+    h2.update(1 + 0.10);      // 2
+    h2.update(1 + 0.199999);  // 2
+
+    // ^ expect [2,3,0,0,0,0,0,0,0,1]
+
+    for (auto& e: h2.histogram) {
+        std::cout << e << ",";
+    }
+    std::cout << '\n';
+
+    std::cout << "\nTESTING IterativeHistogram case 4\n";
+
+    IterativeHistogram h3(-0.5, 0.5, 10);
+    h3.update(-0.5 + 0);         // 1
+    h3.update(-0.5 + -0.1);      // None
+    h3.update(-0.5 + 1.0);       // None right edge
+    h3.update(-0.5 + 0.999999);  // 10
+    h3.update(-0.5 + 1.00001);   // None
+    h3.update(-0.5 + 0.05);      // 1
+    h3.update(-0.5 + 0.15);      // 2
+    h3.update(-0.5 + 0.10);      // 2 ... in near-edge cases float division may shift left a bin
+    h3.update(-0.5 + 0.199999);  // 2
+
+    // ^ expect [2,3,0,0,0,0,0,0,0,1]
+
+    for (auto& e: h3.histogram) {
+        std::cout << e << ",";
+    }
+    std::cout << '\n';
+
+    vector<double> normalized3;
+    h3.getNormalizedHistogram(normalized3);
+    double sum3 = 0;
+
+    for (auto& e: normalized3) {
+        std::cout << e << ",";
+        sum3 += e;
+    }
+    std::cout << '\n';
+    std::cout << sum3 << '\n';
+
+    std::cout << "\nTESTING IterativeHistogram case 5\n";
+
+    IterativeHistogram h4(0, 1.0, 10, true, true);
+    h4.update(0);         // 1
+    h4.update(-0.1);      // 1
+    h4.update(1.0);       // 10
+    h4.update(0.999999);  // 10
+    h4.update(1.00001);   // 10
+    h4.update(0.05);      // 1
+    h4.update(0.15);      // 2
+    h4.update(0.10);      // 2
+    h4.update(0.199999);  // 2
+
+    // ^ expect [3,3,0,0,0,0,0,0,0,3]
+
+    for (auto& e: h4.histogram) {
+        std::cout << e << ",";
+    }
+    std::cout << '\n';
+
+    vector<double> normalized4;
+    h4.getNormalizedHistogram(normalized4);
+    double sum4 = 0;
+
+    for (auto& e: normalized4) {
+        std::cout << e << ",";
+        sum4 += e;
+    }
+    std::cout << '\n';
+    std::cout << sum4 << '\n';
+
+}

--- a/src/Histogram.cpp
+++ b/src/Histogram.cpp
@@ -76,28 +76,50 @@ void shasta::IterativeHistogram::getNormalizedHistogram(vector<double>& normaliz
 
 
 void shasta::IterativeHistogram::writeToHtml(ostream& html, uint64_t sizePx){
-    uint64_t max = 0;
+    uint64_t yMax = 0;
     for (auto& e: histogram){
-        if (e > max){
-            max = e;
+        if (e > yMax){
+            yMax = e;
         }
     }
 
-    double scale = double(sizePx)/double(max);
+    double scale = double(sizePx)/double(yMax);
 
     html << "<table style='margin-top: 1em; margin-bottom: 1em'>";
+    html << "<tr>"
+            "<th class='centered'>Left bound"
+            "<th class='centered'>Right bound"
+            "<th class='centered'>Count"
+            "<th class='centered'>Plot";
+
+    int32_t precision;
 
     for (size_t i=0; i<histogram.size(); i++){
-        html <<
+        const double leftBound = double(i)*(binSize);
+        const double rightBound = double(i+1)*(binSize);
+        const auto y = histogram[i];
+
+        // Check if the bin bounds have any trailing decimals
+        if (std::fmod(leftBound,1) == 0 and std::fmod(rightBound,1) == 0){
+            precision = 0;
+        }
+        else{
+            precision = 2;
+        }
+
+        html << std::fixed << std::setprecision(precision) <<
              "<tr>"
-             "<td class=centered>" << std::fixed << std::setprecision(2) << double(i)*(binSize) <<
-             "<td class=centered>" << histogram[i] <<
+             "<td class=centered>" << leftBound <<
+             "<td class=centered>" << rightBound <<
+             "<td class=centered>" << y <<
              "<td>"
              "<div class=sketch title='alignedFractionHistogram' style='display:inline-block;margin:0px;padding:0px;"
-             "background-color:blue;height:6px;width:" << double(histogram[i])*scale << "px;'></div>";
+             "background-color:blue;height:6px;width:" << double(y)*scale << "px;'></div>";
     }
     html << "</table>";
 
+    // Remove precision settings that were specified above
+    html.unsetf(std::ios_base::floatfield);
 }
 
 

--- a/src/Histogram.cpp
+++ b/src/Histogram.cpp
@@ -5,23 +5,23 @@
 
 using namespace shasta;
 
-shasta::IterativeHistogram::IterativeHistogram(
+shasta::Histogram2::Histogram2(
         double start,
         double stop,
-        size_t nBins,
+        size_t binCount,
         bool unboundedLeft,
         bool unboundedRight):
-    start(start),
-    stop(stop),
-    nBins(nBins),
-    binSize((stop-start)/double(nBins)),
-    histogram(nBins,0),
-    unboundedLeft(unboundedLeft),
-    unboundedRight(unboundedRight)
+        start(start),
+        stop(stop),
+        binCount(binCount),
+        binSize((stop-start)/double(binCount)),
+        histogram(binCount, 0),
+        unboundedLeft(unboundedLeft),
+        unboundedRight(unboundedRight)
 {}
 
 
-int64_t shasta::IterativeHistogram::findIndex(double x){
+int64_t shasta::Histogram2::findIndex(double x){
     /// Find index of bin by normalizing the value w.r.t. bin edges.
     /// If the value does not fit in the range of the histogram, this function returns -1
     /// If the user wants to accumulate values outside the bounds defined, then any value out of bounds will result in
@@ -39,7 +39,7 @@ int64_t shasta::IterativeHistogram::findIndex(double x){
 
     if (x >= stop) {
         if (unboundedRight) {
-            index = int64_t(nBins) - 1;
+            index = int64_t(binCount) - 1;
         }
         else{
             index = -1;
@@ -50,7 +50,7 @@ int64_t shasta::IterativeHistogram::findIndex(double x){
 }
 
 
-void shasta::IterativeHistogram::update(double x) {
+void shasta::Histogram2::update(double x) {
     auto index = findIndex(x);
 
     if (index >= 0) {
@@ -63,7 +63,7 @@ void shasta::IterativeHistogram::update(double x) {
 }
 
 
-void shasta::IterativeHistogram::getNormalizedHistogram(vector<double>& normalizedHistogram){
+void shasta::Histogram2::getNormalizedHistogram(vector<double>& normalizedHistogram){
     uint64_t sum = 0;
     for (auto& e: histogram){
         sum += e;
@@ -75,7 +75,7 @@ void shasta::IterativeHistogram::getNormalizedHistogram(vector<double>& normaliz
 }
 
 
-void shasta::IterativeHistogram::writeToHtml(ostream& html, uint64_t sizePx){
+void shasta::Histogram2::writeToHtml(ostream& html, uint64_t sizePx){
     uint64_t yMax = 0;
     for (auto& e: histogram){
         if (e > yMax){
@@ -126,9 +126,9 @@ void shasta::IterativeHistogram::writeToHtml(ostream& html, uint64_t sizePx){
 void shasta::testIterativeHistogram(){
     /// Test the iterative histogram
 
-    std::cout << "\nTESTING IterativeHistogram case 1\n";
+    std::cout << "\nTESTING Histogram2 case 1\n";
 
-    IterativeHistogram h0(0, 10, 10);
+    Histogram2 h0(0, 10, 10);
     h0.update(0);        // 1
     h0.update(-1);       // None
     h0.update(10);       // None
@@ -146,9 +146,9 @@ void shasta::testIterativeHistogram(){
     }
     std::cout << '\n';
 
-    std::cout << "\nTESTING IterativeHistogram case 2\n";
+    std::cout << "\nTESTING Histogram2 case 2\n";
 
-    IterativeHistogram h1(0, 1.0, 10);
+    Histogram2 h1(0, 1.0, 10);
     h1.update(0);         // 1
     h1.update(-0.1);      // None
     h1.update(1.0);       // None
@@ -166,9 +166,9 @@ void shasta::testIterativeHistogram(){
     }
     std::cout << '\n';
 
-    std::cout << "\nTESTING IterativeHistogram case 3\n";
+    std::cout << "\nTESTING Histogram2 case 3\n";
 
-    IterativeHistogram h2(1, 2.0, 10);
+    Histogram2 h2(1, 2.0, 10);
     h2.update(1 + 0);         // 1
     h2.update(1 + -0.1);      // None
     h2.update(1 + 1.0);       // None
@@ -186,9 +186,9 @@ void shasta::testIterativeHistogram(){
     }
     std::cout << '\n';
 
-    std::cout << "\nTESTING IterativeHistogram case 4\n";
+    std::cout << "\nTESTING Histogram2 case 4\n";
 
-    IterativeHistogram h3(-0.5, 0.5, 10);
+    Histogram2 h3(-0.5, 0.5, 10);
     h3.update(-0.5 + 0);         // 1
     h3.update(-0.5 + -0.1);      // None
     h3.update(-0.5 + 1.0);       // None right edge
@@ -217,9 +217,9 @@ void shasta::testIterativeHistogram(){
     std::cout << '\n';
     std::cout << sum3 << '\n';
 
-    std::cout << "\nTESTING IterativeHistogram case 5\n";
+    std::cout << "\nTESTING Histogram2 case 5\n";
 
-    IterativeHistogram h4(0, 1.0, 10, true, true);
+    Histogram2 h4(0, 1.0, 10, true, true);
     h4.update(0);         // 1
     h4.update(-0.1);      // 1
     h4.update(1.0);       // 10

--- a/src/Histogram.cpp
+++ b/src/Histogram.cpp
@@ -1,5 +1,6 @@
 #include "Histogram.hpp"
 #include <iostream>
+#include <iomanip>
 #include <cmath>
 
 using namespace shasta;
@@ -84,19 +85,18 @@ void shasta::IterativeHistogram::writeToHtml(ostream& html, uint64_t sizePx){
 
     double scale = double(sizePx)/double(max);
 
-    html << "<table style='margin-top: 2em; margin-bottom: 2em'>";
+    html << "<table style='margin-top: 1em; margin-bottom: 1em'>";
 
     for (size_t i=0; i<histogram.size(); i++){
         html <<
              "<tr>"
-             "<td class=centered>" << std::fixed << double(i)*(binSize) <<
+             "<td class=centered>" << std::fixed << std::setprecision(2) << double(i)*(binSize) <<
              "<td class=centered>" << histogram[i] <<
              "<td>"
              "<div class=sketch title='alignedFractionHistogram' style='display:inline-block;margin:0px;padding:0px;"
              "background-color:blue;height:6px;width:" << double(histogram[i])*scale << "px;'></div>";
     }
     html << "</table>";
-    html << "<table style='margin-top: 2em; margin-bottom: 2em'>";
 
 }
 

--- a/src/Histogram.hpp
+++ b/src/Histogram.hpp
@@ -9,7 +9,7 @@
 
 namespace shasta {
     class Histogram;
-    class IterativeHistogram;
+    class Histogram2;
     void testIterativeHistogram();
 }
 
@@ -49,22 +49,22 @@ public:
 
 
 // A histogram class that calculates bin size and finds the appropriate bin to increment given an x value
-class shasta::IterativeHistogram{
+class shasta::Histogram2{
 public:
     /// Attributes ///
     const double start;
     const double stop;
-    const size_t nBins;
+    const size_t binCount;
     const double binSize;
     vector<uint64_t> histogram;
     bool unboundedLeft;
     bool unboundedRight;
 
     /// Methods ///
-    IterativeHistogram(
+    Histogram2(
             double start,
             double stop,
-            size_t nBins,
+            size_t binCount,
             bool unboundedLeft=false,
             bool unboundedRight=false);
 

--- a/src/Histogram.hpp
+++ b/src/Histogram.hpp
@@ -2,13 +2,18 @@
 #define SHASTA_HISTOGRAM_HPP
 
 #include "algorithm.hpp"
-#include <numeric>
 #include "vector.hpp"
+#include <numeric>
+#include <cstdint>
+#include <fstream>
 
 namespace shasta {
     class Histogram;
+    class IterativeHistogram;
+    void testIterativeHistogram();
 }
 
+using std::ostream;
 
 
 // A simple histogram class that stores the histogram in a vector.
@@ -40,6 +45,36 @@ public:
     {
         return *std::max_element(begin(), end());
     }
+};
+
+
+// A histogram class that calculates bin size and finds the appropriate bin to increment given an x value
+class shasta::IterativeHistogram{
+public:
+    /// Attributes ///
+    const double start;
+    const double stop;
+    const size_t nBins;
+    const double binSize;
+    vector<uint64_t> histogram;
+    bool unboundedLeft;
+    bool unboundedRight;
+
+    /// Methods ///
+    IterativeHistogram(
+            double start,
+            double stop,
+            size_t nBins,
+            bool unboundedLeft=false,
+            bool unboundedRight=false);
+
+    void update(double x);
+    void getNormalizedHistogram(vector<double>& normalizedHistogram);
+    void writeToHtml(ostream& html, uint64_t sizePx);
+
+private:
+    /// Methods ///
+    int64_t findIndex(double x);
 };
 
 


### PR DESCRIPTION
This is the first draft of a new page in the assembly browser which allows automated sampling of reads for aligning one-to-all. Bulk sampling enables stats on `alignedFraction` and `alignedMarkerCount` to be collected efficiently. In addition, the ratio of stored:found alignments is computed.

In the future I would like to add sampling from dead ends as an option, and include more data about alignments overhangs found in stored vs computed alignments. This is also a first pass at deciding whether alignments thresholds can be automatically determined at run time.

Its not clear to me where the merge conflict is coming from. I can work that out if needed.

Some example screenshots below:

![image](https://user-images.githubusercontent.com/28764332/88232310-7f05ca00-cc2a-11ea-82d9-aeb09fba5a28.png)
![image](https://user-images.githubusercontent.com/28764332/88232336-8927c880-cc2a-11ea-98b7-2d5a72f60868.png)
![image](https://user-images.githubusercontent.com/28764332/88232355-90e76d00-cc2a-11ea-9033-df48d2d1e620.png)
