### PR TITLE
Make data members of the Reads class, private.

### DIFF
--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -24,11 +24,14 @@ Assembler::Assembler(
         assemblerInfo->largeDataPageSize = largeDataPageSizeArgument;
         largeDataPageSize = largeDataPageSizeArgument;
 
-        reads.reads.createNew(largeDataName("Reads"), largeDataPageSize);
-        reads.readNames.createNew(largeDataName("ReadNames"), largeDataPageSize);
-        reads.readMetaData.createNew(largeDataName("ReadMetaData"), largeDataPageSize);
-        reads.readRepeatCounts.createNew(largeDataName("ReadRepeatCounts"), largeDataPageSize);
-        reads.readFlags.createNew(largeDataName("ReadFlags"), largeDataPageSize);
+        reads.createNew(
+            largeDataName("Reads"),
+            largeDataName("ReadNames"),
+            largeDataName("ReadMetaData"),
+            largeDataName("ReadRepeatCounts"),
+            largeDataName("ReadFlags"),
+            largeDataPageSize
+        );
         // cout << "Created a new assembly with page size " << largeDataPageSize << endl;
 
     } else {
@@ -37,11 +40,13 @@ Assembler::Assembler(
         assemblerInfo.accessExistingReadWrite(largeDataName("Info"));
         largeDataPageSize = assemblerInfo->largeDataPageSize;
 
-        reads.reads.accessExistingReadWrite(largeDataName("Reads"));
-        reads.readNames.accessExistingReadWrite(largeDataName("ReadNames"));
-        reads.readMetaData.accessExistingReadWrite(largeDataName("ReadMetaData"));
-        reads.readRepeatCounts.accessExistingReadWrite(largeDataName("ReadRepeatCounts"));
-        reads.readFlags.accessExistingReadWrite(largeDataName("ReadFlags"));
+        reads.access(
+            largeDataName("Reads"),
+            largeDataName("ReadNames"),
+            largeDataName("ReadMetaData"),
+            largeDataName("ReadRepeatCounts"),
+            largeDataName("ReadFlags")
+        );
         // cout << "Accessed an existing assembly with page size " << largeDataPageSize << endl;
 
     }

--- a/src/AssemblerHttpServer-MarkerGraph.cpp
+++ b/src/AssemblerHttpServer-MarkerGraph.cpp
@@ -61,8 +61,7 @@ void Assembler::exploreMarkerGraph(
     // Create the local marker graph.
     LocalMarkerGraph graph(
         uint32_t(assemblerInfo->k),
-        reads.reads,
-        reads.readRepeatCounts,
+        reads,
         markers,
         markerGraph.vertexTable,
         *consensusCaller);

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -619,9 +619,9 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Read N50 (for raw read sequence)"
         "<td class=right>" << assemblerInfo->readN50 <<
         "<tr><td>Number of run-length encoded bases"
-        "<td class=right>" << reads.readRepeatCounts.totalSize() <<
+        "<td class=right>" << reads.getRepeatCountsTotalSize() <<
         "<tr><td>Average length ratio of run-length encoded sequence over raw sequence"
-        "<td class=right>" << setprecision(4) << double(reads.readRepeatCounts.totalSize()) / double(assemblerInfo->baseCount) <<
+        "<td class=right>" << setprecision(4) << double(reads.getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) <<
         "<tr><td>Number of reads flagged as palindromic"
         "<td class=right>" << assemblerInfo->palindromicReadCount <<
         "<tr><td>Number of reads flagged as chimeric"
@@ -691,14 +691,14 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Average number of markers per raw base"
         "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(assemblerInfo->baseCount) <<
         "<tr><td>Average number of markers per run-length encoded base"
-        "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(reads.readRepeatCounts.totalSize()) <<
+        "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(reads.getRepeatCountsTotalSize()) <<
         "<tr><td>Average base offset between markers in raw sequence"
         "<td class=right>" << setprecision(4) << double(assemblerInfo->baseCount)/double(markers.totalSize()/2) <<
         "<tr><td>Average base offset between markers in run-length encoded sequence"
-        "<td class=right>" << setprecision(4) << double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) <<
+        "<td class=right>" << setprecision(4) << double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) <<
         "<tr><td>Average base gap between markers in run-length encoded sequence"
         "<td class=right>" << setprecision(4) <<
