### PR TITLE
Allow an empty assembly directory to exist before the assembly starts.

### DIFF
--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -229,8 +229,16 @@ void shasta::main::assemble(
 
 
     // Create the run output directory. If it exists and is not empty then stop.
-    bool dirExists = filesystem::isDirectory(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
-    if (dirExists) {
+    bool exists = filesystem::exists(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
+    bool isDir = filesystem::isDirectory(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
+    if (exists) {
+        if (!isDir) {
+            throw runtime_error(
+                assemblerOptions.commandLineOnlyOptions.assemblyDirectory +
+                " already exists and is not a directory.\n"
+                "Use --assemblyDirectory to specify a different assembly directory."
+            );
+        }
         bool isEmpty = filesystem::directoryContents(assemblerOptions.commandLineOnlyOptions.assemblyDirectory).empty();
         if (!isEmpty) {
             throw runtime_error(

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -228,8 +228,8 @@ void shasta::main::assemble(
 
 
 
-    // Create the run the output directory. If it exists and is not empty then stop.
-    bool dirExists = filesystem::exists(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
+    // Create the run output directory. If it exists and is not empty then stop.
+    bool dirExists = filesystem::isDirectory(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
     if (dirExists) {
         bool isEmpty = filesystem::directoryContents(assemblerOptions.commandLineOnlyOptions.assemblyDirectory).empty();
         if (!isEmpty) {

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -228,16 +228,20 @@ void shasta::main::assemble(
 
 
 
-    // Create the run the output directory. If it exists, stop.
-    if(filesystem::exists(assemblerOptions.commandLineOnlyOptions.assemblyDirectory)) {
-        throw runtime_error(
-            "Assembly directory " +
-            assemblerOptions.commandLineOnlyOptions.assemblyDirectory +
-            " already exists.\n"
-            "Remove it or use --assemblyDirectory to specify a different assembly directory.");
+    // Create the run the output directory. If it exists and is not empty then stop.
+    bool dirExists = filesystem::exists(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
+    if (dirExists) {
+        bool isEmpty = filesystem::directoryContents(assemblerOptions.commandLineOnlyOptions.assemblyDirectory).empty();
+        if (!isEmpty) {
+            throw runtime_error(
+                "Assembly directory " +
+                assemblerOptions.commandLineOnlyOptions.assemblyDirectory +
+                " exists and is not empty.\n"
+                "Empty it for reuse or use --assemblyDirectory to specify a different assembly directory.");
+        }
+    } else {
+        filesystem::createDirectory(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
     }
-    filesystem::createDirectory(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
-
     // Make the output directory current.
     filesystem::changeDirectory(assemblerOptions.commandLineOnlyOptions.assemblyDirectory);
 


### PR DESCRIPTION
This will allow integration with tools like snakemake 

https://github.com/chanzuckerberg/shasta/issues/172

###  Test Plan
1. Ran an assembly where --assemblyDirectory does not exist (No error)
2. Ran an assembly where --assemblyDirectory exists and is not empty (Throws an error)
3. Ran an assembly where --assemblyDirectory exists and is empty (No error)