### PR TITLE
[Refactor] Reads class

### DIFF
--- a/scripts/InitializeReadFlags.py
+++ b/scripts/InitializeReadFlags.py
@@ -1,8 +1,0 @@
-#!/usr/bin/python3
-
-import shasta
-
-a = shasta.Assembler()
-a.initializeReadFlags()
-
-

--- a/scripts/WriteOrientedRead.py
+++ b/scripts/WriteOrientedRead.py
@@ -22,5 +22,5 @@ if not (strand==0 or strand==1):
 fileName = str(readId) + '-' + str(strand) + '.fasta'
 
 a = shasta.Assembler()
-a.writeOrientedRead(readId=readId, strand=strand, fileName=fileName)
+a.getReads().writeOrientedRead(readId=readId, strand=strand, fileName=fileName)
 

--- a/scripts/WriteRead.py
+++ b/scripts/WriteRead.py
@@ -15,5 +15,5 @@ readId = int(sys.argv[1])
 fileName = str(readId) + '.fasta'
 
 a = shasta.Assembler()
-a.writeRead(readId=readId, fileName=fileName)
+a.getReads().writeRead(readId=readId, fileName=fileName)
 

--- a/scripts/WriteReads.py
+++ b/scripts/WriteReads.py
@@ -7,5 +7,5 @@ import sys
 
 
 a = shasta.Assembler()
-a.writeReads(fileName='Reads.fasta')
+a.getReads().writeReads(fileName='Reads.fasta')
 