-        double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) <<
+        double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) <<
         "</table>"
         "<ul><li>Here and elsewhere, &quot;raw&quot; refers to the original read sequence, "
         "as opposed to run-length encoded sequence.</ul>"
@@ -867,9 +867,9 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Average read length (for raw read sequence)\": " <<
         assemblerInfo->baseCount / assemblerInfo->readCount << ",\n"
         "    \"Read N50 (for raw read sequence)\": " << assemblerInfo->readN50 << ",\n"
-        "    \"Number of run-length encoded bases\": " << reads.readRepeatCounts.totalSize() << ",\n"
+        "    \"Number of run-length encoded bases\": " << reads.getRepeatCountsTotalSize() << ",\n"
         "    \"Average length ratio of run-length encoded sequence over raw sequence\": " <<
-        setprecision(4) << double(reads.readRepeatCounts.totalSize()) / double(assemblerInfo->baseCount) << ",\n"
+        setprecision(4) << double(reads.getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) << ",\n"
         "    \"Number of reads flagged as palindromic\": " << assemblerInfo->palindromicReadCount << ",\n"
         "    \"Number of reads flagged as chimeric\": " << assemblerInfo->chimericReadCount << "\n"
         "  },\n"
@@ -933,14 +933,14 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Average number of markers per raw base\": "
         << setprecision(4) << double(markers.totalSize()/2)/double(assemblerInfo->baseCount) << ",\n"
         "    \"Average number of markers per run-length encoded base\": "
-        << setprecision(4) << double(markers.totalSize()/2)/double(reads.readRepeatCounts.totalSize()) << ",\n"
+        << setprecision(4) << double(markers.totalSize()/2)/double(reads.getRepeatCountsTotalSize()) << ",\n"
         "    \"Average base offset between markers in raw sequence\": "
         << setprecision(4) << double(assemblerInfo->baseCount)/double(markers.totalSize()/2) << ",\n"
         "    \"Average base offset between markers in run-length encoded sequence\": "
-        << setprecision(4) << double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) << ",\n"
+        << setprecision(4) << double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) << ",\n"
         "    \"Average base gap between markers in run-length encoded sequence\": "
         << setprecision(4) <<
-        double(reads.readRepeatCounts.totalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) << "\n"
+        double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) << "\n"
         "  },\n"
 
 

--- a/src/AssemblerMarkers.cpp
+++ b/src/AssemblerMarkers.cpp
@@ -15,7 +15,7 @@ void Assembler::findMarkers(size_t threadCount)
     MarkerFinder markerFinder(
         assemblerInfo->k,
         kmerTable,
-        reads.reads,
+        reads,
         markers,
         threadCount);
 

--- a/src/LocalMarkerGraph.hpp
+++ b/src/LocalMarkerGraph.hpp
@@ -19,6 +19,7 @@ a group of aligned markers.
 #include "AssemblyGraph.hpp"
 #include "Kmer.hpp"
 #include "MarkerGraph.hpp"
+#include "Reads.hpp"
 
 // Boost libraries.
 #include <boost/graph/adjacency_list.hpp>
