### PR TITLE
Reduce coverage to the desired value if applicable.

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -171,6 +171,7 @@ public:
     void addReads(
         const string& fileName,
         uint64_t minReadLength,
+        uint64_t desiredCoverage,
         bool noCache,
         size_t threadCount);
 

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -201,6 +201,11 @@ void AssemblerOptions::addConfigurableOptions()
         default_value(10000),
         "Read length cutoff. Shorter reads are discarded.")
 
+        ("Reads.desiredCoverage",
+        value<uint64_t>(&readsOptions.desiredCoverage)->
+        default_value(0),
+        "Desired coverage as a number of bases. Coverage will be reduced to this if necessary.")
+
         ("Reads.noCache",
         bool_switch(&readsOptions.noCache)->
         default_value(false),
@@ -594,6 +599,7 @@ void AssemblerOptions::ReadsOptions::write(ostream& s) const
 {
     s << "[Reads]\n";
     s << "minReadLength = " << minReadLength << "\n";
+    s << "desiredCoverage = " << desiredCoverage << "\n";
     s << "noCache = " <<
         convertBoolToPythonString(noCache) << "\n";
     palindromicReads.write(s);

--- a/src/AssemblerOptions.hpp
+++ b/src/AssemblerOptions.hpp
@@ -106,6 +106,7 @@ public:
     public:
         int minReadLength;
         bool noCache;
+        uint64_t desiredCoverage;
         class PalindromicReadOptions {
         public:
             bool skipFlagging;

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -13,6 +13,7 @@ using namespace shasta;
 void Assembler::addReads(
     const string& fileName,
     uint64_t minReadLength,
+    uint64_t desiredCoverage,
     bool noCache,
     const size_t threadCount)
 {
@@ -22,6 +23,7 @@ void Assembler::addReads(
     ReadLoader readLoader(
         fileName,
         minReadLength,
+        desiredCoverage,
         noCache,
         threadCount,
         largeDataFileNamePrefix,
@@ -57,7 +59,7 @@ void Assembler::addReads(
 // in run-length representation.
 void Assembler::histogramReadLength(const string& fileName)
 {
-    reads.computeAndWriteReadLengthHistogram(fileName);
+    reads.writeReadLengthHistogram(fileName);
 
     cout << "Discarded read statistics for all input files:" << endl;;
     cout << "    Discarded " << assemblerInfo->discardedInvalidBaseReadCount <<

--- a/src/LongBaseSequence.cpp
+++ b/src/LongBaseSequence.cpp
@@ -16,6 +16,14 @@ void LongBaseSequences::createNew(
         baseCount.createNew(name + "-BaseCount", pageSize);
         data.createNew(name + "-Bases", pageSize);
     }
+    this->name = name;
+}
+
+void LongBaseSequences::rename(const string& name) {
+    if (!name.empty()) {
+        baseCount.rename(name + "-BaseCount");
+        data.rename(name + "-Bases");
+    }
 }
 
 

--- a/src/LongBaseSequence.hpp
+++ b/src/LongBaseSequence.hpp
@@ -286,6 +286,12 @@ public:
         return baseCount.size() == 0;
     }
 
+    string getName() const {
+        return name;
+    }
+
+    void rename(const string& name);
+
     // Append a new sequence at the end.
     void append(const LongBaseSequenceView&);
     void append(const vector<Base>&);
@@ -298,6 +304,8 @@ private:
 
     // The data for all the sequences.
     MemoryMapped::VectorOfVectors<uint64_t, uint64_t> data;
+
+    string name;
 
 };
 

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -27,6 +27,7 @@ public:
     ReadLoader(
         const string& fileName,
         uint64_t minReadLength,
+        uint64_t desiredCoverage,
         bool noCache,
         size_t threadCount,
         const string& dataNamePrefix,
@@ -55,6 +56,9 @@ private:
 
     // The minimum read length. Shorter reads are not stored.
     const uint64_t minReadLength;
+
+    // Desired coverage as a number of bases. Reads are dropped if necessary to arrive at this number.
+    const uint64_t desiredCoverage;
 
     // If set, use the O_DIRECT flag when opening input files (Linux only).
     bool noCache;
@@ -87,16 +91,20 @@ private:
 
     // Vectors where each thread stores the reads it found.
     // Indexed by threadId.
-    vector< shared_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadNames;
-    vector< shared_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadMetaData;
+    vector< shared_ptr<Reads::ReadNamesType> > threadReadNames;
+    vector< shared_ptr<Reads::ReadMetaDataType> > threadReadMetaData;
     vector< shared_ptr<LongBaseSequences> > threadReads;
-    vector< shared_ptr<MemoryMapped::VectorOfVectors<uint8_t, uint64_t> > > threadReadRepeatCounts;
+    vector< shared_ptr<Reads::ReadRepeatCountsType> > threadReadRepeatCounts;
+    
     void allocatePerThreadDataStructures();
     void allocatePerThreadDataStructures(size_t threadId);
 
     // Store the reads computed by each thread and free
     // the per-thread data structures.
     void storeReads();
+
+    // Remove reads if necessary to adjust to desired coverage.
+    void adjustForDesiredCoverage();
 
     // Functions used for fasta files.
     void processFastaFile();

--- a/src/Reads.cpp
+++ b/src/Reads.cpp
@@ -15,11 +15,19 @@ void Reads::createNew(
     const string& readFlagsDataName,
     uint64_t largeDataPageSize)
 {
-    reads.createNew(readsDataName, largeDataPageSize);
-    readNames.createNew(readNamesDataName, largeDataPageSize);
-    readMetaData.createNew(readMetaDataDataName, largeDataPageSize);
-    readRepeatCounts.createNew(readRepeatCountsDataName, largeDataPageSize);
-    readFlags.createNew(readFlagsDataName, largeDataPageSize);
+    reads = make_unique<LongBaseSequences>();
+    readNames = make_unique<ReadNamesType>();
+    readMetaData = make_unique<ReadMetaDataType>();
+    readRepeatCounts = make_unique<ReadRepeatCountsType>();
+    readFlags = make_unique<ReadFlagsType>();
+
+    reads->createNew(readsDataName, largeDataPageSize);
+    readNames->createNew(readNamesDataName, largeDataPageSize);
+    readMetaData->createNew(readMetaDataDataName, largeDataPageSize);
+    readRepeatCounts->createNew(readRepeatCountsDataName, largeDataPageSize);
+    readFlags->createNew(readFlagsDataName, largeDataPageSize);
+
+    this->largeDataPageSize = largeDataPageSize;
 }
 
 void Reads::access(
@@ -29,16 +37,22 @@ void Reads::access(
     const string& readRepeatCountsDataName,
     const string& readFlagsDataName)
 {
-    reads.accessExistingReadWrite(readsDataName);
-    readNames.accessExistingReadWrite(readNamesDataName);
-    readMetaData.accessExistingReadWrite(readMetaDataDataName);
-    readRepeatCounts.accessExistingReadWrite(readRepeatCountsDataName);
-    readFlags.accessExistingReadWrite(readFlagsDataName);
+    reads = make_unique<LongBaseSequences>();
+    readNames = make_unique<ReadNamesType>();
+    readMetaData = make_unique<ReadMetaDataType>();
+    readRepeatCounts = make_unique<ReadRepeatCountsType>();
+    readFlags = make_unique<ReadFlagsType>();
+
+    reads->accessExistingReadWrite(readsDataName);
+    readNames->accessExistingReadWrite(readNamesDataName);
+    readMetaData->accessExistingReadWrite(readMetaDataDataName);
+    readRepeatCounts->accessExistingReadWrite(readRepeatCountsDataName);
+    readFlags->accessExistingReadWrite(readFlagsDataName);
 }
 
 
 void Reads::checkIfAChimericIsAlsoInSmallComponent() const {
-    for (const ReadFlags& flags: readFlags) {
+    for (const ReadFlags& flags: *readFlags) {
         if (flags.isChimeric) {
             SHASTA_ASSERT(flags.isInSmallComponent);
         }
@@ -51,7 +65,7 @@ Base Reads::getOrientedReadBase(
     OrientedReadId orientedReadId,
     uint32_t position) const
 {
-    const auto& read = reads[orientedReadId.getReadId()];
+    const auto& read = (*reads)[orientedReadId.getReadId()];
     if(orientedReadId.getStrand() == 0) {
         return read[position];
     } else {
@@ -70,8 +84,8 @@ pair<Base, uint8_t> Reads::getOrientedReadBaseAndRepeatCount(
     const Strand strand = orientedReadId.getStrand();
 
     // Access the bases and repeat counts for this read.
-    const auto& read = reads[readId];
-    const auto& counts = readRepeatCounts[readId];
+    const auto& read = (*reads)[readId];
+    const auto& counts = (*readRepeatCounts)[readId];
 
     // Compute the position as stored, depending on strand.
     uint32_t orientedPosition = position;
@@ -97,7 +111,7 @@ vector<Base> Reads::getOrientedReadRawSequence(OrientedReadId orientedReadId) co
     vector<Base> sequence;
 
     // The number of bases stored, in run-length representation.
-    const uint32_t storedBaseCount = uint32_t(reads[orientedReadId.getReadId()].baseCount);
+    const uint32_t storedBaseCount = uint32_t((*reads)[orientedReadId.getReadId()].baseCount);
 
 
     // We are storing a run-length representation of the read.
@@ -117,15 +131,15 @@ vector<Base> Reads::getOrientedReadRawSequence(OrientedReadId orientedReadId) co
 // Return the length of the raw sequence of a read.
 // If using the run-length representation of reads, this counts each
 // base a number of times equal to its repeat count.
-size_t Reads::getReadRawSequenceLength(ReadId readId) const
+uint64_t Reads::getReadRawSequenceLength(ReadId readId) const
 {
     // We are using the run-length representation.
     // The number of raw bases equals the sum of all
     // the repeat counts.
     // Don't use std::accumulate to compute the sum,
     // otherwise the sum is computed using uint8_t!
-    const auto& counts = readRepeatCounts[readId];
-    size_t sum = 0;;
+    const auto& counts = (*readRepeatCounts)[readId];
+    uint64_t sum = 0;;
     for(uint8_t count: counts) {
         sum += count;
     }
@@ -141,13 +155,13 @@ vector<uint32_t> Reads::getRawPositions(OrientedReadId orientedReadId) const
 {
     const ReadId readId = orientedReadId.getReadId();
     const ReadId strand = orientedReadId.getStrand();
-    const auto repeatCounts = readRepeatCounts[readId];
-    const size_t n = repeatCounts.size();
+    const auto repeatCounts = (*readRepeatCounts)[readId];
+    const uint64_t n = repeatCounts.size();
 
     vector<uint32_t> v;
 
     uint32_t position = 0;
-    for(size_t i=0; i<n; i++) {
+    for(uint64_t i=0; i<n; i++) {
         v.push_back(position);
         uint8_t count;
         if(strand == 0) {
@@ -168,12 +182,12 @@ vector<uint32_t> Reads::getRawPositions(OrientedReadId orientedReadId) const
 // without embedded spaces in each Key=Value pair.
 span<const char> Reads::getMetaData(ReadId readId, const string& key) const
 {
-    SHASTA_ASSERT(readId < readMetaData.size());
+    SHASTA_ASSERT(readId < readMetaData->size());
     const uint64_t keySize = key.size();
     char* keyBegin = const_cast<char*>(&key[0]);
     char* keyEnd = keyBegin + keySize;
-    const char* begin = readMetaData.begin(readId);
-    const char* end = readMetaData.end(readId);
+    const char* begin = readMetaData->begin(readId);
+    const char* end = readMetaData->end(readId);
 
 
     const char* p = begin;
@@ -224,7 +238,7 @@ span<const char> Reads::getMetaData(ReadId readId, const string& key) const
 void Reads::writeReads(const string& fileName)
 {
     ofstream file(fileName);
-    for(ReadId readId=0; readId<reads.size(); readId++) {
+    for(ReadId readId=0; readId<reads->size(); readId++) {
         writeRead(readId, file);
     }
 }
@@ -244,8 +258,8 @@ void Reads::writeRead(ReadId readId, ostream& file)
     checkReadId(readId);
 
     const vector<Base> rawSequence = getOrientedReadRawSequence(OrientedReadId(readId, 0));
-    const auto readName = readNames[readId];
-    const auto metaData = readMetaData[readId];
+    const auto readName = (*readNames)[readId];
+    const auto metaData = (*readMetaData)[readId];
 
     file << ">";
     copy(readName.begin(), readName.end(), ostream_iterator<char>(file));
@@ -281,7 +295,7 @@ void Reads::writeOrientedRead(OrientedReadId orientedReadId, ostream& file)
     checkReadNamesAreOpen();
 
     const vector<Base> rawSequence = getOrientedReadRawSequence(orientedReadId);
-    const auto readName = readNames[orientedReadId.getReadId()];
+    const auto readName = (*readNames)[orientedReadId.getReadId()];
 
     file << ">" << orientedReadId;
     file << " " << rawSequence.size() << " ";
@@ -295,8 +309,9 @@ void Reads::writeOrientedRead(OrientedReadId orientedReadId, ostream& file)
 // All lengths here are raw sequence lengths
 // (length of the original read), not lengths
 // in run-length representation.
-void Reads::computeAndWriteReadLengthHistogram(const string& fileName) {
+void Reads::computeReadLengthHistogram() {
     checkReadsAreOpen();
+    histogram.clear();
     // Create the histogram.
     // It contains the number of reads of each length.
     // Indexed by the length.
@@ -304,7 +319,7 @@ void Reads::computeAndWriteReadLengthHistogram(const string& fileName) {
     totalBaseCount = 0;
     
     for(ReadId readId=0; readId<totalReadCount; readId++) {
-        const size_t length = getReadRawSequenceLength(readId);
+        const uint64_t length = getReadRawSequenceLength(readId);
         totalBaseCount += length;
         if(histogram.size() <= length) {
             histogram.resize(length+1, 0);
@@ -312,17 +327,38 @@ void Reads::computeAndWriteReadLengthHistogram(const string& fileName) {
         ++(histogram[length]);
     }
 
+    // Create binned histogram.
+    binnedHistogram.clear();
+    const uint64_t binWidth = 1000;
+    for(uint64_t length=0; length<histogram.size(); length++) {
+        const uint64_t readCount = histogram[length];
+        if(readCount) {
+            const uint64_t bin = length / binWidth;
+            if(binnedHistogram.size() <= bin) {
+                binnedHistogram.resize(bin+1, make_pair(0, 0));
+            }
+            binnedHistogram[bin].first += readCount;
+            binnedHistogram[bin].second += readCount * length;
+        }
+    }
+
+}
+
+void Reads::writeReadLengthHistogram(const string& fileName) {
+    checkReadsAreOpen();
+    uint64_t totalReadCount = readCount();
+
     n50 = 0;
     {
         ofstream csv(fileName);
         csv << "Length,Reads,Bases,CumulativeReads,CumulativeBases,"
             "FractionalCumulativeReads,FractionalCumulativeBases,\n";
-        size_t cumulativeReadCount = totalReadCount;
-        size_t cumulativeBaseCount = totalBaseCount;
-        for(size_t length=0; length<histogram.size(); length++) {
-            const size_t frequency = histogram[length];
+        uint64_t cumulativeReadCount = totalReadCount;
+        uint64_t cumulativeBaseCount = totalBaseCount;
+        for(uint64_t length=0; length<histogram.size(); length++) {
+            const uint64_t frequency = histogram[length];
             if(frequency) {
-                const  size_t baseCount = frequency * length;
+                const  uint64_t baseCount = frequency * length;
                 const double cumulativeReadFraction =
                     double(cumulativeReadCount)/double(totalReadCount);
                 const double comulativeBaseFraction =
@@ -338,7 +374,6 @@ void Reads::computeAndWriteReadLengthHistogram(const string& fileName) {
                 }
             }
         }
-        
         SHASTA_ASSERT(cumulativeReadCount == 0);
         SHASTA_ASSERT(cumulativeBaseCount == 0);
     }
@@ -346,27 +381,15 @@ void Reads::computeAndWriteReadLengthHistogram(const string& fileName) {
     // Binned Histogram.
     {
         const uint64_t binWidth = 1000;
-        for(size_t length=0; length<histogram.size(); length++) {
-            const size_t readCount = histogram[length];
-            if(readCount) {
-                const size_t bin = length / binWidth;
-                if(binnedHistogram.size() <= bin) {
-                    binnedHistogram.resize(bin+1, make_pair(0, 0));
-                }
-                binnedHistogram[bin].first += readCount;
-                binnedHistogram[bin].second += readCount * length;
-            }
-        }
-
         ofstream csv("Binned-" + fileName);
         csv << "LengthBegin,LengthEnd,Reads,Bases,CumulativeReads,CumulativeBases,"
             "FractionalCumulativeReads,FractionalCumulativeBases,\n";
-        size_t cumulativeReadCount = totalReadCount;
-        size_t cumulativeBaseCount = totalBaseCount;
-        for(size_t bin=0; bin<binnedHistogram.size(); bin++) {
+        uint64_t cumulativeReadCount = totalReadCount;
+        uint64_t cumulativeBaseCount = totalBaseCount;
+        for(uint64_t bin=0; bin<binnedHistogram.size(); bin++) {
             const auto& histogramBin = binnedHistogram[bin];
-            const size_t readCount = histogramBin.first;
-            const size_t baseCount = histogramBin.second;
+            const uint64_t readCount = histogramBin.first;
+            const uint64_t baseCount = histogramBin.second;
             const double cumulativeReadFraction =
                 double(cumulativeReadCount)/double(totalReadCount);
             const double comulativeBaseFraction =

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -6,6 +6,8 @@
 namespace shasta {
     using std::make_shared;
     using std::shared_ptr;
+    using std::make_unique;
+    using std::unique_ptr;
 }
 
 #endif

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -478,6 +478,7 @@ void shasta::main::assemble(
         assembler.addReads(
             inputFileName,
             assemblerOptions.readsOptions.minReadLength,
+            assemblerOptions.readsOptions.desiredCoverage,
             assemblerOptions.readsOptions.noCache,
             threadCount);
     }
@@ -488,13 +489,10 @@ void shasta::main::assemble(
     cout << timestamp << "Done loading reads from " << inputFileNames.size() << " files." << endl;
     cout << "Read loading took " << seconds(t1-t0) << "s." << endl;
 
-
-    // Create a histogram of read lengths.
+    // Log the read length histogram.
     assembler.histogramReadLength("ReadLengthHistogram.csv");
 
-
-
-    // Select the k-mers that will be used as markers.
+        // Select the k-mers that will be used as markers.
     switch(assemblerOptions.kmersOptions.generationMethod) {
     case 0:
         assembler.randomlySelectKmers(


### PR DESCRIPTION
Desired coverage, as a number of raw bases, can be set using the new configuration parameter -  `Reads.desiredCoverage`. This value will be auto-generated by the `GenerateConfig.py` script (different PR). `Reads.minReadLength` should now default to a potentially smaller value (from the current default value of 10,000). 

- If there isn't enough coverage available with reads longer than `Reads.minReadLength`, the program will abort. 
- If more than desired coverage is available with reads longer than `Reads.minReadLength`, then Shasta will increase the value of `minReadLength` to arrive close to the desired coverage