--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -24,10 +24,11 @@ Assembler::Assembler(
         assemblerInfo->largeDataPageSize = largeDataPageSizeArgument;
         largeDataPageSize = largeDataPageSizeArgument;
 
-        reads.createNew(largeDataName("Reads"), largeDataPageSize);
-        readNames.createNew(largeDataName("ReadNames"), largeDataPageSize);
-        readMetaData.createNew(largeDataName("ReadMetaData"), largeDataPageSize);
-        readRepeatCounts.createNew(largeDataName("ReadRepeatCounts"), largeDataPageSize);
+        reads.reads.createNew(largeDataName("Reads"), largeDataPageSize);
+        reads.readNames.createNew(largeDataName("ReadNames"), largeDataPageSize);
+        reads.readMetaData.createNew(largeDataName("ReadMetaData"), largeDataPageSize);
+        reads.readRepeatCounts.createNew(largeDataName("ReadRepeatCounts"), largeDataPageSize);
+        reads.readFlags.createNew(largeDataName("ReadFlags"), largeDataPageSize);
         // cout << "Created a new assembly with page size " << largeDataPageSize << endl;
 
     } else {
@@ -36,10 +37,11 @@ Assembler::Assembler(
         assemblerInfo.accessExistingReadWrite(largeDataName("Info"));
         largeDataPageSize = assemblerInfo->largeDataPageSize;
 
-        reads.accessExistingReadWrite(largeDataName("Reads"));
-        readNames.accessExistingReadWrite(largeDataName("ReadNames"));
-        readMetaData.accessExistingReadWrite(largeDataName("ReadMetaData"));
-        readRepeatCounts.accessExistingReadWrite(largeDataName("ReadRepeatCounts"));
+        reads.reads.accessExistingReadWrite(largeDataName("Reads"));
+        reads.readNames.accessExistingReadWrite(largeDataName("ReadNames"));
+        reads.readMetaData.accessExistingReadWrite(largeDataName("ReadMetaData"));
+        reads.readRepeatCounts.accessExistingReadWrite(largeDataName("ReadRepeatCounts"));
+        reads.readFlags.accessExistingReadWrite(largeDataName("ReadFlags"));
         // cout << "Accessed an existing assembly with page size " << largeDataPageSize << endl;
 
     }

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -38,8 +38,8 @@ void Assembler::alignOrientedReads(
     uint32_t maxMarkerFrequency
 )
 {
-    checkReadsAreOpen();
-    checkReadNamesAreOpen();
+    reads.checkReadsAreOpen();
+    reads.checkReadNamesAreOpen();
     checkMarkersAreOpen();
 
 
@@ -62,9 +62,9 @@ void Assembler::alignOrientedReads(
     uint32_t leftTrim;
     uint32_t rightTrim;
     tie(leftTrim, rightTrim) = alignmentInfo.computeTrim();
-    cout << orientedReadId0 << " has " << reads[orientedReadId0.getReadId()].baseCount;
+    cout << orientedReadId0 << " has " << reads.getRead(orientedReadId0.getReadId()).baseCount;
     cout << " bases and " << markersSortedByKmerId[0].size() << " markers." << endl;
-    cout << orientedReadId1 << " has " << reads[orientedReadId1.getReadId()].baseCount;
+    cout << orientedReadId1 << " has " << reads.getRead(orientedReadId1.getReadId()).baseCount;
     cout << " bases and " << markersSortedByKmerId[1].size() << " markers." << endl;
     cout << "The alignment has " << alignmentInfo.markerCount;
     cout << " markers. Left trim " << leftTrim;
@@ -146,7 +146,7 @@ void Assembler::alignOverlappingOrientedReads(
 )
 {
     // Check that we have what we need.
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkMarkersAreOpen();
     checkAlignmentCandidatesAreOpen();
 
@@ -253,7 +253,7 @@ void Assembler::computeAlignments(
     cout << alignmentCandidates.candidates.size() << " alignment candidates." << endl;
 
     // Check that we have what we need.
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkKmersAreOpen();
     checkMarkersAreOpen();
     checkAlignmentCandidatesAreOpen();
@@ -524,7 +524,7 @@ void Assembler::accessCompressedAlignments()
 void Assembler::computeAlignmentTable()
 {
     alignmentTable.createNew(largeDataName("AlignmentTable"), largeDataPageSize);
-    alignmentTable.beginPass1(ReadId(2 * reads.size()));
+    alignmentTable.beginPass1(ReadId(2 * reads.readCount()));
     for(const AlignmentData& ad: alignmentData) {
         const auto& readIds = ad.readIds;
         OrientedReadId orientedReadId0(readIds[0], 0);
@@ -555,7 +555,7 @@ void Assembler::computeAlignmentTable()
 
     // Sort each section of the alignment table by OrientedReadId.
     vector< pair<OrientedReadId, uint32_t> > v;
-    for(ReadId readId0=0; readId0<reads.size(); readId0++) {
+    for(ReadId readId0=0; readId0<reads.readCount(); readId0++) {
         for(Strand strand0=0; strand0<2; strand0++) {
             const OrientedReadId orientedReadId0(readId0, strand0);
 
@@ -676,9 +676,10 @@ void Assembler::flagPalindromicReads(
     flagPalindromicReadsData.deltaThreshold = deltaThreshold;
 
     // Reset all palindromic flags.
-    const ReadId readCount = ReadId(readFlags.size());
+    reads.assertReadsAndFlagsOfSameSize();
+    const ReadId readCount = reads.readCount();
     for(ReadId readId=0; readId<readCount; readId++) {
-        readFlags[readId].isPalindromic = 0;
+        reads.setPalindromicFlag(readId, false);
     }
 
     // Do it in parallel.
@@ -688,7 +689,7 @@ void Assembler::flagPalindromicReads(
     // Count the reads flagged as palindromic.
     size_t palindromicReadCount = 0;
     for(ReadId readId=0; readId<readCount; readId++) {
-        if(readFlags[readId].isPalindromic) {
+        if(reads.getFlags(readId).isPalindromic) {
             ++palindromicReadCount;
         }
     }
@@ -704,7 +705,7 @@ void Assembler::flagPalindromicReads(
     // palindromic reads is around 1e-4.
     ofstream csvOut("PalindromicReads.csv");
     for(ReadId readId=0; readId<readCount; readId++) {
-        if(readFlags[readId].isPalindromic) {
+        if(reads.getFlags(readId).isPalindromic) {
             csvOut << readId << "\n";
         }
     }
@@ -733,10 +734,13 @@ void Assembler::flagPalindromicReadsThreadFunction(size_t threadId)
 
     // Loop over all batches assigned to this thread.
     uint64_t begin, end;
+    reads.assertReadsAndFlagsOfSameSize();
+    ReadId readCount = reads.readCount();
+
     while(getNextBatch(begin, end)) {
         if((begin%1000000) == 0) {
             std::lock_guard<std::mutex> lock(mutex);
-            cout << timestamp << begin << "/" << readFlags.size() << endl;
+            cout << timestamp << begin << "/" << readCount << endl;
         }
 
         // Loop over all reads in this batch.
@@ -776,7 +780,7 @@ void Assembler::flagPalindromicReadsThreadFunction(size_t threadId)
             }
 
             // If we got here, mark the read as palindromic.
-            readFlags[readId].isPalindromic = 1;
+            reads.setPalindromicFlag(readId, true);
 
         }
     }
@@ -1035,11 +1039,11 @@ bool Assembler::suppressAlignment(
     // don't suppress the alignment.
     // Check the channel first for efficiency,
     // so we can return faster in most cases.
-    const auto ch0 = getMetaData(readId0, "ch");
+    const auto ch0 = reads.getMetaData(readId0, "ch");
     if(ch0.empty()) {
         return false;
     }
-    const auto ch1 = getMetaData(readId1, "ch");
+    const auto ch1 = reads.getMetaData(readId1, "ch");
     if(ch1.empty()) {
         return false;
     }
@@ -1051,11 +1055,11 @@ bool Assembler::suppressAlignment(
 
     // If the sampleid meta data fields of the two reads are missing or different,
     // don't suppress the alignment.
-    const auto sampleid0 = getMetaData(readId0, "sampleid");
+    const auto sampleid0 = reads.getMetaData(readId0, "sampleid");
     if(sampleid0.empty()) {
         return false;
     }
-    const auto sampleid1 = getMetaData(readId1, "sampleid");
+    const auto sampleid1 = reads.getMetaData(readId1, "sampleid");
     if(sampleid1.empty()) {
         return false;
     }
@@ -1067,11 +1071,11 @@ bool Assembler::suppressAlignment(
 
     // If the runid meta data fields of the two reads are missing or different,
     // don't suppress the alignment.
-    const auto runid0 = getMetaData(readId0, "runid");
+    const auto runid0 = reads.getMetaData(readId0, "runid");
     if(runid0.empty()) {
         return false;
     }
-    const auto runid1 = getMetaData(readId1, "runid");
+    const auto runid1 = reads.getMetaData(readId1, "runid");
     if(runid1.empty()) {
         return false;
     }
@@ -1084,11 +1088,11 @@ bool Assembler::suppressAlignment(
 
     // If the read meta data fields of the two reads are missing,
     // don't suppress the alignment.
-    const auto read0 = getMetaData(readId0, "read");
+    const auto read0 = reads.getMetaData(readId0, "read");
     if(read0.empty()) {
         return false;
     }
-    const auto read1 = getMetaData(readId1, "read");
+    const auto read1 = reads.getMetaData(readId1, "read");
     if(read1.empty()) {
         return false;
     }
@@ -1148,8 +1152,8 @@ void Assembler::suppressAlignmentCandidates(
             const ReadId readId1 = alignmentCandidates.candidates[i].readIds[1];
             csv << readId0 << "," << readId1 << ","
                 << (alignmentCandidates.candidates[i].isSameStrand ? "Yes" : "No") << ","
-                << readNames[readId0] << "," << readNames[readId1] << ","
-                << readMetaData[readId0] << "," << readMetaData[readId1] << endl;
+                << reads.getReadName(readId0) << "," << reads.getReadName(readId1) << ","
+                << reads.getReadMetaData(readId0) << "," << reads.getReadMetaData(readId1) << endl;
         } else {
             alignmentCandidates.candidates[j++] =
                 alignmentCandidates.candidates[i];

--- a/src/AssemblerAlignmentGraph.cpp
+++ b/src/AssemblerAlignmentGraph.cpp
@@ -31,7 +31,7 @@ bool Assembler::createLocalAlignmentGraph(
 
     // Add the starting vertex.
     graph.addVertex(orientedReadIdStart,
-        uint32_t(reads[orientedReadIdStart.getReadId()].baseCount), 0);
+        uint32_t(reads.getRead(orientedReadIdStart.getReadId()).baseCount), 0);
 
     // Initialize a BFS starting at the start vertex.
     std::queue<OrientedReadId> q;
@@ -87,7 +87,7 @@ bool Assembler::createLocalAlignmentGraph(
             if(distance0 < maxDistance) {
                 if(!graph.vertexExists(orientedReadId1)) {
                     graph.addVertex(orientedReadId1,
-                        uint32_t(reads[orientedReadId1.getReadId()].baseCount), distance1);
+                        uint32_t(reads.getRead(orientedReadId1.getReadId()).baseCount), distance1);
                     q.push(orientedReadId1);
                 }
                 graph.addEdge(orientedReadId0, orientedReadId1,
@@ -109,7 +109,7 @@ bool Assembler::createLocalAlignmentGraph(
             // we already reached the maximum distance.
             if(!graph.vertexExists(orientedReadId1)) {
                 graph.addVertex(orientedReadId1,
-                    uint32_t(reads[orientedReadId1.getReadId()].baseCount), distance1);
+                    uint32_t(reads.getRead(orientedReadId1.getReadId()).baseCount), distance1);
                 if(distance1 < maxDistance) {
                     q.push(orientedReadId1);
                     // cout << "Enqueued " << orientedReadId1 << endl;

--- a/src/AssemblerAnalyzePaths.cpp
+++ b/src/AssemblerAnalyzePaths.cpp
@@ -302,8 +302,8 @@ void Assembler::analyzeOrientedReadPaths() const
     // This vector is indexed by OrientedReadId::getValue().
     vector<MarkerGraph::EdgeId> path;
     vector< pair<uint32_t, uint32_t> > pathOrdinals;
-    vector<PseudoPath> pseudoPaths(2*readCount());
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    vector<PseudoPath> pseudoPaths(2*reads.readCount());
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             computePseudoPath(orientedReadId, path, pathOrdinals,
@@ -316,7 +316,7 @@ void Assembler::analyzeOrientedReadPaths() const
     // Write a csv file with the pseudo-path of each oriented read.
     {
         ofstream csv("PseudoPaths.csv");
-        for(ReadId readId=0; readId<readCount(); readId++) {
+        for(ReadId readId=0; readId<reads.readCount(); readId++) {
             for(Strand strand=0; strand<2; strand++) {
                 const OrientedReadId orientedReadId(readId, strand);
                 csv << orientedReadId << ",";
@@ -337,7 +337,7 @@ void Assembler::analyzeOrientedReadPaths() const
     // For each segmentId, we store a vector of pairs (orientedReadId, ordinal) such that
     // pseudoPaths[orientedReadId.getValue()][ordinal] == segmentId
     vector< vector< pair<OrientedReadId, uint64_t> > >  pseudoPathTable(segmentCount);
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             const PseudoPath& pseudoPath = pseudoPaths[orientedReadId.getValue()];
@@ -499,7 +499,7 @@ void Assembler::analyzeOrientedReadPaths() const
     // The alignment table contains, for each oriented reads,
     // pairs (index in orientedReadPairs, score).
     // it is indexed by OrientedReadId::getValue(0.
-    vector< vector< pair<uint64_t, int64_t> > > alignmentTable(2 * readCount());
+    vector< vector< pair<uint64_t, int64_t> > > alignmentTable(2 * reads.readCount());
     for(uint64_t i=0; i<orientedReadPairs.size(); i++) {
 
         // Skip this pair if we already decided not to use it.
@@ -560,9 +560,9 @@ void Assembler::analyzeOrientedReadPaths() const
 
     // Vector to contain, for each oriented read, the starting point of
     // its pseudo-path in the disjoint set data structure.
-    vector<uint64_t> start(2*readCount(), std::numeric_limits<uint64_t>::max());
+    vector<uint64_t> start(2*reads.readCount(), std::numeric_limits<uint64_t>::max());
     uint64_t n = 0;
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             const PseudoPath& pseudoPath = pseudoPaths[orientedReadId.getValue()];
@@ -631,9 +631,9 @@ void Assembler::analyzeOrientedReadPaths() const
 
     // Each of the disjoint data sets becomes a vertex of the MetaMarkerGraph.
     // Store the disjoint set for each position of the pseudo-path of each oriented read.
-    vector< vector<uint64_t> > vertexTable(2*readCount());
+    vector< vector<uint64_t> > vertexTable(2*reads.readCount());
     vector< vector< pair<OrientedReadId, uint64_t > > > vertices(n);
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             const PseudoPath& pseudoPath = pseudoPaths[orientedReadId.getValue()];

--- a/src/AssemblerAssemblyGraph.cpp
+++ b/src/AssemblerAssemblyGraph.cpp
@@ -570,7 +570,7 @@ void Assembler::assemble(
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
     checkMarkerGraphEdgesIsOpen();

--- a/src/AssemblerConflictReadGraph.cpp
+++ b/src/AssemblerConflictReadGraph.cpp
@@ -46,7 +46,7 @@ void Assembler::createConflictReadGraph(
 
     // Initialize the conflict read graph.
     conflictReadGraph.createNew(largeDataName("ConflictReadGraph"), largeDataPageSize);
-    conflictReadGraph.createVertices(readCount());
+    conflictReadGraph.createVertices(reads.readCount());
 
 #if 0
     // Compute leftTrim, rightTrim, longestGap for each vertex.
@@ -67,8 +67,8 @@ void Assembler::createConflictReadGraph(
     }
 
     // Add edges.
-    conflictReadGraph.edges.reserve(10 * readCount());
-    setupLoadBalancing(readCount(), 1);
+    conflictReadGraph.edges.reserve(10 * reads.readCount());
+    setupLoadBalancing(reads.readCount(), 1);
     runThreads(&Assembler::createConflictReadGraphThreadFunction2, threadCount);
     conflictReadGraph.edges.unreserve();
     conflictReadGraph.computeConnectivity();

--- a/src/AssemblerDirectedReadGraph.cpp
+++ b/src/AssemblerDirectedReadGraph.cpp
@@ -9,11 +9,11 @@ void Assembler::createDirectedReadGraph(
 {
     // Initialize the directed read graph.
     directedReadGraph.createNew(largeDataName("DirectedReadGraph"), largeDataPageSize);
-    directedReadGraph.createVertices(readCount());
+    directedReadGraph.createVertices(reads.readCount());
 
     // Store the number of bases in each oriented read.
-    for(ReadId readId=0; readId<readCount(); readId++) {
-        const uint32_t baseCount = uint32_t(getReadRawSequenceLength(readId));
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+        const uint32_t baseCount = uint32_t(reads.getReadRawSequenceLength(readId));
         const uint32_t markerCount = uint32_t(markers.size(OrientedReadId(readId, 0).getValue()));
         DirectedReadGraphVertex& vertex0 = directedReadGraph.getVertex(OrientedReadId(readId, 0).getValue());
         DirectedReadGraphVertex& vertex1 = directedReadGraph.getVertex(OrientedReadId(readId, 1).getValue());
@@ -40,14 +40,14 @@ void Assembler::createDirectedReadGraph(
     // Count the number of isolated reads and their bases.
     uint64_t isolatedReadCount = 0;
     uint64_t isolatedReadBaseCount = 0;
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         const OrientedReadId orientedReadId(readId, 0);
         const DirectedReadGraph::VertexId vertexId = orientedReadId.getValue();
         if(directedReadGraph.totalDegree(vertexId) > 0) {
             continue;
         }
         ++isolatedReadCount;
-        isolatedReadBaseCount += getReadRawSequenceLength(readId);
+        isolatedReadBaseCount += reads.getReadRawSequenceLength(readId);
     }
     assemblerInfo->isolatedReadCount = isolatedReadCount;
     assemblerInfo->isolatedReadBaseCount = isolatedReadBaseCount;

--- a/src/AssemblerHttpServer-DirectedReadGraph.cpp
+++ b/src/AssemblerHttpServer-DirectedReadGraph.cpp
@@ -106,7 +106,7 @@ void Assembler::exploreDirectedReadGraph(
         "<div style='float:left;margin:10px;'>"
         "<table>"
 
-        "<tr title='Read id between 0 and " << reads.size()-1 << "'>"
+        "<tr title='Read id between 0 and " << reads.readCount()-1 << "'>"
         "<td>Start vertex read id"
         "<td><input type=text required name=readId size=8 style='text-align:center'"
         << (readIdIsPresent ? ("value='"+to_string(readId)+"'") : "") <<
@@ -267,9 +267,9 @@ void Assembler::exploreDirectedReadGraph(
     }
 
     // Validity checks.
-    if(readId > reads.size()) {
+    if(readId > reads.readCount()) {
         html << "<p>Invalid read id " << readId;
-        html << ". Must be between 0 and " << reads.size()-1 << ".";
+        html << ". Must be between 0 and " << reads.readCount()-1 << ".";
         return;
     }
 
@@ -387,8 +387,8 @@ void Assembler::exploreDirectedReadGraph(
             if(MurmurHash2(&orientedReadId, sizeof(orientedReadId), 117) > hashThreshold) {
                 continue;
             }
-            const vector<Base> sequence = getOrientedReadRawSequence(vertex.orientedReadId);
-            const auto readName = readNames[vertex.orientedReadId.getReadId()];
+            const vector<Base> sequence = reads.getOrientedReadRawSequence(vertex.orientedReadId);
+            const auto readName = reads.getReadName(vertex.orientedReadId.getReadId());
             fastaFile << ">" << vertex.orientedReadId << " ";
             copy(readName.begin(), readName.end(), ostream_iterator<char>(fastaFile));
             fastaFile << "\n";

--- a/src/AssemblerHttpServer-MarkerGraph.cpp
+++ b/src/AssemblerHttpServer-MarkerGraph.cpp
@@ -61,8 +61,8 @@ void Assembler::exploreMarkerGraph(
     // Create the local marker graph.
     LocalMarkerGraph graph(
         uint32_t(assemblerInfo->k),
-        reads,
-        readRepeatCounts,
+        reads.reads,
+        reads.readRepeatCounts,
         markers,
         markerGraph.vertexTable,
         *consensusCaller);
@@ -464,7 +464,7 @@ void Assembler::exploreMarkerGraphVertex(const vector<string>& request, ostream&
         for(size_t i=0; i<k; i++) {
             Base base;
             tie(base, repeatCounts[j][i]) =
-                getOrientedReadBaseAndRepeatCount(orientedReadIds[j], uint32_t(marker.position+i));
+                reads.getOrientedReadBaseAndRepeatCount(orientedReadIds[j], uint32_t(marker.position+i));
             SHASTA_ASSERT(base == kmer[i]);
         }
     }
@@ -803,7 +803,7 @@ void Assembler::exploreMarkerGraphEdge(const vector<string>& request, ostream& h
         for(uint32_t position=positionBegin; position!=positionEnd; ++position) {
             Base base;
             uint8_t repeatCount;
-            tie(base, repeatCount) = getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+            tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, position);
             sequences[j].push_back(base);
             repeatCounts[j].push_back(repeatCount);
         }
@@ -1167,13 +1167,13 @@ void Assembler::exploreMarkerGraphInducedAlignment(
         "<form>"
         "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
-        " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand0", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
     html <<
         "<br><input type=text name=readId1 required size=8 " <<
         (readId1IsPresent ? "value="+to_string(readId1) : "") <<
-        " title='Enter a read id between 0 and " << reads.size()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand1", strand1IsPresent && strand1==0, strand1IsPresent && strand1==1);
 
@@ -1286,7 +1286,7 @@ void Assembler::exploreMarkerCoverage(
         "<tr><td>Read id<td class=centered>"
         "<input type=text name=readId required style='text-align:center'" <<
         (readIdIsPresent ? (" value=" + to_string(readId)) : "") <<
-        " size=8 title='Enter a read id between 0 and " << reads.size()-1 << "'>"
+        " size=8 title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
         "<tr><td>Strand<td class=centered>";
     writeStrandSelection(html, "strand", strandIsPresent && strand==0, strandIsPresent && strand==1);
     html <<

--- a/src/AssemblerHttpServer-ReadGraph.cpp
+++ b/src/AssemblerHttpServer-ReadGraph.cpp
@@ -127,7 +127,7 @@ void Assembler::exploreUndirectedReadGraph(
          "<div style='float:left;margin:10px;'>"
          "<table>"
 
-         "<tr title='Read id between 0 and " << reads.size() - 1 << "'>"
+         "<tr title='Read id between 0 and " << reads.readCount() - 1 << "'>"
          "<td style=\"white-space:pre-wrap; word-wrap:break-word\">"
          "Start vertex reads\n"
          "The oriented read should be in the form <code>readId-strand</code>\n"
@@ -248,9 +248,9 @@ void Assembler::exploreUndirectedReadGraph(
 
     // Validity checks.
     for (auto &readId: readIds){
-        if (readId.getReadId() > reads.size()) {
+        if (readId.getReadId() > reads.readCount()) {
             html << "<p>Invalid read id " << readId;
-            html << ". Must be between 0 and " << reads.size() - 1 << ".";
+            html << ". Must be between 0 and " << reads.readCount() - 1 << ".";
             return;
         }
     }
@@ -281,8 +281,8 @@ void Assembler::exploreUndirectedReadGraph(
         ofstream fastaFile(fastaFileName);
         BGL_FORALL_VERTICES(v, graph, LocalReadGraph) {
             const LocalReadGraphVertex& vertex = graph[v];
-            const vector<Base> sequence = getOrientedReadRawSequence(vertex.orientedReadId);
-            const auto readName = readNames[vertex.orientedReadId.getReadId()];
+            const vector<Base> sequence = reads.getOrientedReadRawSequence(vertex.orientedReadId);
+            const auto readName = reads.getReadName(vertex.orientedReadId.getReadId());
             fastaFile << ">" << vertex.orientedReadId << " ";
             copy(readName.begin(), readName.end(), ostream_iterator<char>(fastaFile));
             fastaFile << "\n";

--- a/src/AssemblerHttpServer-Reads.cpp
+++ b/src/AssemblerHttpServer-Reads.cpp
@@ -39,7 +39,7 @@ void Assembler::exploreRead(
         "read &nbsp" <<
         "<input type=text name=readId required" <<
         (readIdIsPresent ? (" value=" + to_string(readId)) : "") <<
-        " size=8 title='Enter a read id between 0 and " << reads.size()-1 << "'>"
+        " size=8 title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand", strandIsPresent && strand==0, strandIsPresent && strand==1);
     
@@ -74,7 +74,7 @@ void Assembler::exploreRead(
     }
 
     // Access the read.
-    if(readId >= reads.size()) {
+    if(readId >= reads.readCount()) {
         html << "<p>Invalid read id.";
         return;
     }
@@ -83,10 +83,10 @@ void Assembler::exploreRead(
         return;
     }
     const OrientedReadId orientedReadId(readId, strand);
-    const vector<Base> rawOrientedReadSequence = getOrientedReadRawSequence(orientedReadId);
-    const auto readStoredSequence = reads[readId];
-    const auto readName = readNames[readId];
-    const auto metaData = readMetaData[readId];
+    const vector<Base> rawOrientedReadSequence = reads.getOrientedReadRawSequence(orientedReadId);
+    const auto readStoredSequence = reads.getRead(readId);
+    const auto readName = reads.getReadName(readId);
+    const auto metaData = reads.getReadMetaData(readId);
     const auto orientedReadMarkers = markers[orientedReadId.getValue()];
     if(!beginPositionIsPresent) {
         beginPosition = 0;
@@ -281,7 +281,7 @@ void Assembler::exploreRead(
             html << "<pre style='font-family:monospace;margin:0'";
             html << " title='Position in run-length read sequence'>";
 
-            const vector<uint32_t> rawPositions = getRawPositions(orientedReadId);
+            const vector<uint32_t> rawPositions = reads.getRawPositions(orientedReadId);
 
             // Scale.
             bool firstTime = true;
@@ -429,7 +429,7 @@ void Assembler::exploreRead(
     // element for each character).
     // Note that here we display the entire read, regardless of beginPosition and endPosition.
     size_t beginRlePosition, endRlePosition;
-    const vector<uint32_t> rawPositions = getRawPositions(orientedReadId);
+    const vector<uint32_t> rawPositions = reads.getRawPositions(orientedReadId);
     
     if (beginPositionIsPresent) {
         beginRlePosition = std::lower_bound(rawPositions.begin(), rawPositions.end(), beginPosition) - rawPositions.begin();
@@ -512,7 +512,7 @@ void Assembler::exploreRead(
     for(size_t position=beginRlePosition; position!=endRlePosition; position++) {
         Base base;
         uint8_t repeatCount;
-        tie(base, repeatCount) = getOrientedReadBaseAndRepeatCount(orientedReadId, uint32_t(position));
+        tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, uint32_t(position));
         
         html <<
             "<text class='mono'" <<
@@ -547,7 +547,7 @@ void Assembler::exploreRead(
             " y='" << readSequenceLine*verticalSpacing << "'"
             " textLength='" << (blockEnd-blockBegin) * horizontalSpacing<< "'>";
         for(size_t position=beginRlePosition+blockBegin; position<beginRlePosition+blockEnd; position++) {
-            html << getOrientedReadBase(orientedReadId, uint32_t(position));
+            html << reads.getOrientedReadBase(orientedReadId, uint32_t(position));
         }
         html << "</text>";
     }

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -431,14 +431,6 @@ void Assembler::accessAllSoft()
     bool allDataAreAvailable = true;
 
     try {
-        accessReadFlags(false);
-    } catch(const exception& e) {
-        cout << "Read flags are not accessible." << endl;
-        allDataAreAvailable = false;
-    }
-
-
-    try {
         accessKmers();
     } catch(const exception& e) {
         cout << "K-mers are not accessible." << endl;
@@ -627,9 +619,9 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Read N50 (for raw read sequence)"
         "<td class=right>" << assemblerInfo->readN50 <<
         "<tr><td>Number of run-length encoded bases"
-        "<td class=right>" << readRepeatCounts.totalSize() <<
+        "<td class=right>" << reads.readRepeatCounts.totalSize() <<
         "<tr><td>Average length ratio of run-length encoded sequence over raw sequence"
-        "<td class=right>" << setprecision(4) << double(readRepeatCounts.totalSize()) / double(assemblerInfo->baseCount) <<
+        "<td class=right>" << setprecision(4) << double(reads.readRepeatCounts.totalSize()) / double(assemblerInfo->baseCount) <<
         "<tr><td>Number of reads flagged as palindromic"
         "<td class=right>" << assemblerInfo->palindromicReadCount <<
         "<tr><td>Number of reads flagged as chimeric"
@@ -699,14 +691,14 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Average number of markers per raw base"
         "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(assemblerInfo->baseCount) <<
         "<tr><td>Average number of markers per run-length encoded base"
-        "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(readRepeatCounts.totalSize()) <<
+        "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(reads.readRepeatCounts.totalSize()) <<
         "<tr><td>Average base offset between markers in raw sequence"
         "<td class=right>" << setprecision(4) << double(assemblerInfo->baseCount)/double(markers.totalSize()/2) <<
         "<tr><td>Average base offset between markers in run-length encoded sequence"
-        "<td class=right>" << setprecision(4) << double(readRepeatCounts.totalSize())/double(markers.totalSize()/2) <<
+        "<td class=right>" << setprecision(4) << double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) <<
         "<tr><td>Average base gap between markers in run-length encoded sequence"
         "<td class=right>" << setprecision(4) <<
-        double(readRepeatCounts.totalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) <<
+        double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) <<
         "</table>"
         "<ul><li>Here and elsewhere, &quot;raw&quot; refers to the original read sequence, "
         "as opposed to run-length encoded sequence.</ul>"
@@ -875,9 +867,9 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Average read length (for raw read sequence)\": " <<
         assemblerInfo->baseCount / assemblerInfo->readCount << ",\n"
         "    \"Read N50 (for raw read sequence)\": " << assemblerInfo->readN50 << ",\n"
-        "    \"Number of run-length encoded bases\": " << readRepeatCounts.totalSize() << ",\n"
+        "    \"Number of run-length encoded bases\": " << reads.readRepeatCounts.totalSize() << ",\n"
         "    \"Average length ratio of run-length encoded sequence over raw sequence\": " <<
-        setprecision(4) << double(readRepeatCounts.totalSize()) / double(assemblerInfo->baseCount) << ",\n"
+        setprecision(4) << double(reads.readRepeatCounts.totalSize()) / double(assemblerInfo->baseCount) << ",\n"
         "    \"Number of reads flagged as palindromic\": " << assemblerInfo->palindromicReadCount << ",\n"
         "    \"Number of reads flagged as chimeric\": " << assemblerInfo->chimericReadCount << "\n"
         "  },\n"
@@ -941,14 +933,14 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Average number of markers per raw base\": "
         << setprecision(4) << double(markers.totalSize()/2)/double(assemblerInfo->baseCount) << ",\n"
         "    \"Average number of markers per run-length encoded base\": "
-        << setprecision(4) << double(markers.totalSize()/2)/double(readRepeatCounts.totalSize()) << ",\n"
+        << setprecision(4) << double(markers.totalSize()/2)/double(reads.readRepeatCounts.totalSize()) << ",\n"
         "    \"Average base offset between markers in raw sequence\": "
         << setprecision(4) << double(assemblerInfo->baseCount)/double(markers.totalSize()/2) << ",\n"
         "    \"Average base offset between markers in run-length encoded sequence\": "
-        << setprecision(4) << double(readRepeatCounts.totalSize())/double(markers.totalSize()/2) << ",\n"
+        << setprecision(4) << double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) << ",\n"
         "    \"Average base gap between markers in run-length encoded sequence\": "
         << setprecision(4) <<
-        double(readRepeatCounts.totalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) << "\n"
+        double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) << "\n"
         "  },\n"
 
 
@@ -1167,7 +1159,7 @@ void Assembler::blastRead(
 
 
     // Access the read.
-    if(readId >= reads.size()) {
+    if(readId >= reads.readCount()) {
         html << "<p>Invalid read id.";
         return;
     }
@@ -1176,7 +1168,7 @@ void Assembler::blastRead(
         return;
     }
     const OrientedReadId orientedReadId(readId, strand);
-    const vector<Base> rawOrientedReadSequence = getOrientedReadRawSequence(orientedReadId);
+    const vector<Base> rawOrientedReadSequence = reads.getOrientedReadRawSequence(orientedReadId);
     if(!endPositionIsPresent) {
         endPosition = uint32_t(rawOrientedReadSequence.size());
     }

--- a/src/AssemblerKmers.cpp
+++ b/src/AssemblerKmers.cpp
@@ -222,7 +222,7 @@ void Assembler::selectKmersBasedOnFrequency(
     initializeKmerTable();
 
     // Compute the frequency of all k-mers in oriented reads.
-    setupLoadBalancing(reads.size(), 1000);
+    setupLoadBalancing(reads.readCount(), 1000);
     runThreads(&Assembler::computeKmerFrequency, threadCount);
 
     // Compute the total number of k-mer occurrences
@@ -378,7 +378,7 @@ void Assembler::computeKmerFrequency(size_t threadId)
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
 
             // Access the sequence of this read.
-            const LongBaseSequenceView read = reads[readId];
+            const LongBaseSequenceView read = reads.getRead(readId);
 
             // If the read is pathologically short, it has no k-mers.
             if(read.baseCount < k) {
@@ -575,7 +575,7 @@ void Assembler::selectKmers2(
     fill(
         selectKmers2Data.overenrichedReadCount.begin(),
         selectKmers2Data.overenrichedReadCount.end(), 0);
-    setupLoadBalancing(reads.size(), 100);
+    setupLoadBalancing(reads.readCount(), 100);
     runThreads(&Assembler::selectKmers2ThreadFunction, threadCount);
 
 
@@ -746,7 +746,7 @@ void Assembler::selectKmers2ThreadFunction(size_t threadId)
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
 
             // Access the sequence of this read.
-            const LongBaseSequenceView read = reads[readId];
+            const LongBaseSequenceView read = reads.getRead(readId);
 
             // If the read is pathologically short, it has no k-mers.
             if(read.baseCount < k) {

--- a/src/AssemblerLowHash.cpp
+++ b/src/AssemblerLowHash.cpp
@@ -44,7 +44,7 @@ void Assembler::findAlignmentCandidatesLowHash0(
         minFrequency,
         threadCount,
         kmerTable,
-        readFlags,
+        reads,
         markers,
         alignmentCandidates.candidates,
         readLowHashStatistics,
@@ -95,7 +95,7 @@ void Assembler::writeOverlappingReads(
     const string& fileName)
 {
     // Check that we have what we need.
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkAlignmentCandidatesAreOpen();
 
 
@@ -103,9 +103,9 @@ void Assembler::writeOverlappingReads(
     // Open the output file and write the oriented read we were given.
     ofstream file(fileName);
     const OrientedReadId orientedReadId0(readId0, strand0);
-    writeOrientedRead(orientedReadId0, file);
+    reads.writeOrientedRead(orientedReadId0, file);
 
-    const uint64_t length0 = reads[orientedReadId0.getReadId()].baseCount;
+    const uint64_t length0 = reads.getRead(orientedReadId0.getReadId()).baseCount;
     cout << "Reads overlapping " << orientedReadId0 << " length " << length0 << endl;
 
     // Loop over all overlaps involving this oriented read.
@@ -116,9 +116,9 @@ void Assembler::writeOverlappingReads(
         const OrientedReadId orientedReadId1 = ad.getOther(orientedReadId0);
 
         // Write it out.
-        const uint64_t length1 = reads[orientedReadId1.getReadId()].baseCount;
+        const uint64_t length1 = reads.getRead(orientedReadId1.getReadId()).baseCount;
         cout << orientedReadId1 << " length " << length1 << endl;
-        writeOrientedRead(orientedReadId1, file);
+        reads.writeOrientedRead(orientedReadId1, file);
     }
     cout << "Found " << alignmentTable[orientedReadId0.getValue()].size();
     cout << " overlapping oriented reads." << endl;
@@ -162,7 +162,7 @@ void Assembler::findAlignmentCandidatesLowHash1(
         minFrequency,
         threadCount,
         kmerTable,
-        readFlags,
+        reads,
         markers,
         alignmentCandidates,
         largeDataFileNamePrefix,
@@ -256,7 +256,7 @@ void Assembler::markAlignmentCandidatesAllPairs()
     alignmentCandidates.candidates.createNew(largeDataName("AlignmentCandidates"), largeDataPageSize);
 
     // Add all pairs on both orientations.
-    const ReadId n = readCount();
+    const ReadId n = reads.readCount();
     for(ReadId r0=0; r0<n-1; r0++) {
         for(ReadId r1=r0+1; r1<n; r1++) {
             alignmentCandidates.candidates.push_back(OrientedReadPair(r0, r1, true));

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -88,8 +88,8 @@ void Assembler::createMarkerGraphVertices(
     cout << timestamp << "Begin computing marker graph vertices." << endl;
 
     // Check that we have what we need.
-    checkReadsAreOpen();
-    SHASTA_ASSERT(readFlags.isOpen);
+    reads.checkReadsAreOpen();
+    reads.checkReadFlagsAreOpen();
     checkKmersAreOpen();
     checkMarkersAreOpen();
     checkAlignmentDataAreOpen();
@@ -554,8 +554,8 @@ void Assembler::createMarkerGraphVerticesThreadFunction1(size_t threadId)
                 SHASTA_ASSERT(orientedReadIds[0] < orientedReadIds[1]);
 
                 // If either of the reads is flagged chimeric, skip it.
-                if( readFlags[orientedReadIds[0].getReadId()].isChimeric ||
-                    readFlags[orientedReadIds[1].getReadId()].isChimeric) {
+                if( reads.getFlags(orientedReadIds[0].getReadId()).isChimeric ||
+                    reads.getFlags(orientedReadIds[1].getReadId()).isChimeric) {
                     continue;
                 }
             } else if(readGraphCreationMethod == 1) {
@@ -1657,7 +1657,7 @@ vector<Assembler::GlobalMarkerGraphEdgeInformation> Assembler::getGlobalMarkerGr
                 // The markers don't overlap.
                 info.overlappingBaseCount = 0;
                 for(uint32_t position=info.position0+k; position!=info.position1; position++) {
-                    const Base base = getOrientedReadBase(childInfo.orientedReadId, position);
+                    const Base base = reads.getOrientedReadBase(childInfo.orientedReadId, position);
                     info.sequence.push_back(base.character());
                 }
             }
@@ -3182,7 +3182,7 @@ void Assembler::computeMarkerGraphVertexConsensusSequence(
             const uint32_t markerPosition = markerPositions[i];
             Base base;
             uint8_t repeatCount;
-            tie(base, repeatCount) = getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
+            tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
 
             // Add it to the Coverage object.
             coverage.addRead(AlignedBase(base), orientedReadId.getStrand(), size_t(repeatCount));
@@ -3289,7 +3289,7 @@ void Assembler::computeMarkerGraphEdgeConsensusSequenceUsingSpoa(
             for(uint32_t position=position0+k; position!=position1; position++) {
                 Base base;
                 uint32_t repeatCount;
-                tie(base, repeatCount) = getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+                tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, position);
                 sequence.push_back(base);
                 repeatCounts.push_back(repeatCount);
                 if(coverageData) {
@@ -3465,8 +3465,8 @@ void Assembler::computeMarkerGraphEdgeConsensusSequenceUsingSpoa(
         for(uint32_t position=begin; position!=end; position++) {
             Base base;
             uint8_t repeatCount;
-            tie(base, repeatCount) = getOrientedReadBaseAndRepeatCount(orientedReadId, position);
-            interveningSequence.push_back(getOrientedReadBase(orientedReadId, position));
+            tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+            interveningSequence.push_back(reads.getOrientedReadBase(orientedReadId, position));
             interveningRepeatCounts[i].push_back(repeatCount);
         }
 
@@ -4282,7 +4282,7 @@ void Assembler::assembleMarkerGraphVertices(size_t threadCount)
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
 
@@ -4350,7 +4350,7 @@ void Assembler::computeMarkerGraphVerticesCoverageData(size_t threadCount)
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
 
@@ -4473,7 +4473,7 @@ void Assembler::computeMarkerGraphVerticesCoverageDataThreadFunction(size_t thre
                     const uint32_t markerPosition = markerPositions[i];
                     Base base;
                     uint8_t repeatCount;
-                    tie(base, repeatCount) = getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
+                    tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
 
                     // Add it to the Coverage object.
                     coverage.addRead(AlignedBase(base), orientedReadId.getStrand(), size_t(repeatCount));
@@ -4518,7 +4518,7 @@ void Assembler::assembleMarkerGraphEdges(
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
     checkMarkerGraphEdgesIsOpen();

--- a/src/AssemblerMarkers.cpp
+++ b/src/AssemblerMarkers.cpp
@@ -8,14 +8,14 @@ using namespace shasta;
 
 void Assembler::findMarkers(size_t threadCount)
 {
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkKmersAreOpen();
 
     markers.createNew(largeDataName("Markers"), largeDataPageSize);
     MarkerFinder markerFinder(
         assemblerInfo->k,
         kmerTable,
-        reads,
+        reads.reads,
         markers,
         threadCount);
 
@@ -40,9 +40,9 @@ void Assembler::writeMarkers(ReadId readId, Strand strand, const string& fileNam
 {
     // Check that we have what we need.
     checkKmersAreOpen();
-    checkReadsAreOpen();
+    reads.checkReadsAreOpen();
     checkMarkersAreOpen();
-    checkReadId(readId);
+    reads.checkReadId(readId);
 
     // Get the markers.
     const OrientedReadId orientedReadId(readId, strand);

--- a/src/AssemblerPhasing.cpp
+++ b/src/AssemblerPhasing.cpp
@@ -386,7 +386,7 @@ void Assembler::phasingGatherOrientedReadsPass(int pass)
 void Assembler::phasingGatherAssemblyGraphEdges(size_t threadCount)
 {
     AssemblyGraph& assemblyGraph = *assemblyGraphPointer;
-    const uint64_t orientedReadCount = 2 * reads.size();
+    const uint64_t orientedReadCount = 2 * reads.readCount();
 
     phasingData.assemblyGraphEdges.createNew(
         largeDataName("PhasingGraphAssemblyGraphEdges"), largeDataPageSize);
@@ -445,7 +445,7 @@ void Assembler::phasingGatherAssemblyGraphEdgesPass(int pass)
 
 void Assembler::phasingSortAssemblyGraphEdges(size_t threadCount)
 {
-    const uint64_t orientedReadCount = 2 * reads.size();
+    const uint64_t orientedReadCount = 2 * reads.readCount();
     setupLoadBalancing(orientedReadCount, 1000);
     runThreads(&Assembler::phasingSortAssemblyGraphEdgesThreadFunction,
         threadCount);

--- a/src/AssemblerReadGraph2.cpp
+++ b/src/AssemblerReadGraph2.cpp
@@ -26,7 +26,7 @@ void Assembler::createReadGraph2(size_t threadCount)
 
     // Parallel loop over reads. For each read, flag the alignments we want to discard.
     const uint64_t batchSize = 100;
-    setupLoadBalancing(readCount(), batchSize);
+    setupLoadBalancing(reads.readCount(), batchSize);
     runThreads(&Assembler::createReadGraph2ThreadFunction, threadCount);;
 
     // Create the read graph using the alignments we selected.

--- a/src/AssemblerSegmentGraph.cpp
+++ b/src/AssemblerSegmentGraph.cpp
@@ -32,10 +32,10 @@ void Assembler::createSegmentGraph()
     // Here we find, for each oriented read, the sequence of assembly graph edges
     // encountered along its marker graph path.
     // This vector is indexed by OrientedReadId::getValue().
-    vector< vector<AssemblyGraph::EdgeId> > orientedReadAssemblyGraphEdges(2*readCount());
+    vector< vector<AssemblyGraph::EdgeId> > orientedReadAssemblyGraphEdges(2*reads.readCount());
     vector<MarkerGraph::EdgeId> markerGraphPath;
     vector< pair<uint32_t, uint32_t> > pathOrdinals;
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             vector<AssemblyGraph::EdgeId>& assemblyGraphEdges =
@@ -86,7 +86,7 @@ void Assembler::createSegmentGraph()
     // Write a csv file with the sequence of assembly graph edges
     // for each oriented read.
     ofstream csv("OrientedReadSegments.csv");
-    for(ReadId readId=0; readId<readCount(); readId++) {
+    for(ReadId readId=0; readId<reads.readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             csv << orientedReadId << ",";
@@ -140,7 +140,7 @@ void Assembler::createSegmentGraph()
         // Follow the sequence of assembly graph edges
         // for each oriented read.
         vector<AssemblyGraph::EdgeId> v;
-        for(ReadId readId=0; readId<readCount(); readId++) {
+        for(ReadId readId=0; readId<reads.readCount(); readId++) {
             for(Strand strand=0; strand<2; strand++) {
                 const OrientedReadId orientedReadId(readId, strand);
 

--- a/src/CompressedAssemblyGraph.cpp
+++ b/src/CompressedAssemblyGraph.cpp
@@ -282,7 +282,7 @@ void CompressedAssemblyGraph::findOrientedReads(
 
     // Fill in the oriented read table, which tells us
     // which edges each read appears in.
-    orientedReadTable.resize(2 * assembler.readCount());
+    orientedReadTable.resize(2 * assembler.getReads().readCount());
     BGL_FORALL_EDGES(e, graph, CompressedAssemblyGraph) {
         for(const OrientedReadId orientedReadId: graph[e].orientedReadIds) {
             orientedReadTable[orientedReadId.getValue()].push_back(e);
@@ -298,7 +298,7 @@ void CompressedAssemblyGraph::fillOrientedReadTable(
     CompressedAssemblyGraph& graph = *this;
 
     orientedReadTable.clear();
-    orientedReadTable.resize(2 * assembler.readCount());
+    orientedReadTable.resize(2 * assembler.getReads().readCount());
     BGL_FORALL_EDGES(e, graph, CompressedAssemblyGraph) {
         for(const OrientedReadId orientedReadId: graph[e].orientedReadIds) {
             orientedReadTable[orientedReadId.getValue()].push_back(e);

--- a/src/LowHash0.cpp
+++ b/src/LowHash0.cpp
@@ -30,7 +30,7 @@ LowHash0::LowHash0(
     size_t minFrequency,            // Minimum number of minHash hits for a pair to be considered a candidate.
     size_t threadCountArgument,
     const MemoryMapped::Vector<KmerInfo>& kmerTable,
-    const MemoryMapped::Vector<ReadFlags>& readFlags,
+    const Reads& reads,
     const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers,
     MemoryMapped::Vector<OrientedReadPair>& candidateAlignments,
     MemoryMapped::Vector< array<uint64_t, 3> >& readLowHashStatistics,
@@ -45,7 +45,7 @@ LowHash0::LowHash0(
     minFrequency(minFrequency),
     threadCount(threadCountArgument),
     kmerTable(kmerTable),
-    readFlags(readFlags),
+    reads(reads),
     markers(markers),
     readLowHashStatistics(readLowHashStatistics),
     largeDataFileNamePrefix(largeDataFileNamePrefix),
@@ -223,7 +223,7 @@ LowHash0::LowHash0(
         const uint64_t featureCount = markers.size(OrientedReadId(readId, 0).getValue()) - (m-1);
         const double featureSampling = double(total) / double(featureCount);
         csv << readId << ",";
-        csv << (readFlags[readId].isPalindromic ? "Yes," : "No,");
+        csv << (reads.getFlags(readId).isPalindromic ? "Yes," : "No,");
         csv << featureCount << ",";
         csv << counters[0] << ",";
         csv << counters[1] << ",";
@@ -319,7 +319,7 @@ void LowHash0::pass1ThreadFunction(size_t threadId)
 
         // Loop over oriented reads assigned to this batch.
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
-            if(readFlags[readId].isPalindromic) {
+            if(reads.getFlags(readId).isPalindromic) {
                 continue;
             }
             for(Strand strand=0; strand<2; strand++) {
@@ -368,7 +368,7 @@ void LowHash0::pass2ThreadFunction(size_t threadId)
 
         // Loop over oriented reads assigned to this batch.
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
-            if(readFlags[readId].isPalindromic) {
+            if(reads.getFlags(readId).isPalindromic) {
                 continue;
             }
             for(Strand strand=0; strand<2; strand++) {

--- a/src/LowHash0.hpp
+++ b/src/LowHash0.hpp
@@ -7,10 +7,11 @@
 #include "MultithreadedObject.hpp"
 #include "OrientedReadPair.hpp"
 #include "ReadId.hpp"
+#include "Reads.hpp"
 
 namespace shasta {
     class LowHash0;
-    class ReadFlags;
+    class Reads;
 }
 
 
@@ -37,7 +38,7 @@ public:
         size_t minFrequency,            // Minimum number of minHash hits for a pair to be considered a candidate.
         size_t threadCount,
         const MemoryMapped::Vector<KmerInfo>& kmerTable,
-        const MemoryMapped::Vector<ReadFlags>& readFlags,
+        const Reads& reads,
         const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>&,
         MemoryMapped::Vector<OrientedReadPair>&,
         MemoryMapped::Vector< array<uint64_t, 3> >& readLowHashStatistics,
@@ -55,7 +56,7 @@ private:
     size_t minFrequency;            // Minimum number of minHash hits for a pair to be considered a candidate.
     size_t threadCount;
     const MemoryMapped::Vector<KmerInfo>& kmerTable;
-    const MemoryMapped::Vector<ReadFlags>& readFlags;
+    const Reads& reads;
     const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers;
     MemoryMapped::Vector< array<uint64_t, 3> > &readLowHashStatistics;
     const string& largeDataFileNamePrefix;

--- a/src/LowHash1.cpp
+++ b/src/LowHash1.cpp
@@ -20,7 +20,7 @@ LowHash1::LowHash1(
     size_t minFrequency,            // Minimum number of minHash hits for a pair to be considered a candidate.
     size_t threadCountArgument,
     const MemoryMapped::Vector<KmerInfo>& kmerTable,
-    const MemoryMapped::Vector<ReadFlags>& readFlags,
+    const Reads& reads,
     const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers,
     AlignmentCandidates& candidates,
     const string& largeDataFileNamePrefix,
@@ -34,7 +34,7 @@ LowHash1::LowHash1(
     minFrequency(minFrequency),
     threadCount(threadCountArgument),
     kmerTable(kmerTable),
-    readFlags(readFlags),
+    reads(reads),
     markers(markers),
     candidates(candidates),
     largeDataFileNamePrefix(largeDataFileNamePrefix),
@@ -239,7 +239,7 @@ void LowHash1::computeHashesThreadFunction(size_t threadId)
 
         // Loop over oriented reads assigned to this batch.
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
-            if(readFlags[readId].isPalindromic) {
+            if(reads.getFlags(readId).isPalindromic) {
                 continue;
             }
             for(Strand strand=0; strand<2; strand++) {
@@ -287,7 +287,7 @@ void LowHash1::fillBucketsThreadFunction(size_t threadId)
 
         // Loop over oriented reads assigned to this batch.
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
-            if(readFlags[readId].isPalindromic) {
+            if(reads.getFlags(readId).isPalindromic) {
                 continue;
             }
             for(Strand strand=0; strand<2; strand++) {

--- a/src/LowHash1.hpp
+++ b/src/LowHash1.hpp
@@ -6,7 +6,7 @@
 #include "MemoryMappedVectorOfVectors.hpp"
 #include "MultithreadedObject.hpp"
 #include "OrientedReadPair.hpp"
-#include "ReadFlags.hpp"
+#include "Reads.hpp"
 
 // Standard library.
 #include "memory.hpp"
@@ -37,7 +37,7 @@ public:
         size_t minFrequency,            // Minimum number of minHash hits for a pair to be considered a candidate.
         size_t threadCount,
         const MemoryMapped::Vector<KmerInfo>& kmerTable,
-        const MemoryMapped::Vector<ReadFlags>& readFlags,
+        const Reads& reads,
         const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>&,
         AlignmentCandidates& candidates,
         const string& largeDataFileNamePrefix,
@@ -54,7 +54,7 @@ private:
     size_t minFrequency;            // Minimum number of minHash hits for a pair to be considered a candidate.
     size_t threadCount;
     const MemoryMapped::Vector<KmerInfo>& kmerTable;
-    const MemoryMapped::Vector<ReadFlags>& readFlags;
+    const Reads& reads;
     const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers;
     AlignmentCandidates& candidates;
     const string& largeDataFileNamePrefix;

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -51,7 +51,33 @@ PYBIND11_MODULE(shasta, module)
         .def_readonly("isSameStrand", &OrientedReadPair::isSameStrand)
         ;
 
-
+    // Expose class Reads to Python
+    class_<Reads>(module, "Reads")
+        .def("readCount", &Reads::readCount, "Get the number of reads.")
+        .def("writeReads",
+            &Reads::writeReads,
+            "Write all reads to a file in fasta format.",
+            arg("fileName"))
+        .def("writeRead",
+            (
+                void (Reads::*)
+                (ReadId, const string&)
+            )
+            &Reads::writeRead,
+            "Write one read to a file in fasta format.",
+            arg("readId"),
+            arg("fileName"))
+        .def("writeOrientedRead",
+            (
+                void (Reads::*)
+                (ReadId, Strand, const string&)
+            )
+            &Reads::writeOrientedRead,
+            "Write one oriented read to a file in fasta format.",
+            arg("readId"),
+            arg("strand"),
+            arg("fileName"))
+        ;
 
     // Expose class Assembler to Python.
     class_<Assembler>(module, "Assembler")
@@ -66,43 +92,11 @@ PYBIND11_MODULE(shasta, module)
 
 
         // Reads
-        .def("readCount",
-            &Assembler::readCount,
-            "Get the number of reads.")
+        .def("getReads", &Assembler::getReads, return_value_policy::reference)
         .def("histogramReadLength",
             &Assembler::histogramReadLength,
             "Create a histogram of read length and write it to a csv file.",
             arg("fileName") = "ReadLengthHistogram.csv")
-        .def("writeReads",
-            &Assembler::writeReads,
-            "Write all reads to a file in fasta format.",
-            arg("fileName"))
-        .def("writeRead",
-            (
-                void (Assembler::*)
-                (ReadId, const string&)
-            )
-            &Assembler::writeRead,
-            "Write one read to a file in fasta format.",
-            arg("readId"),
-            arg("fileName"))
-        .def("writeOrientedRead",
-            (
-                void (Assembler::*)
-                (ReadId, Strand, const string&)
-            )
-            &Assembler::writeOrientedRead,
-            "Write one oriented read to a file in fasta format.",
-            arg("readId"),
-            arg("strand"),
-            arg("fileName"))
-        .def("initializeReadFlags",
-            &Assembler::initializeReadFlags)
-        .def("accessReadFlags",
-            &Assembler::accessReadFlags,
-            arg("readWriteAccess") = false)
-
-
 
         // K-mers.
         .def("accessKmers",

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -5,6 +5,7 @@
 #include "LongBaseSequence.hpp"
 #include "MemoryMappedObject.hpp"
 #include "MultithreadedObject.hpp"
+#include "Reads.hpp"
 
 // Standard library.
 #include "memory.hpp"
@@ -25,15 +26,12 @@ public:
     // The constructor does all the work.
     ReadLoader(
         const string& fileName,
-        size_t minReadLength,
+        uint64_t minReadLength,
         bool noCache,
         size_t threadCount,
         const string& dataNamePrefix,
         size_t pageSize,
-        LongBaseSequences& reads,
-        MemoryMapped::VectorOfVectors<char, uint64_t>& readNames,
-        MemoryMapped::VectorOfVectors<char, uint64_t>& readMetaData,
-        MemoryMapped::VectorOfVectors<uint8_t, uint64_t>& readRepeatCounts);
+        Reads& reads);
 
     // The number of reads and raw bases discarded because the read
     // contained invalid bases.
@@ -56,7 +54,7 @@ private:
     const string& fileName;
 
     // The minimum read length. Shorter reads are not stored.
-    const size_t minReadLength;
+    const uint64_t minReadLength;
 
     // If set, use the O_DIRECT flag when opening input files (Linux only).
     bool noCache;
@@ -73,11 +71,8 @@ private:
     const size_t pageSize;
 
     // The data structure that the reads will be added to.
-    LongBaseSequences& reads;
-    MemoryMapped::VectorOfVectors<char, uint64_t>& readNames;
-    MemoryMapped::VectorOfVectors<char, uint64_t>& readMetaData;
-    MemoryMapped::VectorOfVectors<uint8_t, uint64_t>& readRepeatCounts;
-
+    Reads& reads;
+    
     // Create the name to be used for a MemoryMapped object.
     string dataName(
         const string& dataName) const;

--- a/src/Reads.cpp
+++ b/src/Reads.cpp
@@ -1,0 +1,358 @@
+// Shasta
+#include "Reads.hpp"
+
+// Standard Library
+#include "fstream.hpp"
+
+using namespace shasta;
+
+void Reads::checkIfAChimericIsAlsoInSmallComponent() const {
+    for (const ReadFlags& flags: readFlags) {
+        if (flags.isChimeric) {
+            SHASTA_ASSERT(flags.isInSmallComponent);
+        }
+    }
+}
+
+
+// Return a base of an oriented read.
+Base Reads::getOrientedReadBase(
+    OrientedReadId orientedReadId,
+    uint32_t position)
+{
+    const auto& read = reads[orientedReadId.getReadId()];
+    if(orientedReadId.getStrand() == 0) {
+        return read[position];
+    } else {
+        return read[read.baseCount-1-position].complement();
+    }
+}
+
+// Same as above, but also returns the repeat count.
+pair<Base, uint8_t> Reads::getOrientedReadBaseAndRepeatCount(
+    OrientedReadId orientedReadId,
+    uint32_t position)
+{
+
+    // Extract the read id and strand.
+    const ReadId readId = orientedReadId.getReadId();
+    const Strand strand = orientedReadId.getStrand();
+
+    // Access the bases and repeat counts for this read.
+    const auto& read = reads[readId];
+    const auto& counts = readRepeatCounts[readId];
+
+    // Compute the position as stored, depending on strand.
+    uint32_t orientedPosition = position;
+    if(strand == 1) {
+        orientedPosition = uint32_t(read.baseCount) - 1 - orientedPosition;
+    }
+
+    // Extract the base and repeat count at this position.
+    pair<Base, uint8_t> p = make_pair(read[orientedPosition], counts[orientedPosition]);
+
+    // Complement the base, if necessary.
+    if(strand == 1) {
+        p.first = p.first.complement();
+    }
+
+    return p;
+}
+
+// Return a vector containing the raw sequence of an oriented read.
+vector<Base> Reads::getOrientedReadRawSequence(OrientedReadId orientedReadId)
+{
+    // The sequence we will return;
+    vector<Base> sequence;
+
+    // The number of bases stored, in run-length representation.
+    const uint32_t storedBaseCount = uint32_t(reads[orientedReadId.getReadId()].baseCount);
+
+
+    // We are storing a run-length representation of the read.
+    // Expand it base by base to create the raw representation.
+    for(uint32_t position=0; position<storedBaseCount; position++) {
+        Base base;
+        uint8_t count;
+        tie(base, count) = getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+        for(uint32_t i=0; i<uint32_t(count); i++) {
+            sequence.push_back(base);
+        }
+    }
+
+    return sequence;
+}
+
+// Return the length of the raw sequence of a read.
+// If using the run-length representation of reads, this counts each
+// base a number of times equal to its repeat count.
+size_t Reads::getReadRawSequenceLength(ReadId readId)
+{
+    // We are using the run-length representation.
+    // The number of raw bases equals the sum of all
+    // the repeat counts.
+    // Don't use std::accumulate to compute the sum,
+    // otherwise the sum is computed using uint8_t!
+    const auto& counts = readRepeatCounts[readId];
+    size_t sum = 0;;
+    for(uint8_t count: counts) {
+        sum += count;
+    }
+    return sum;
+}
+
+
+
+// Get a vector of the raw read positions
+// corresponding to each position in the run-length
+// representation of an oriented read.
+vector<uint32_t> Reads::getRawPositions(OrientedReadId orientedReadId) const
+{
+    const ReadId readId = orientedReadId.getReadId();
+    const ReadId strand = orientedReadId.getStrand();
+    const auto repeatCounts = readRepeatCounts[readId];
+    const size_t n = repeatCounts.size();
+
+    vector<uint32_t> v;
+
+    uint32_t position = 0;
+    for(size_t i=0; i<n; i++) {
+        v.push_back(position);
+        uint8_t count;
+        if(strand == 0) {
+            count = repeatCounts[i];
+        } else {
+            count = repeatCounts[n-1-i];
+        }
+        position += count;
+    }
+
+    return v;
+}
+
+
+// Return a meta data field for a read, or an empty string
+// if that field is missing. This treats the meta data
+// as a space separated sequence of Key=Value,
+// without embedded spaces in each Key=Value pair.
+span<char> Reads::getMetaData(ReadId readId, const string& key)
+{
+    SHASTA_ASSERT(readId < readMetaData.size());
+    const uint64_t keySize = key.size();
+    char* keyBegin = const_cast<char*>(&key[0]);
+    char* keyEnd = keyBegin + keySize;
+    char* begin = readMetaData.begin(readId);
+    char* end = readMetaData.end(readId);
+
+
+    char* p = begin;
+    while(p != end) {
+
+        // Look for the next space or line end.
+        char*q = p;
+        while(q != end and not isspace(*q)) {
+            ++q;
+        }
+
+        // When getting here, the interval [p, q) contains
+        // a possible (Key,Value) pair.
+
+        // Check if we have the key we are looking for,
+        // immediately followed by an equal sign.
+        // If so, return what follows.
+        if(q > p + keySize + 1) {
+            if(std::equal(keyBegin, keyEnd, p)) {
+                if(p[keySize] == '=') {
+                    char* valueBegin = p + keySize + 1;
+                    char* valueEnd = q;
+                    return span<char>(valueBegin, valueEnd);
+                }
+            }
+        }
+
+        // If we reached the end of our meta data, stop here.
+        if(q == end) {
+            break;
+        }
+
+        // Look for the next non-space.
+        p = q;
+        while(p != end and isspace(*p)) {
+            ++p;
+        }
+    }
+
+    // If getting here, we didn't find this keyword.
+    // Return an empty string.
+    return span<char>();
+}
+
+
+
+// Function to write one or all reads in Fasta format.
+void Reads::writeReads(const string& fileName)
+{
+    ofstream file(fileName);
+    for(ReadId readId=0; readId<reads.size(); readId++) {
+        writeRead(readId, file);
+    }
+}
+
+
+void Reads::writeRead(ReadId readId, const string& fileName)
+{
+    ofstream file(fileName);
+    writeRead(readId, file);
+}
+
+
+void Reads::writeRead(ReadId readId, ostream& file)
+{
+    checkReadsAreOpen();
+    checkReadNamesAreOpen();
+    checkReadId(readId);
+
+    const vector<Base> rawSequence = getOrientedReadRawSequence(OrientedReadId(readId, 0));
+    const auto readName = readNames[readId];
+    const auto metaData = readMetaData[readId];
+
+    file << ">";
+    copy(readName.begin(), readName.end(), ostream_iterator<char>(file));
+    file << " " << readId;
+    file << " " << rawSequence.size();
+    if(metaData.size() > 0) {
+        file << " ";
+        copy(metaData.begin(), metaData.end(), ostream_iterator<char>(file));
+    }
+    file << "\n";
+    copy(rawSequence.begin(), rawSequence.end(), ostream_iterator<Base>(file));
+    file << "\n";
+
+}
+
+
+void Reads::writeOrientedRead(ReadId readId, Strand strand, const string& fileName)
+{
+    writeOrientedRead(OrientedReadId(readId, strand), fileName);
+}
+
+
+void Reads::writeOrientedRead(OrientedReadId orientedReadId, const string& fileName)
+{
+    ofstream file(fileName);
+    writeOrientedRead(orientedReadId, file);
+}
+
+
+void Reads::writeOrientedRead(OrientedReadId orientedReadId, ostream& file)
+{
+    checkReadsAreOpen();
+    checkReadNamesAreOpen();
+
+    const vector<Base> rawSequence = getOrientedReadRawSequence(orientedReadId);
+    const auto readName = readNames[orientedReadId.getReadId()];
+
+    file << ">" << orientedReadId;
+    file << " " << rawSequence.size() << " ";
+    copy(readName.begin(), readName.end(), ostream_iterator<char>(file));
+    file << "\n";
+    copy(rawSequence.begin(), rawSequence.end(), ostream_iterator<Base>(file));
+    file << "\n";
+}
+
+// Create a histogram of read lengths.
+// All lengths here are raw sequence lengths
+// (length of the original read), not lengths
+// in run-length representation.
+void Reads::computeAndWriteReadLengthHistogram(const string& fileName) {
+    checkReadsAreOpen();
+    // Create the histogram.
+    // It contains the number of reads of each length.
+    // Indexed by the length.
+    const ReadId totalReadCount = readCount();
+    totalBaseCount = 0;
+    
+    for(ReadId readId=0; readId<totalReadCount; readId++) {
+        const size_t length = getReadRawSequenceLength(readId);
+        totalBaseCount += length;
+        if(histogram.size() <= length) {
+            histogram.resize(length+1, 0);
+        }
+        ++(histogram[length]);
+    }
+
+    n50 = 0;
+    {
+        ofstream csv(fileName);
+        csv << "Length,Reads,Bases,CumulativeReads,CumulativeBases,"
+            "FractionalCumulativeReads,FractionalCumulativeBases,\n";
+        size_t cumulativeReadCount = totalReadCount;
+        size_t cumulativeBaseCount = totalBaseCount;
+        for(size_t length=0; length<histogram.size(); length++) {
+            const size_t frequency = histogram[length];
+            if(frequency) {
+                const  size_t baseCount = frequency * length;
+                const double cumulativeReadFraction =
+                    double(cumulativeReadCount)/double(totalReadCount);
+                const double comulativeBaseFraction =
+                    double(cumulativeBaseCount)/double(baseCount);
+                csv << length << "," << frequency << "," << baseCount << ",";
+                csv << cumulativeReadCount << "," << cumulativeBaseCount << ",";
+                csv << cumulativeReadFraction << ",";
+                csv << comulativeBaseFraction << "\n";
+                cumulativeReadCount -= frequency;
+                cumulativeBaseCount -= baseCount;
+                if(comulativeBaseFraction > 0.5) {
+                    n50 = length;
+                }
+            }
+        }
+        
+        SHASTA_ASSERT(cumulativeReadCount == 0);
+        SHASTA_ASSERT(cumulativeBaseCount == 0);
+    }
+
+    // Binned Histogram.
+    {
+        const uint64_t binWidth = 1000;
+        for(size_t length=0; length<histogram.size(); length++) {
+            const size_t readCount = histogram[length];
+            if(readCount) {
+                const size_t bin = length / binWidth;
+                if(binnedHistogram.size() <= bin) {
+                    binnedHistogram.resize(bin+1, make_pair(0, 0));
+                }
+                binnedHistogram[bin].first += readCount;
+                binnedHistogram[bin].second += readCount * length;
+            }
+        }
+
+        ofstream csv("Binned-" + fileName);
+        csv << "LengthBegin,LengthEnd,Reads,Bases,CumulativeReads,CumulativeBases,"
+            "FractionalCumulativeReads,FractionalCumulativeBases,\n";
+        size_t cumulativeReadCount = totalReadCount;
+        size_t cumulativeBaseCount = totalBaseCount;
+        for(size_t bin=0; bin<binnedHistogram.size(); bin++) {
+            const auto& histogramBin = binnedHistogram[bin];
+            const size_t readCount = histogramBin.first;
+            const size_t baseCount = histogramBin.second;
+            const double cumulativeReadFraction =
+                double(cumulativeReadCount)/double(totalReadCount);
+            const double comulativeBaseFraction =
+                double(cumulativeBaseCount)/double(totalBaseCount);
+            csv << bin*binWidth << ",";
+            csv << (bin+1)*binWidth << ",";
+            csv << readCount << "," << baseCount << ",";
+            csv << cumulativeReadCount << "," << cumulativeBaseCount << ",";
+            csv << cumulativeReadFraction << ",";
+            csv << comulativeBaseFraction << "\n";
+            cumulativeReadCount -= readCount;
+            cumulativeBaseCount -= baseCount;
+        }
+        SHASTA_ASSERT(cumulativeReadCount == 0);
+        SHASTA_ASSERT(cumulativeBaseCount == 0);
+    }
+
+    cout << "See " << fileName << " and Binned-" << fileName <<
+        " for details of the read length distribution." << endl;
+}

--- a/src/Reads.hpp
+++ b/src/Reads.hpp
@@ -1,0 +1,254 @@
+#ifndef SHASTA_READS
+#define SHASTA_READS
+
+// shasta
+#include "LongBaseSequence.hpp"
+#include "MemoryMappedObject.hpp"
+#include "ReadId.hpp"
+#include "Base.hpp"
+#include "span.hpp"
+#include "ReadFlags.hpp"
+#include "SHASTA_ASSERT.hpp"
+
+namespace shasta {
+    class Reads;
+}
+
+/***************************************************************************
+
+The reads used for this assembly.
+Indexed by ReadId.
+
+We use a run-length representation
+(https://en.wikipedia.org/wiki/Run-length_encoding)
+for reads: all repeated bases are removed, and
+for each base we store a repeat base count that says how many
+times that base was repeated in the original read.
+Many assembly phases use only the run-length representation
+(without using the base repeat count).
+This includes the generation of markers, the computation of
+alignments, and the creation of the marker graph.
+
+For example, suppose we have the following read sequence:
+
+TAATCATTTTGATGTAAGTCTAAAAATTTCACCTTAATACTTATTTTTCC
+
+The read is stored like this:
+
+TATCATGATGTAGTCTATCACTATACTATC
+121114111112111153112221112152
+
+The first line is stored in reads[readId] and the second line
+is stored in readRepeatCount[readId]. Note that base caller errors
+in the number of times a base is repeated (a g. AAAA versus AAAAA)
+leave the first line unchanged.
+
+In this representation the sequence never has any repeated bases.
+However, repeats with period 2 or longer are possible, for example TATA
+above.
+
+In the run-length representation, the read sequence, which has all
+repeated bases removed, is insensitive to base caller errors
+in the number of repetitions of individual bases, which is the
+most common type of error in nanopore sequencing.
+Therefore, it is hoped that the run-length representation results
+in better resilience to base caller errors.
+
+The base repeat count is stored in one byte per base and so
+it can store base repeat lengths up to 255.
+If a read contains bases repeated 256 or more times,
+it cannot be stored and is discarded on input.
+The stored base repeat count is never zero, and is one
+for most bases.
+
+The run-length representation is typically around 25% shorter than
+the raw representation, due to the removal of repeated bases.
+This gives some performance benefits for assembly phases that
+don't use the base repeat counts. However, the need to store
+repeat base counts (8 bits per base) increases the memory
+requirement from 2 to 10 bits per base. So overall the
+run-length representation requires more memory for the reads
+than the raw representation.
+
+Run-length representations that are more economic in memory are possible,
+at the price of additional code complexity and performance cost
+in assembly phases that use the base repeat counts.
+>
+***************************************************************************/
+
+class shasta::Reads {
+public:
+
+    LongBaseSequences reads;
+    MemoryMapped::VectorOfVectors<uint8_t, uint64_t> readRepeatCounts;
+
+    // The names of the reads from the input fasta or fastq files.
+    // Indexed by ReadId.
+    // Note that we don't enforce uniqueness of read names.
+    // We don't use read names to identify reads.
+    // These names are only used as an aid in tracing each read
+    // back to its origin.
+    MemoryMapped::VectorOfVectors<char, uint64_t> readNames;
+
+    // Read meta data. This is the information following the read name
+    // in the header line for fasta and fastq files.
+    // Indexed by ReadId.
+    MemoryMapped::VectorOfVectors<char, uint64_t> readMetaData;
+
+    MemoryMapped::Vector<ReadFlags> readFlags;
+
+    
+    // Default Constructor
+    Reads(): totalBaseCount(0), n50(0) {};
+
+    inline ReadId readCount() const {
+        return ReadId(reads.size());
+    }
+
+    inline LongBaseSequenceView getRead(ReadId readId) {
+        return reads[readId];
+    }
+
+    inline span<uint8_t> getReadRepeatCounts(ReadId readId) {
+        return readRepeatCounts[readId];
+    }
+
+    inline span<char> getReadName(ReadId readId) {
+        return readNames[readId];
+    }
+
+    inline span<char> getReadMetaData(ReadId readId) {
+        return readMetaData[readId];
+    }
+
+    inline const ReadFlags& getFlags(ReadId readId) const {
+        return readFlags[readId];
+    }
+
+    
+    Base getOrientedReadBase(
+        OrientedReadId orientedReadId,
+        uint32_t position
+    );
+
+    pair<Base, uint8_t> getOrientedReadBaseAndRepeatCount(
+        OrientedReadId orientedReadId,
+        uint32_t position
+    );
+
+    // Return a vector containing the raw sequence of an oriented read.
+    vector<Base> getOrientedReadRawSequence(OrientedReadId);
+
+    // Return the length of the raw sequence of a read.
+    // If using the run-length representation of reads, this counts each
+    // base a number of times equal to its repeat count.
+    size_t getReadRawSequenceLength(ReadId);
+
+    // Get a vector of the raw read positions
+    // corresponding to each position in the run-length
+    // representation of an oriented read.
+    vector<uint32_t> getRawPositions(OrientedReadId) const;
+
+    // Return a meta data field for a read, or an empty string
+    // if that field is missing. This treats the meta data
+    // as a space separated sequence of Key=Value,
+    // without embedded spaces in each Key=Value pair.
+    span<char> getMetaData(ReadId, const string& key);
+
+
+    // Setters for readFlags.
+    inline void setPalindromicFlag(ReadId readId, bool value) {
+        readFlags[readId].isPalindromic = value;
+    }
+    inline void setChimericFlag(ReadId readId, bool value) {
+        readFlags[readId].isChimeric = value;
+    }
+    inline void setIsInSmallComponentFlag(ReadId readId, bool value) {
+        readFlags[readId].isInSmallComponent = value;
+    }
+    inline void setIsInSmallComponentFlagForAll(bool value) {
+        for (ReadId i = 0; i < readFlags.size(); i++) {
+            setIsInSmallComponentFlag(i, value);
+        }
+    }
+    inline void setStrandFlag(ReadId readId, Strand strand) {
+        readFlags[readId].strand = strand & 1;
+    }
+    inline void setStrandFlagForAll(Strand strand) {
+        for (ReadId i = 0; i < readFlags.size(); i++) {
+            setStrandFlag(i, strand & 1);
+        }
+    }
+
+    // Function to write one or all reads in Fasta format.
+    void writeReads(const string& fileName);
+    void writeRead(ReadId, const string& fileName);
+    void writeOrientedRead(ReadId, Strand, const string& fileName);
+
+    void writeRead(ReadId, ostream&);
+    void writeOrientedRead(OrientedReadId, ostream&);
+    void writeOrientedRead(OrientedReadId, const string& fileName);
+
+
+    // Assertions for data integrity.
+    inline void checkSanity() const {
+        SHASTA_ASSERT(readNames.size() == reads.size());
+        SHASTA_ASSERT(readMetaData.size() == reads.size());
+    }
+
+    inline void checkReadsAreOpen() const {
+        SHASTA_ASSERT(reads.isOpen());
+        SHASTA_ASSERT(readRepeatCounts.isOpen());
+    }
+
+    inline void checkReadNamesAreOpen() const {
+        SHASTA_ASSERT(readNames.isOpen());
+    }
+
+    inline void checkReadMetaDataAreOpen() const {
+        SHASTA_ASSERT(readMetaData.isOpen());
+    }
+
+    inline void checkReadFlagsAreOpen() const {
+        SHASTA_ASSERT(readFlags.isOpen);
+    }
+
+    inline void checkReadFlagsAreOpenForWriting() const {
+        SHASTA_ASSERT(readFlags.isOpenWithWriteAccess);
+    }
+
+    inline void checkReadId(ReadId readId) const {
+        if (readId >= reads.size()) {
+            throw runtime_error("Read id " + to_string(readId) +
+                " is not valid. Must be between 0 and " + to_string(reads.size()) +
+                " inclusive.");
+        }
+    }
+
+    void checkIfAChimericIsAlsoInSmallComponent() const;
+
+    inline void assertReadsAndFlagsOfSameSize() const {
+        SHASTA_ASSERT(reads.size() == readFlags.size());
+    }
+
+    void computeAndWriteReadLengthHistogram(const string& fileName);
+    
+    inline uint64_t getTotalBaseCount() const {
+        return totalBaseCount;
+    }
+    inline uint64_t getN50() const {
+        return n50;
+    }
+
+
+private:
+
+    // Read statistics.
+    vector<uint64_t> histogram;
+    vector< pair<uint64_t, uint64_t> > binnedHistogram;
+    uint64_t totalBaseCount;
+    uint64_t n50;    
+
+};
+
+#endif

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -469,17 +469,13 @@ void shasta::main::assemble(
             assemblerOptions.readsOptions.noCache,
             threadCount);
     }
-    if(assembler.readCount() == 0) {
+    if(assembler.getReads().readCount() == 0) {
         throw runtime_error("There are no input reads.");
     }
     const auto t1 = steady_clock::now();
     cout << timestamp << "Done loading reads from " << inputFileNames.size() << " files." << endl;
     cout << "Read loading took " << seconds(t1-t0) << "s." << endl;
 
-
-
-    // Initialize read flags.
-    assembler.initializeReadFlags();
 
     // Create a histogram of read lengths.
     assembler.histogramReadLength("ReadLengthHistogram.csv");


### PR DESCRIPTION
1. `reads`, `readRepeatCounts`, `readNames`, `readMetaData` & `readFlags` are now wrapped in a class named `Reads`.
2. Moved the Read length histogram computation to the `Reads` class as well. This will allow us to do something based on desired coverage (in a later PR).
3. Consolidated creation of `readFlags` with the others. `ReadLoader` now prepares (resizes) `readFlags` after it is done populating `reads` & `readRepeatCounts`. 

In follow-up PR(s)
1. Make `reads`, `readRepeatCounts`, `readNames`, `readMetaData` & `readFlags` private. This would require creating a const version of `LongBaseSequenceView` (and potentially other things).
2. Switch the data members to pointers so that they can be swapped after implementing support for `--Reads.desiredCoverage`


### Test Plan
Ran E-coli assembly before and after the change. `diff `d the two AssemblySummary.json files to verify that there was no material change in the assembly.

Explored the assembly using the HTTP server to ensure those code paths work as well.