@@ -188,8 +189,7 @@ public:
 
     LocalMarkerGraph(
         uint32_t k,
-        LongBaseSequences& reads,
-        const MemoryMapped::VectorOfVectors<uint8_t, uint64_t>& readRepeatCounts,
+        const Reads& reads,
         const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers,
         const MemoryMapped::Vector<MarkerGraph::CompressedVertexId>& globalMarkerGraphVertex,
         const ConsensusCaller&
@@ -263,8 +263,7 @@ private:
 
     // Reference to the global data structure containing all reads and markers
     // (not just those in this local marker graph).
-    LongBaseSequences& reads;
-    const MemoryMapped::VectorOfVectors<uint8_t, uint64_t>& readRepeatCounts;
+    const Reads& reads;
     const MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers;
 
     // A reference to the vector containing the global marker graph vertex id

--- a/src/MarkerFinder.hpp
+++ b/src/MarkerFinder.hpp
@@ -3,6 +3,7 @@
 
 #include "Marker.hpp"
 #include "MultithreadedObject.hpp"
+#include "Reads.hpp"
 
 namespace shasta {
     class MarkerFinder;
@@ -24,7 +25,7 @@ public:
     MarkerFinder(
         size_t k,
         const MemoryMapped::Vector<KmerInfo>& kmerTable,
-        LongBaseSequences& reads,
+        const Reads& reads,
         MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers,
         size_t threadCount);
 
@@ -33,7 +34,7 @@ private:
     // The arguments passed to the constructor.
     size_t k;
     const MemoryMapped::Vector<KmerInfo>& kmerTable;
-    LongBaseSequences& reads;
+    const Reads& reads;
     MemoryMapped::VectorOfVectors<CompressedMarker, uint64_t>& markers;
     size_t threadCount;
 

--- a/src/span.hpp
+++ b/src/span.hpp
@@ -14,16 +14,16 @@
 namespace shasta {
     template<class T> class span;
 
-    // Output a span<char> as a string.
-    inline ostream& operator<<(ostream&, const span<char>&);
+    // Output a span<const char> as a string.
+    inline ostream& operator<<(ostream&, const span<const char>&);
 
-    // Convert a span<char> to an integer.
+    // Convert a span<const char> to an integer.
     // This cannot be done using std::atol because the
-    // span<char> is not null terminated.
-    uint64_t atoul(const span<char>&);
+    // span<const char> is not null terminated.
+    uint64_t atoul(const span<const char>&);
 
-    // Convert a span<char> to an std::string.
-    string convertToString(const span<char>&);
+    // Convert a span<const char> to an std::string.
+    string convertToString(const span<const char>&);
 }
 
 
@@ -110,21 +110,21 @@ private:
 
 
 
-// Output a span<char> as a string.
+// Output a span<const char> as a string.
 inline std::ostream& shasta::operator<<(
     std::ostream& s,
-    const shasta::span<char>&  m)
+    const shasta::span<const char>&  m)
 {
     copy(m.begin(), m.end(), ostream_iterator<char>(s));
     return s;
 }
 
 
-// Convert a span<char> to an integer.
+// Convert a span<const char> to an integer.
 // This cannot be done using std::atol because the
-// span<char> is not null terminated.
+// span<const char> is not null terminated.
 // The string can only contain numeric characters.
-inline uint64_t shasta::atoul(const span<char>& s)
+inline uint64_t shasta::atoul(const span<const char>& s)
 {
     uint64_t n = 0;
     for(uint64_t i=0; ; i++) {
@@ -145,8 +145,8 @@ inline uint64_t shasta::atoul(const span<char>& s)
 
 
 
-// Convert a span<char> to an std::string.
-inline std::string shasta::convertToString(const span<char>& m)
+// Convert a span<const char> to an std::string.
+inline std::string shasta::convertToString(const span<const char>& m)
 {
     return string(m.begin(), m.size());
 }


### PR DESCRIPTION
`LongBaseSequences::operator[]` needs a `const` overload to cleanup dependent code. There're a couple different ways to accomplish that. This one feels the cleanest - I am open to be convinced otherwise. 

While tightening the `const` screws, I had to do the modifications in `span.hpp` as well. 

### Test Plan
1. Ran an E-Coli assembly.
2. Explored said assembly using the HTTP server.