### PR TITLE
Reduce coverage to desired value if applicable.

### DIFF
--- a/src/Assembler.cpp
+++ b/src/Assembler.cpp
@@ -24,7 +24,8 @@ Assembler::Assembler(
         assemblerInfo->largeDataPageSize = largeDataPageSizeArgument;
         largeDataPageSize = largeDataPageSizeArgument;
 
-        reads.createNew(
+        reads = make_unique<Reads>();
+        reads->createNew(
             largeDataName("Reads"),
             largeDataName("ReadNames"),
             largeDataName("ReadMetaData"),
@@ -40,7 +41,8 @@ Assembler::Assembler(
         assemblerInfo.accessExistingReadWrite(largeDataName("Info"));
         largeDataPageSize = assemblerInfo->largeDataPageSize;
 
-        reads.access(
+        reads = make_unique<Reads>();
+        reads->access(
             largeDataName("Reads"),
             largeDataName("ReadNames"),
             largeDataName("ReadMetaData"),

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -108,6 +108,7 @@ public:
     size_t readCount = 0;
     size_t baseCount = 0;
     size_t readN50 = 0;
+    uint64_t minReadLength = 0;
 
     // Other read statistics.
     size_t palindromicReadCount = 0;
@@ -461,10 +462,7 @@ public:
         return *reads;
     }
 
-    void adjustCoverage(
-        uint64_t minReadLength,
-        uint64_t desiredCoverage
-    );
+    uint64_t adjustCoverageAndGetNewMinReadLength(uint64_t desiredCoverage);
 
     // Write a csv file with summary information for each read.
 public:

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -454,13 +454,18 @@ private:
     MemoryMapped::Object<AssemblerInfo> assemblerInfo;
 
     // Reads in RLE representation.
-    Reads reads;
+    unique_ptr<Reads> reads;
 public:
     const Reads& getReads() const {
-        return reads;
+        SHASTA_ASSERT(reads);
+        return *reads;
     }
 
-    
+    void adjustCoverage(
+        uint64_t minReadLength,
+        uint64_t desiredCoverage
+    );
+
     // Write a csv file with summary information for each read.
 public:
     void writeReadsSummary();

--- a/src/AssemblerAlignmentGraph.cpp
+++ b/src/AssemblerAlignmentGraph.cpp
@@ -31,7 +31,7 @@ bool Assembler::createLocalAlignmentGraph(
 
     // Add the starting vertex.
     graph.addVertex(orientedReadIdStart,
-        uint32_t(reads.getRead(orientedReadIdStart.getReadId()).baseCount), 0);
+        uint32_t(reads->getRead(orientedReadIdStart.getReadId()).baseCount), 0);
 
     // Initialize a BFS starting at the start vertex.
     std::queue<OrientedReadId> q;
@@ -87,7 +87,7 @@ bool Assembler::createLocalAlignmentGraph(
             if(distance0 < maxDistance) {
                 if(!graph.vertexExists(orientedReadId1)) {
                     graph.addVertex(orientedReadId1,
-                        uint32_t(reads.getRead(orientedReadId1.getReadId()).baseCount), distance1);
+                        uint32_t(reads->getRead(orientedReadId1.getReadId()).baseCount), distance1);
                     q.push(orientedReadId1);
                 }
                 graph.addEdge(orientedReadId0, orientedReadId1,
@@ -109,7 +109,7 @@ bool Assembler::createLocalAlignmentGraph(
             // we already reached the maximum distance.
             if(!graph.vertexExists(orientedReadId1)) {
                 graph.addVertex(orientedReadId1,
-                    uint32_t(reads.getRead(orientedReadId1.getReadId()).baseCount), distance1);
+                    uint32_t(reads->getRead(orientedReadId1.getReadId()).baseCount), distance1);
                 if(distance1 < maxDistance) {
                     q.push(orientedReadId1);
                     // cout << "Enqueued " << orientedReadId1 << endl;

--- a/src/AssemblerAnalyzePaths.cpp
+++ b/src/AssemblerAnalyzePaths.cpp
@@ -302,8 +302,8 @@ void Assembler::analyzeOrientedReadPaths() const
     // This vector is indexed by OrientedReadId::getValue().
     vector<MarkerGraph::EdgeId> path;
     vector< pair<uint32_t, uint32_t> > pathOrdinals;
-    vector<PseudoPath> pseudoPaths(2*reads.readCount());
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    vector<PseudoPath> pseudoPaths(2*reads->readCount());
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             computePseudoPath(orientedReadId, path, pathOrdinals,
@@ -316,7 +316,7 @@ void Assembler::analyzeOrientedReadPaths() const
     // Write a csv file with the pseudo-path of each oriented read.
     {
         ofstream csv("PseudoPaths.csv");
-        for(ReadId readId=0; readId<reads.readCount(); readId++) {
+        for(ReadId readId=0; readId<reads->readCount(); readId++) {
             for(Strand strand=0; strand<2; strand++) {
                 const OrientedReadId orientedReadId(readId, strand);
                 csv << orientedReadId << ",";
@@ -337,7 +337,7 @@ void Assembler::analyzeOrientedReadPaths() const
     // For each segmentId, we store a vector of pairs (orientedReadId, ordinal) such that
     // pseudoPaths[orientedReadId.getValue()][ordinal] == segmentId
     vector< vector< pair<OrientedReadId, uint64_t> > >  pseudoPathTable(segmentCount);
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             const PseudoPath& pseudoPath = pseudoPaths[orientedReadId.getValue()];
@@ -499,7 +499,7 @@ void Assembler::analyzeOrientedReadPaths() const
     // The alignment table contains, for each oriented reads,
     // pairs (index in orientedReadPairs, score).
     // it is indexed by OrientedReadId::getValue(0.
-    vector< vector< pair<uint64_t, int64_t> > > alignmentTable(2 * reads.readCount());
+    vector< vector< pair<uint64_t, int64_t> > > alignmentTable(2 * reads->readCount());
     for(uint64_t i=0; i<orientedReadPairs.size(); i++) {
 
         // Skip this pair if we already decided not to use it.
@@ -560,9 +560,9 @@ void Assembler::analyzeOrientedReadPaths() const
 
     // Vector to contain, for each oriented read, the starting point of
     // its pseudo-path in the disjoint set data structure.
-    vector<uint64_t> start(2*reads.readCount(), std::numeric_limits<uint64_t>::max());
+    vector<uint64_t> start(2*reads->readCount(), std::numeric_limits<uint64_t>::max());
     uint64_t n = 0;
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             const PseudoPath& pseudoPath = pseudoPaths[orientedReadId.getValue()];
@@ -631,9 +631,9 @@ void Assembler::analyzeOrientedReadPaths() const
 
     // Each of the disjoint data sets becomes a vertex of the MetaMarkerGraph.
     // Store the disjoint set for each position of the pseudo-path of each oriented read.
-    vector< vector<uint64_t> > vertexTable(2*reads.readCount());
+    vector< vector<uint64_t> > vertexTable(2*reads->readCount());
     vector< vector< pair<OrientedReadId, uint64_t > > > vertices(n);
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             const PseudoPath& pseudoPath = pseudoPaths[orientedReadId.getValue()];

--- a/src/AssemblerAssemblyGraph.cpp
+++ b/src/AssemblerAssemblyGraph.cpp
@@ -570,7 +570,7 @@ void Assembler::assemble(
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
     checkMarkerGraphEdgesIsOpen();

--- a/src/AssemblerConflictReadGraph.cpp
+++ b/src/AssemblerConflictReadGraph.cpp
@@ -46,7 +46,7 @@ void Assembler::createConflictReadGraph(
 
     // Initialize the conflict read graph.
     conflictReadGraph.createNew(largeDataName("ConflictReadGraph"), largeDataPageSize);
-    conflictReadGraph.createVertices(reads.readCount());
+    conflictReadGraph.createVertices(reads->readCount());
 
 #if 0
     // Compute leftTrim, rightTrim, longestGap for each vertex.
@@ -67,8 +67,8 @@ void Assembler::createConflictReadGraph(
     }
 
     // Add edges.
-    conflictReadGraph.edges.reserve(10 * reads.readCount());
-    setupLoadBalancing(reads.readCount(), 1);
+    conflictReadGraph.edges.reserve(10 * reads->readCount());
+    setupLoadBalancing(reads->readCount(), 1);
     runThreads(&Assembler::createConflictReadGraphThreadFunction2, threadCount);
     conflictReadGraph.edges.unreserve();
     conflictReadGraph.computeConnectivity();

--- a/src/AssemblerDirectedReadGraph.cpp
+++ b/src/AssemblerDirectedReadGraph.cpp
@@ -9,11 +9,11 @@ void Assembler::createDirectedReadGraph(
 {
     // Initialize the directed read graph.
     directedReadGraph.createNew(largeDataName("DirectedReadGraph"), largeDataPageSize);
-    directedReadGraph.createVertices(reads.readCount());
+    directedReadGraph.createVertices(reads->readCount());
 
     // Store the number of bases in each oriented read.
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
-        const uint32_t baseCount = uint32_t(reads.getReadRawSequenceLength(readId));
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
+        const uint32_t baseCount = uint32_t(reads->getReadRawSequenceLength(readId));
         const uint32_t markerCount = uint32_t(markers.size(OrientedReadId(readId, 0).getValue()));
         DirectedReadGraphVertex& vertex0 = directedReadGraph.getVertex(OrientedReadId(readId, 0).getValue());
         DirectedReadGraphVertex& vertex1 = directedReadGraph.getVertex(OrientedReadId(readId, 1).getValue());
@@ -40,14 +40,14 @@ void Assembler::createDirectedReadGraph(
     // Count the number of isolated reads and their bases.
     uint64_t isolatedReadCount = 0;
     uint64_t isolatedReadBaseCount = 0;
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         const OrientedReadId orientedReadId(readId, 0);
         const DirectedReadGraph::VertexId vertexId = orientedReadId.getValue();
         if(directedReadGraph.totalDegree(vertexId) > 0) {
             continue;
         }
         ++isolatedReadCount;
-        isolatedReadBaseCount += reads.getReadRawSequenceLength(readId);
+        isolatedReadBaseCount += reads->getReadRawSequenceLength(readId);
     }
     assemblerInfo->isolatedReadCount = isolatedReadCount;
     assemblerInfo->isolatedReadBaseCount = isolatedReadBaseCount;

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -41,7 +41,7 @@ void Assembler::exploreAlignments(
         "<input type=submit value='Show alignments involving read'> "
         "<input type=text name=readId required" <<
         (readId0IsPresent ? (" value=" + to_string(readId0)) : "") <<
-        " size=8 title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " size=8 title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
     html << "</form>";
@@ -352,13 +352,13 @@ void Assembler::exploreAlignment(
         "&nbsp of read &nbsp"
         "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
-        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand0", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
     html <<
         "&nbsp and read <input type=text name=readId1 required size=8 " <<
         (readId1IsPresent ? "value="+to_string(readId1) : "") <<
-        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand1", strand1IsPresent && strand1==0, strand1IsPresent && strand1==1);
 
@@ -1056,7 +1056,7 @@ void Assembler::computeAllAlignments(
         "&nbsp of oriented read &nbsp"
         "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
-        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand0", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
 
@@ -1098,7 +1098,7 @@ void Assembler::computeAllAlignments(
     const size_t threadCount =std::thread::hardware_concurrency();
     computeAllAlignmentsData.threadAlignments.resize(threadCount);
     const size_t batchSize = 1000;
-    setupLoadBalancing(reads.readCount(), batchSize);
+    setupLoadBalancing(reads->readCount(), batchSize);
     const auto t0 = std::chrono::steady_clock::now();
     runThreads(&Assembler::computeAllAlignmentsThreadFunction, threadCount);
     const auto t1 = std::chrono::steady_clock::now();
@@ -1127,9 +1127,9 @@ void Assembler::computeAllAlignments(
     // it for large assemblies.
     size_t computedAlignmentCount = 0;
     const auto t0 = std::chrono::steady_clock::now();
-    for(ReadId readId1=0; readId1<reads.readCount(); readId1++) {
+    for(ReadId readId1=0; readId1<reads->readCount(); readId1++) {
         if((readId1 % 10000) == 0) {
-            cout << timestamp << readId1 << "/" << reads.readCount() << " " << alignments.size() << endl;
+            cout << timestamp << readId1 << "/" << reads->readCount() << " " << alignments.size() << endl;
         }
         for(Strand strand1=0; strand1<2; strand1++) {
 
@@ -1201,7 +1201,7 @@ void Assembler::sampleReads(vector<OrientedReadId>& sample, uint64_t n){
 
     while (sample.size() < n) {
         // Randomly select a read in the read set
-        const ReadId readId = uint32_t(rand() % reads.readCount());
+        const ReadId readId = uint32_t(rand() % reads->readCount());
 
         // Randomly select an orientation
         const Strand strand = uint32_t(rand() % 2);
@@ -1216,7 +1216,7 @@ void Assembler::sampleReads(vector<OrientedReadId>& sample, uint64_t n, uint64_t
 
     while (sample.size() < n) {
         // Randomly select a read in the read set
-        const ReadId readId = uint32_t(rand() % reads.readCount());
+        const ReadId readId = uint32_t(rand() % reads->readCount());
 
         // Randomly select an orientation
         const Strand strand = uint32_t(rand() % 2);
@@ -1224,7 +1224,7 @@ void Assembler::sampleReads(vector<OrientedReadId>& sample, uint64_t n, uint64_t
         const OrientedReadId r(readId, strand);
 
         // Number of raw bases.
-        const auto repeatCounts = reads.getReadRepeatCounts(readId);
+        const auto repeatCounts = reads->getReadRepeatCounts(readId);
         uint64_t length = 0;
         for(const auto repeatCount: repeatCounts) {
             length += repeatCount;
@@ -1375,7 +1375,7 @@ void Assembler::assessAlignments(
         const size_t threadCount = std::thread::hardware_concurrency();
         computeAllAlignmentsData.threadAlignments.resize(threadCount);
         const size_t batchSize = 1;
-        setupLoadBalancing(reads.readCount(), batchSize);
+        setupLoadBalancing(reads->readCount(), batchSize);
         const auto t0 = std::chrono::steady_clock::now();
         runThreads(&Assembler::computeAllAlignmentsThreadFunction, threadCount);
         const auto t1 = std::chrono::steady_clock::now();
@@ -1595,7 +1595,7 @@ void Assembler::exploreAlignmentGraph(
 
         "<table>"
 
-        "<tr title='Read id between 0 and " << reads.readCount()-1 << "'>"
+        "<tr title='Read id between 0 and " << reads->readCount()-1 << "'>"
         "<td>Read id"
         "<td><input type=text required name=readId size=8 style='text-align:center'"
         << (readIdIsPresent ? ("value='"+to_string(readId)+"'") : "") <<
@@ -1657,9 +1657,9 @@ void Assembler::exploreAlignmentGraph(
 
 
     // Validity checks.
-    if(readId > reads.readCount()) {
+    if(readId > reads->readCount()) {
         html << "<p>Invalid read id " << readId;
-        html << ". Must be between 0 and " << reads.readCount()-1 << ".";
+        html << ". Must be between 0 and " << reads->readCount()-1 << ".";
         return;
     }
     if(strand>1) {

--- a/src/AssemblerHttpServer-DirectedReadGraph.cpp
+++ b/src/AssemblerHttpServer-DirectedReadGraph.cpp
@@ -106,7 +106,7 @@ void Assembler::exploreDirectedReadGraph(
         "<div style='float:left;margin:10px;'>"
         "<table>"
 
-        "<tr title='Read id between 0 and " << reads.readCount()-1 << "'>"
+        "<tr title='Read id between 0 and " << reads->readCount()-1 << "'>"
         "<td>Start vertex read id"
         "<td><input type=text required name=readId size=8 style='text-align:center'"
         << (readIdIsPresent ? ("value='"+to_string(readId)+"'") : "") <<
@@ -267,9 +267,9 @@ void Assembler::exploreDirectedReadGraph(
     }
 
     // Validity checks.
-    if(readId > reads.readCount()) {
+    if(readId > reads->readCount()) {
         html << "<p>Invalid read id " << readId;
-        html << ". Must be between 0 and " << reads.readCount()-1 << ".";
+        html << ". Must be between 0 and " << reads->readCount()-1 << ".";
         return;
     }
 
@@ -387,8 +387,8 @@ void Assembler::exploreDirectedReadGraph(
             if(MurmurHash2(&orientedReadId, sizeof(orientedReadId), 117) > hashThreshold) {
                 continue;
             }
-            const vector<Base> sequence = reads.getOrientedReadRawSequence(vertex.orientedReadId);
-            const auto readName = reads.getReadName(vertex.orientedReadId.getReadId());
+            const vector<Base> sequence = reads->getOrientedReadRawSequence(vertex.orientedReadId);
+            const auto readName = reads->getReadName(vertex.orientedReadId.getReadId());
             fastaFile << ">" << vertex.orientedReadId << " ";
             copy(readName.begin(), readName.end(), ostream_iterator<char>(fastaFile));
             fastaFile << "\n";

--- a/src/AssemblerHttpServer-MarkerGraph.cpp
+++ b/src/AssemblerHttpServer-MarkerGraph.cpp
@@ -61,7 +61,7 @@ void Assembler::exploreMarkerGraph(
     // Create the local marker graph.
     LocalMarkerGraph graph(
         uint32_t(assemblerInfo->k),
-        reads,
+        getReads(),
         markers,
         markerGraph.vertexTable,
         *consensusCaller);
@@ -463,7 +463,7 @@ void Assembler::exploreMarkerGraphVertex(const vector<string>& request, ostream&
         for(size_t i=0; i<k; i++) {
             Base base;
             tie(base, repeatCounts[j][i]) =
-                reads.getOrientedReadBaseAndRepeatCount(orientedReadIds[j], uint32_t(marker.position+i));
+                reads->getOrientedReadBaseAndRepeatCount(orientedReadIds[j], uint32_t(marker.position+i));
             SHASTA_ASSERT(base == kmer[i]);
         }
     }
@@ -802,7 +802,7 @@ void Assembler::exploreMarkerGraphEdge(const vector<string>& request, ostream& h
         for(uint32_t position=positionBegin; position!=positionEnd; ++position) {
             Base base;
             uint8_t repeatCount;
-            tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+            tie(base, repeatCount) = reads->getOrientedReadBaseAndRepeatCount(orientedReadId, position);
             sequences[j].push_back(base);
             repeatCounts[j].push_back(repeatCount);
         }
@@ -1166,13 +1166,13 @@ void Assembler::exploreMarkerGraphInducedAlignment(
         "<form>"
         "<input type=text name=readId0 required size=8 " <<
         (readId0IsPresent ? "value="+to_string(readId0) : "") <<
-        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand0", strand0IsPresent && strand0==0, strand0IsPresent && strand0==1);
     html <<
         "<br><input type=text name=readId1 required size=8 " <<
         (readId1IsPresent ? "value="+to_string(readId1) : "") <<
-        " title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand1", strand1IsPresent && strand1==0, strand1IsPresent && strand1==1);
 
@@ -1285,7 +1285,7 @@ void Assembler::exploreMarkerCoverage(
         "<tr><td>Read id<td class=centered>"
         "<input type=text name=readId required style='text-align:center'" <<
         (readIdIsPresent ? (" value=" + to_string(readId)) : "") <<
-        " size=8 title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " size=8 title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         "<tr><td>Strand<td class=centered>";
     writeStrandSelection(html, "strand", strandIsPresent && strand==0, strandIsPresent && strand==1);
     html <<

--- a/src/AssemblerHttpServer-ReadGraph.cpp
+++ b/src/AssemblerHttpServer-ReadGraph.cpp
@@ -127,7 +127,7 @@ void Assembler::exploreUndirectedReadGraph(
          "<div style='float:left;margin:10px;'>"
          "<table>"
 
-         "<tr title='Read id between 0 and " << reads.readCount() - 1 << "'>"
+         "<tr title='Read id between 0 and " << reads->readCount() - 1 << "'>"
          "<td style=\"white-space:pre-wrap; word-wrap:break-word\">"
          "Start vertex reads\n"
          "The oriented read should be in the form <code>readId-strand</code>\n"
@@ -248,9 +248,9 @@ void Assembler::exploreUndirectedReadGraph(
 
     // Validity checks.
     for (auto &readId: readIds){
-        if (readId.getReadId() > reads.readCount()) {
+        if (readId.getReadId() > reads->readCount()) {
             html << "<p>Invalid read id " << readId;
-            html << ". Must be between 0 and " << reads.readCount() - 1 << ".";
+            html << ". Must be between 0 and " << reads->readCount() - 1 << ".";
             return;
         }
     }
@@ -281,8 +281,8 @@ void Assembler::exploreUndirectedReadGraph(
         ofstream fastaFile(fastaFileName);
         BGL_FORALL_VERTICES(v, graph, LocalReadGraph) {
             const LocalReadGraphVertex& vertex = graph[v];
-            const vector<Base> sequence = reads.getOrientedReadRawSequence(vertex.orientedReadId);
-            const auto readName = reads.getReadName(vertex.orientedReadId.getReadId());
+            const vector<Base> sequence = reads->getOrientedReadRawSequence(vertex.orientedReadId);
+            const auto readName = reads->getReadName(vertex.orientedReadId.getReadId());
             fastaFile << ">" << vertex.orientedReadId << " ";
             copy(readName.begin(), readName.end(), ostream_iterator<char>(fastaFile));
             fastaFile << "\n";

--- a/src/AssemblerHttpServer-Reads.cpp
+++ b/src/AssemblerHttpServer-Reads.cpp
@@ -39,7 +39,7 @@ void Assembler::exploreRead(
         "read &nbsp" <<
         "<input type=text name=readId required" <<
         (readIdIsPresent ? (" value=" + to_string(readId)) : "") <<
-        " size=8 title='Enter a read id between 0 and " << reads.readCount()-1 << "'>"
+        " size=8 title='Enter a read id between 0 and " << reads->readCount()-1 << "'>"
         " on strand ";
     writeStrandSelection(html, "strand", strandIsPresent && strand==0, strandIsPresent && strand==1);
     
@@ -74,7 +74,7 @@ void Assembler::exploreRead(
     }
 
     // Access the read.
-    if(readId >= reads.readCount()) {
+    if(readId >= reads->readCount()) {
         html << "<p>Invalid read id.";
         return;
     }
@@ -83,10 +83,10 @@ void Assembler::exploreRead(
         return;
     }
     const OrientedReadId orientedReadId(readId, strand);
-    const vector<Base> rawOrientedReadSequence = reads.getOrientedReadRawSequence(orientedReadId);
-    const auto readStoredSequence = reads.getRead(readId);
-    const auto readName = reads.getReadName(readId);
-    const auto metaData = reads.getReadMetaData(readId);
+    const vector<Base> rawOrientedReadSequence = reads->getOrientedReadRawSequence(orientedReadId);
+    const auto readStoredSequence = reads->getRead(readId);
+    const auto readName = reads->getReadName(readId);
+    const auto metaData = reads->getReadMetaData(readId);
     const auto orientedReadMarkers = markers[orientedReadId.getValue()];
     if(!beginPositionIsPresent) {
         beginPosition = 0;
@@ -281,7 +281,7 @@ void Assembler::exploreRead(
             html << "<pre style='font-family:monospace;margin:0'";
             html << " title='Position in run-length read sequence'>";
 
-            const vector<uint32_t> rawPositions = reads.getRawPositions(orientedReadId);
+            const vector<uint32_t> rawPositions = reads->getRawPositions(orientedReadId);
 
             // Scale.
             bool firstTime = true;
@@ -429,7 +429,7 @@ void Assembler::exploreRead(
     // element for each character).
     // Note that here we display the entire read, regardless of beginPosition and endPosition.
     size_t beginRlePosition, endRlePosition;
-    const vector<uint32_t> rawPositions = reads.getRawPositions(orientedReadId);
+    const vector<uint32_t> rawPositions = reads->getRawPositions(orientedReadId);
     
     if (beginPositionIsPresent) {
         beginRlePosition = std::lower_bound(rawPositions.begin(), rawPositions.end(), beginPosition) - rawPositions.begin();
@@ -512,7 +512,7 @@ void Assembler::exploreRead(
     for(size_t position=beginRlePosition; position!=endRlePosition; position++) {
         Base base;
         uint8_t repeatCount;
-        tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, uint32_t(position));
+        tie(base, repeatCount) = reads->getOrientedReadBaseAndRepeatCount(orientedReadId, uint32_t(position));
         
         html <<
             "<text class='mono'" <<
@@ -547,7 +547,7 @@ void Assembler::exploreRead(
             " y='" << readSequenceLine*verticalSpacing << "'"
             " textLength='" << (blockEnd-blockBegin) * horizontalSpacing<< "'>";
         for(size_t position=beginRlePosition+blockBegin; position<beginRlePosition+blockEnd; position++) {
-            html << reads.getOrientedReadBase(orientedReadId, uint32_t(position));
+            html << reads->getOrientedReadBase(orientedReadId, uint32_t(position));
         }
         html << "</text>";
     }

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -610,6 +610,8 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
 
         "<h3>Reads used in this assembly</h3>"
         "<table>"
+        "<tr><td>Minimum read length"
+        "<td class=right>" << assemblerInfo->minReadLength <<
         "<tr><td>Number of reads"
         "<td class=right>" << assemblerInfo->readCount <<
         "<tr><td>Number of raw sequence bases"
@@ -862,6 +864,7 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
 
         "  \"Reads used in this assembly\":\n"
         "  {\n"
+        "    \"Minimum read length\": " << assemblerInfo->minReadLength << ",\n"
         "    \"Number of reads\": " << assemblerInfo->readCount << ",\n"
         "    \"Number of raw sequence bases\": " << assemblerInfo->baseCount << ",\n"
         "    \"Average read length (for raw read sequence)\": " <<

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -619,9 +619,9 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Read N50 (for raw read sequence)"
         "<td class=right>" << assemblerInfo->readN50 <<
         "<tr><td>Number of run-length encoded bases"
-        "<td class=right>" << reads.getRepeatCountsTotalSize() <<
+        "<td class=right>" << reads->getRepeatCountsTotalSize() <<
         "<tr><td>Average length ratio of run-length encoded sequence over raw sequence"
-        "<td class=right>" << setprecision(4) << double(reads.getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) <<
+        "<td class=right>" << setprecision(4) << double(reads->getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) <<
         "<tr><td>Number of reads flagged as palindromic"
         "<td class=right>" << assemblerInfo->palindromicReadCount <<
         "<tr><td>Number of reads flagged as chimeric"
@@ -691,14 +691,14 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Average number of markers per raw base"
         "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(assemblerInfo->baseCount) <<
         "<tr><td>Average number of markers per run-length encoded base"
-        "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(reads.getRepeatCountsTotalSize()) <<
+        "<td class=right>" << setprecision(4) << double(markers.totalSize()/2)/double(reads->getRepeatCountsTotalSize()) <<
         "<tr><td>Average base offset between markers in raw sequence"
         "<td class=right>" << setprecision(4) << double(assemblerInfo->baseCount)/double(markers.totalSize()/2) <<
         "<tr><td>Average base offset between markers in run-length encoded sequence"
-        "<td class=right>" << setprecision(4) << double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) <<
+        "<td class=right>" << setprecision(4) << double(reads->getRepeatCountsTotalSize())/double(markers.totalSize()/2) <<
         "<tr><td>Average base gap between markers in run-length encoded sequence"
         "<td class=right>" << setprecision(4) <<
-        double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) <<
+        double(reads->getRepeatCountsTotalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) <<
         "</table>"
         "<ul><li>Here and elsewhere, &quot;raw&quot; refers to the original read sequence, "
         "as opposed to run-length encoded sequence.</ul>"
@@ -867,9 +867,9 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Average read length (for raw read sequence)\": " <<
         assemblerInfo->baseCount / assemblerInfo->readCount << ",\n"
         "    \"Read N50 (for raw read sequence)\": " << assemblerInfo->readN50 << ",\n"
-        "    \"Number of run-length encoded bases\": " << reads.getRepeatCountsTotalSize() << ",\n"
+        "    \"Number of run-length encoded bases\": " << reads->getRepeatCountsTotalSize() << ",\n"
         "    \"Average length ratio of run-length encoded sequence over raw sequence\": " <<
-        setprecision(4) << double(reads.getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) << ",\n"
+        setprecision(4) << double(reads->getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) << ",\n"
         "    \"Number of reads flagged as palindromic\": " << assemblerInfo->palindromicReadCount << ",\n"
         "    \"Number of reads flagged as chimeric\": " << assemblerInfo->chimericReadCount << "\n"
         "  },\n"
@@ -933,14 +933,14 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Average number of markers per raw base\": "
         << setprecision(4) << double(markers.totalSize()/2)/double(assemblerInfo->baseCount) << ",\n"
         "    \"Average number of markers per run-length encoded base\": "
-        << setprecision(4) << double(markers.totalSize()/2)/double(reads.getRepeatCountsTotalSize()) << ",\n"
+        << setprecision(4) << double(markers.totalSize()/2)/double(reads->getRepeatCountsTotalSize()) << ",\n"
         "    \"Average base offset between markers in raw sequence\": "
         << setprecision(4) << double(assemblerInfo->baseCount)/double(markers.totalSize()/2) << ",\n"
         "    \"Average base offset between markers in run-length encoded sequence\": "
-        << setprecision(4) << double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) << ",\n"
+        << setprecision(4) << double(reads->getRepeatCountsTotalSize())/double(markers.totalSize()/2) << ",\n"
         "    \"Average base gap between markers in run-length encoded sequence\": "
         << setprecision(4) <<
-        double(reads.getRepeatCountsTotalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) << "\n"
+        double(reads->getRepeatCountsTotalSize())/double(markers.totalSize()/2) - double(assemblerInfo->k) << "\n"
         "  },\n"
 
 
@@ -1159,7 +1159,7 @@ void Assembler::blastRead(
 
 
     // Access the read.
-    if(readId >= reads.readCount()) {
+    if(readId >= reads->readCount()) {
         html << "<p>Invalid read id.";
         return;
     }
@@ -1168,7 +1168,7 @@ void Assembler::blastRead(
         return;
     }
     const OrientedReadId orientedReadId(readId, strand);
-    const vector<Base> rawOrientedReadSequence = reads.getOrientedReadRawSequence(orientedReadId);
+    const vector<Base> rawOrientedReadSequence = reads->getOrientedReadRawSequence(orientedReadId);
     if(!endPositionIsPresent) {
         endPosition = uint32_t(rawOrientedReadSequence.size());
     }

--- a/src/AssemblerKmers.cpp
+++ b/src/AssemblerKmers.cpp
@@ -222,7 +222,7 @@ void Assembler::selectKmersBasedOnFrequency(
     initializeKmerTable();
 
     // Compute the frequency of all k-mers in oriented reads.
-    setupLoadBalancing(reads.readCount(), 1000);
+    setupLoadBalancing(reads->readCount(), 1000);
     runThreads(&Assembler::computeKmerFrequency, threadCount);
 
     // Compute the total number of k-mer occurrences
@@ -378,7 +378,7 @@ void Assembler::computeKmerFrequency(size_t threadId)
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
 
             // Access the sequence of this read.
-            const LongBaseSequenceView read = reads.getRead(readId);
+            const LongBaseSequenceView read = reads->getRead(readId);
 
             // If the read is pathologically short, it has no k-mers.
             if(read.baseCount < k) {
@@ -575,7 +575,7 @@ void Assembler::selectKmers2(
     fill(
         selectKmers2Data.overenrichedReadCount.begin(),
         selectKmers2Data.overenrichedReadCount.end(), 0);
-    setupLoadBalancing(reads.readCount(), 100);
+    setupLoadBalancing(reads->readCount(), 100);
     runThreads(&Assembler::selectKmers2ThreadFunction, threadCount);
 
 
@@ -746,7 +746,7 @@ void Assembler::selectKmers2ThreadFunction(size_t threadId)
         for(ReadId readId=ReadId(begin); readId!=ReadId(end); readId++) {
 
             // Access the sequence of this read.
-            const LongBaseSequenceView read = reads.getRead(readId);
+            const LongBaseSequenceView read = reads->getRead(readId);
 
             // If the read is pathologically short, it has no k-mers.
             if(read.baseCount < k) {

--- a/src/AssemblerLowHash.cpp
+++ b/src/AssemblerLowHash.cpp
@@ -44,7 +44,7 @@ void Assembler::findAlignmentCandidatesLowHash0(
         minFrequency,
         threadCount,
         kmerTable,
-        reads,
+        getReads(),
         markers,
         alignmentCandidates.candidates,
         readLowHashStatistics,
@@ -95,7 +95,7 @@ void Assembler::writeOverlappingReads(
     const string& fileName)
 {
     // Check that we have what we need.
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkAlignmentCandidatesAreOpen();
 
 
@@ -103,9 +103,9 @@ void Assembler::writeOverlappingReads(
     // Open the output file and write the oriented read we were given.
     ofstream file(fileName);
     const OrientedReadId orientedReadId0(readId0, strand0);
-    reads.writeOrientedRead(orientedReadId0, file);
+    reads->writeOrientedRead(orientedReadId0, file);
 
-    const uint64_t length0 = reads.getRead(orientedReadId0.getReadId()).baseCount;
+    const uint64_t length0 = reads->getRead(orientedReadId0.getReadId()).baseCount;
     cout << "Reads overlapping " << orientedReadId0 << " length " << length0 << endl;
 
     // Loop over all overlaps involving this oriented read.
@@ -116,9 +116,9 @@ void Assembler::writeOverlappingReads(
         const OrientedReadId orientedReadId1 = ad.getOther(orientedReadId0);
 
         // Write it out.
-        const uint64_t length1 = reads.getRead(orientedReadId1.getReadId()).baseCount;
+        const uint64_t length1 = reads->getRead(orientedReadId1.getReadId()).baseCount;
         cout << orientedReadId1 << " length " << length1 << endl;
-        reads.writeOrientedRead(orientedReadId1, file);
+        reads->writeOrientedRead(orientedReadId1, file);
     }
     cout << "Found " << alignmentTable[orientedReadId0.getValue()].size();
     cout << " overlapping oriented reads." << endl;
@@ -162,7 +162,7 @@ void Assembler::findAlignmentCandidatesLowHash1(
         minFrequency,
         threadCount,
         kmerTable,
-        reads,
+        getReads(),
         markers,
         alignmentCandidates,
         largeDataFileNamePrefix,
@@ -256,7 +256,7 @@ void Assembler::markAlignmentCandidatesAllPairs()
     alignmentCandidates.candidates.createNew(largeDataName("AlignmentCandidates"), largeDataPageSize);
 
     // Add all pairs on both orientations.
-    const ReadId n = reads.readCount();
+    const ReadId n = reads->readCount();
     for(ReadId r0=0; r0<n-1; r0++) {
         for(ReadId r1=r0+1; r1<n; r1++) {
             alignmentCandidates.candidates.push_back(OrientedReadPair(r0, r1, true));

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -89,8 +89,8 @@ void Assembler::createMarkerGraphVertices(
     cout << timestamp << "Begin computing marker graph vertices." << endl;
 
     // Check that we have what we need.
-    reads.checkReadsAreOpen();
-    reads.checkReadFlagsAreOpen();
+    reads->checkReadsAreOpen();
+    reads->checkReadFlagsAreOpen();
     checkKmersAreOpen();
     checkMarkersAreOpen();
     checkAlignmentDataAreOpen();
@@ -557,8 +557,8 @@ void Assembler::createMarkerGraphVerticesThreadFunction1(size_t threadId)
                 SHASTA_ASSERT(orientedReadIds[0] < orientedReadIds[1]);
 
                 // If either of the reads is flagged chimeric, skip it.
-                if( reads.getFlags(orientedReadIds[0].getReadId()).isChimeric ||
-                    reads.getFlags(orientedReadIds[1].getReadId()).isChimeric) {
+                if( reads->getFlags(orientedReadIds[0].getReadId()).isChimeric ||
+                    reads->getFlags(orientedReadIds[1].getReadId()).isChimeric) {
                     continue;
                 }
             } else if(readGraphCreationMethod == 1) {
@@ -1660,7 +1660,7 @@ vector<Assembler::GlobalMarkerGraphEdgeInformation> Assembler::getGlobalMarkerGr
                 // The markers don't overlap.
                 info.overlappingBaseCount = 0;
                 for(uint32_t position=info.position0+k; position!=info.position1; position++) {
-                    const Base base = reads.getOrientedReadBase(childInfo.orientedReadId, position);
+                    const Base base = reads->getOrientedReadBase(childInfo.orientedReadId, position);
                     info.sequence.push_back(base.character());
                 }
             }
@@ -3185,7 +3185,7 @@ void Assembler::computeMarkerGraphVertexConsensusSequence(
             const uint32_t markerPosition = markerPositions[i];
             Base base;
             uint8_t repeatCount;
-            tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
+            tie(base, repeatCount) = reads->getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
 
             // Add it to the Coverage object.
             coverage.addRead(AlignedBase(base), orientedReadId.getStrand(), size_t(repeatCount));
@@ -3292,7 +3292,7 @@ void Assembler::computeMarkerGraphEdgeConsensusSequenceUsingSpoa(
             for(uint32_t position=position0+k; position!=position1; position++) {
                 Base base;
                 uint32_t repeatCount;
-                tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+                tie(base, repeatCount) = reads->getOrientedReadBaseAndRepeatCount(orientedReadId, position);
                 sequence.push_back(base);
                 repeatCounts.push_back(repeatCount);
                 if(coverageData) {
@@ -3468,8 +3468,8 @@ void Assembler::computeMarkerGraphEdgeConsensusSequenceUsingSpoa(
         for(uint32_t position=begin; position!=end; position++) {
             Base base;
             uint8_t repeatCount;
-            tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, position);
-            interveningSequence.push_back(reads.getOrientedReadBase(orientedReadId, position));
+            tie(base, repeatCount) = reads->getOrientedReadBaseAndRepeatCount(orientedReadId, position);
+            interveningSequence.push_back(reads->getOrientedReadBase(orientedReadId, position));
             interveningRepeatCounts[i].push_back(repeatCount);
         }
 
@@ -4285,7 +4285,7 @@ void Assembler::assembleMarkerGraphVertices(size_t threadCount)
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
 
@@ -4353,7 +4353,7 @@ void Assembler::computeMarkerGraphVerticesCoverageData(size_t threadCount)
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
 
@@ -4476,7 +4476,7 @@ void Assembler::computeMarkerGraphVerticesCoverageDataThreadFunction(size_t thre
                     const uint32_t markerPosition = markerPositions[i];
                     Base base;
                     uint8_t repeatCount;
-                    tie(base, repeatCount) = reads.getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
+                    tie(base, repeatCount) = reads->getOrientedReadBaseAndRepeatCount(orientedReadId, markerPosition + position);
 
                     // Add it to the Coverage object.
                     coverage.addRead(AlignedBase(base), orientedReadId.getStrand(), size_t(repeatCount));
@@ -4521,7 +4521,7 @@ void Assembler::assembleMarkerGraphEdges(
 
     // Check that we have what we need.
     checkKmersAreOpen();
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkMarkersAreOpen();
     checkMarkerGraphVerticesAreAvailable();
     checkMarkerGraphEdgesIsOpen();

--- a/src/AssemblerMarkers.cpp
+++ b/src/AssemblerMarkers.cpp
@@ -8,14 +8,14 @@ using namespace shasta;
 
 void Assembler::findMarkers(size_t threadCount)
 {
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkKmersAreOpen();
 
     markers.createNew(largeDataName("Markers"), largeDataPageSize);
     MarkerFinder markerFinder(
         assemblerInfo->k,
         kmerTable,
-        reads,
+        getReads(),
         markers,
         threadCount);
 
@@ -40,9 +40,9 @@ void Assembler::writeMarkers(ReadId readId, Strand strand, const string& fileNam
 {
     // Check that we have what we need.
     checkKmersAreOpen();
-    reads.checkReadsAreOpen();
+    reads->checkReadsAreOpen();
     checkMarkersAreOpen();
-    reads.checkReadId(readId);
+    reads->checkReadId(readId);
 
     // Get the markers.
     const OrientedReadId orientedReadId(readId, strand);

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -762,18 +762,14 @@ void AssemblerOptions::MarkerGraphOptions::parseSimplifyMaxLength()
 }
 
 void AssemblerOptions::ReadsOptions::parseDesiredCoverageString() {
-    desiredCoverage = std::stoull(desiredCoverageString);
-
-    size_t pos = desiredCoverageString.find_last_of("0123456789");
-    if (pos == desiredCoverageString.size() - 1) {
+    size_t pos = 0;
+    desiredCoverage = std::stoull(desiredCoverageString, &pos);
+    
+    if (pos == desiredCoverageString.size()) {
         // Raw number of bases specified.
         return;
     }
-    pos++;
     
-    while (isspace(desiredCoverageString[pos])) {
-        pos++;
-    }
     string suffix = desiredCoverageString.substr(pos);
     if (suffix == "Gbp" or suffix == "Gb" or suffix == "G") {
         desiredCoverage *= 1000 * 1000 * 1000;

--- a/src/AssemblerOptions.hpp
+++ b/src/AssemblerOptions.hpp
@@ -106,6 +106,8 @@ public:
     public:
         int minReadLength;
         bool noCache;
+        string desiredCoverageString;
+        uint64_t desiredCoverage;
         class PalindromicReadOptions {
         public:
             bool skipFlagging;
@@ -120,6 +122,8 @@ public:
         PalindromicReadOptions palindromicReads;
 
         void write(ostream&) const;
+
+        void parseDesiredCoverageString();
     };
     ReadsOptions readsOptions;
 

--- a/src/AssemblerPhasing.cpp
+++ b/src/AssemblerPhasing.cpp
@@ -386,7 +386,7 @@ void Assembler::phasingGatherOrientedReadsPass(int pass)
 void Assembler::phasingGatherAssemblyGraphEdges(size_t threadCount)
 {
     AssemblyGraph& assemblyGraph = *assemblyGraphPointer;
-    const uint64_t orientedReadCount = 2 * reads.readCount();
+    const uint64_t orientedReadCount = 2 * reads->readCount();
 
     phasingData.assemblyGraphEdges.createNew(
         largeDataName("PhasingGraphAssemblyGraphEdges"), largeDataPageSize);
@@ -445,7 +445,7 @@ void Assembler::phasingGatherAssemblyGraphEdgesPass(int pass)
 
 void Assembler::phasingSortAssemblyGraphEdges(size_t threadCount)
 {
-    const uint64_t orientedReadCount = 2 * reads.readCount();
+    const uint64_t orientedReadCount = 2 * reads->readCount();
     setupLoadBalancing(orientedReadCount, 1000);
     runThreads(&Assembler::phasingSortAssemblyGraphEdgesThreadFunction,
         threadCount);

--- a/src/AssemblerReadGraph.cpp
+++ b/src/AssemblerReadGraph.cpp
@@ -116,7 +116,7 @@ void Assembler::createReadGraphUsingSelectedAlignments(vector<bool>& keepAlignme
 
     // Create read graph connectivity.
     readGraph.connectivity.createNew(largeDataName("ReadGraphConnectivity"), largeDataPageSize);
-    readGraph.connectivity.beginPass1(2 * reads.readCount());
+    readGraph.connectivity.beginPass1(2 * reads->readCount());
     for(const ReadGraphEdge& edge: readGraph.edges) {
         readGraph.connectivity.incrementCount(edge.orientedReadIds[0].getValue());
         readGraph.connectivity.incrementCount(edge.orientedReadIds[1].getValue());
@@ -132,14 +132,14 @@ void Assembler::createReadGraphUsingSelectedAlignments(vector<bool>& keepAlignme
     // Count the number of isolated reads and their bases.
     uint64_t isolatedReadCount = 0;
     uint64_t isolatedReadBaseCount = 0;
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         const OrientedReadId orientedReadId(readId, 0);
         const uint64_t neighborCount = readGraph.connectivity.size(orientedReadId.getValue());
         if(neighborCount > 0) {
             continue;
         }
         ++isolatedReadCount;
-        isolatedReadBaseCount += reads.getReadRawSequenceLength(readId);
+        isolatedReadBaseCount += reads->getReadRawSequenceLength(readId);
     }
     assemblerInfo->isolatedReadCount = isolatedReadCount;
     assemblerInfo->isolatedReadBaseCount = isolatedReadBaseCount;
@@ -215,13 +215,13 @@ bool Assembler::createLocalReadGraph(
 
     for (auto& start: starts) {
         // If the starting read is chimeric and we don't allow chimeric reads, do nothing.
-        if (!allowChimericReads && reads.getFlags(start.getReadId()).isChimeric) {
+        if (!allowChimericReads && reads->getFlags(start.getReadId()).isChimeric) {
             continue;
         }
 
         // Add the starting vertex.
         graph.addVertex(start, uint32_t(markers[start.getValue()].size()),
-                        reads.getFlags(start.getReadId()).isChimeric, 0);
+                        reads->getFlags(start.getReadId()).isChimeric, 0);
 
         // Add each starting vertex to the BFS queue
         q.push(start);
@@ -255,7 +255,7 @@ bool Assembler::createLocalReadGraph(
             const OrientedReadId orientedReadId1 = globalEdge.getOther(orientedReadId0);
 
             // If this read is flagged chimeric and we don't allow chimeric reads, skip.
-            if (!allowChimericReads && reads.getFlags(orientedReadId1.getReadId()).isChimeric) {
+            if (!allowChimericReads && reads->getFlags(orientedReadId1.getReadId()).isChimeric) {
                 continue;
             }
 
@@ -284,7 +284,7 @@ bool Assembler::createLocalReadGraph(
                 if (!graph.vertexExists(orientedReadId1)) {
                     graph.addVertex(orientedReadId1,
                                     uint32_t(markers[orientedReadId1.getValue()].size()),
-                                    reads.getFlags(orientedReadId1.getReadId()).isChimeric, distance1);
+                                    reads->getFlags(orientedReadId1.getReadId()).isChimeric, distance1);
                     q.push(orientedReadId1);
                 }
                 graph.addEdge(
@@ -333,7 +333,7 @@ void Assembler::flagChimericReads(size_t maxDistance, size_t threadCount)
     // If maxDistance is zero, just flag all reads as not chimeric.
     if(maxDistance == 0) {
         for(ReadId readId=0; readId<readCount; readId++) {
-            reads.setChimericFlag(readId, false);
+            reads->setChimericFlag(readId, false);
         }
         return;
     }
@@ -356,7 +356,7 @@ void Assembler::flagChimericReads(size_t maxDistance, size_t threadCount)
 
     size_t chimericReadCount = 0;
     for(ReadId readId=0; readId!=readCount; readId++) {
-        if(reads.getFlags(readId).isChimeric) {
+        if(reads->getFlags(readId).isChimeric) {
             ++chimericReadCount;
         }
     }
@@ -411,7 +411,7 @@ void Assembler::flagChimericReadsThreadFunction(size_t threadId)
             SHASTA_ASSERT(q.empty());
 
             // Begin by flagging this read as not chimeric.
-            reads.setChimericFlag(startReadId, false);
+            reads->setChimericFlag(startReadId, false);
 
 
 
@@ -523,7 +523,7 @@ void Assembler::flagChimericReadsThreadFunction(size_t threadId)
                     component = uComponent;
                 } else {
                     if(uComponent != component) {
-                        reads.setChimericFlag(startReadId, true);
+                        reads->setChimericFlag(startReadId, true);
                         break;
                     }
                 }
@@ -558,9 +558,9 @@ void Assembler::computeReadGraphConnectedComponents(
     )
 {
     // Check that we have what we need.
-    reads.checkReadFlagsAreOpenForWriting();
+    reads->checkReadFlagsAreOpenForWriting();
     checkReadGraphIsOpen();
-    const size_t readCount = reads.readCount();
+    const size_t readCount = reads->readCount();
     const size_t orientedReadCount = 2*readCount;
     SHASTA_ASSERT(readGraph.connectivity.size() == orientedReadCount);
     checkAlignmentDataAreOpen();
@@ -586,10 +586,10 @@ void Assembler::computeReadGraphConnectedComponents(
         const OrientedReadId orientedReadId1 = edge.orientedReadIds[1];
         const ReadId readId0 = orientedReadId0.getReadId();
         const ReadId readId1 = orientedReadId1.getReadId();
-        if(reads.getFlags(readId0).isChimeric) {
+        if(reads->getFlags(readId0).isChimeric) {
             continue;
         }
-        if(reads.getFlags(readId1).isChimeric) {
+        if(reads->getFlags(readId1).isChimeric) {
             continue;
         }
         disjointSets.union_set(orientedReadId0.getValue(), orientedReadId1.getValue());
@@ -662,8 +662,8 @@ void Assembler::computeReadGraphConnectedComponents(
 
     // Clear the read flags that will be set below.
     // Note that we are not changing the isChimeric flags.
-    reads.setIsInSmallComponentFlagForAll(false);
-    reads.setStrandFlagForAll(Strand(0));
+    reads->setIsInSmallComponentFlagForAll(false);
+    reads->setStrandFlagForAll(Strand(0));
 
 
     // Strand separation. Process the connected components one at a time.
@@ -675,7 +675,7 @@ void Assembler::computeReadGraphConnectedComponents(
         if(component.size() < minComponentSize) {
             for(const OrientedReadId orientedReadId: component) {
                 const ReadId readId = orientedReadId.getReadId();
-                reads.setIsInSmallComponentFlag(readId, true);
+                reads->setIsInSmallComponentFlag(readId, true);
             }
             continue;
         }
@@ -697,7 +697,7 @@ void Assembler::computeReadGraphConnectedComponents(
                 for(const OrientedReadId orientedReadId: component) {
                     const ReadId readId = orientedReadId.getReadId();
                     const Strand strand = orientedReadId.getStrand();
-                    reads.setStrandFlag(readId, strand);
+                    reads->setStrandFlag(readId, strand);
                 }
             } else {
                 // No need to set any strand flags here.
@@ -717,7 +717,7 @@ void Assembler::computeReadGraphConnectedComponents(
 
 
     // Check that any read flagged isChimeric is also flagged isInSmallComponent.
-    reads.checkIfAChimericIsAlsoInSmallComponent();
+    reads->checkIfAChimericIsAlsoInSmallComponent();
 }
 
 
@@ -756,10 +756,10 @@ void Assembler::writeLocalReadGraphReads(
     for(const ReadId readId: readsSet) {
 
         // Write the header line with the read name.
-        const auto readName = reads.getReadName(readId);
+        const auto readName = reads->getReadName(readId);
         fasta << ">" << readId << " ";
         copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-        const auto metaData = reads.getReadMetaData(readId);
+        const auto metaData = reads->getReadMetaData(readId);
         if(metaData.size() > 0) {
             fasta << " ";
             copy(metaData.begin(), metaData.end(), ostream_iterator<char>(fasta));
@@ -767,8 +767,8 @@ void Assembler::writeLocalReadGraphReads(
         fasta << "\n";
 
         // Write the sequence.
-        const auto& sequence = reads.getRead(readId);
-        const auto& counts = reads.getReadRepeatCounts(readId);
+        const auto& sequence = reads->getRead(readId);
+        const auto& counts = reads->getReadRepeatCounts(readId);
         const size_t n = sequence.baseCount;
         SHASTA_ASSERT(counts.size() == n);
         for(size_t i=0; i<n; i++) {
@@ -796,7 +796,7 @@ void Assembler::flagCrossStrandReadGraphEdges(int maxDistance, size_t threadCoun
 
     // Check that we have what we need.
     checkReadGraphIsOpen();
-    const size_t readCount = reads.readCount();
+    const size_t readCount = reads->readCount();
     const size_t orientedReadCount = 2*readCount;
     SHASTA_ASSERT(readGraph.connectivity.size() == orientedReadCount);
     checkAlignmentDataAreOpen();
@@ -1025,7 +1025,7 @@ void Assembler::flagCrossStrandReadGraphEdges(int maxDistance, size_t threadCoun
 
 void Assembler::flagCrossStrandReadGraphEdgesThreadFunction(size_t threadId)
 {
-    const size_t readCount = reads.readCount();
+    const size_t readCount = reads->readCount();
     const size_t maxDistance = flagCrossStrandReadGraphEdgesData.maxDistance;
     auto& isNearStrandJump = flagCrossStrandReadGraphEdgesData.isNearStrandJump;
     vector<uint32_t> distance(2*readCount, ReadGraph::infiniteDistance);

--- a/src/AssemblerReadGraph2.cpp
+++ b/src/AssemblerReadGraph2.cpp
@@ -26,7 +26,7 @@ void Assembler::createReadGraph2(size_t threadCount)
 
     // Parallel loop over reads. For each read, flag the alignments we want to discard.
     const uint64_t batchSize = 100;
-    setupLoadBalancing(reads.readCount(), batchSize);
+    setupLoadBalancing(reads->readCount(), batchSize);
     runThreads(&Assembler::createReadGraph2ThreadFunction, threadCount);;
 
     // Create the read graph using the alignments we selected.

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -218,7 +218,7 @@ void Assembler::adjustCoverage(uint64_t minReadLength, uint64_t desiredCoverage)
         );
     }
 
-    uint64_t newMinReadLength = 0;
+    uint64_t newMinReadLength = std::numeric_limits<uint64_t>::max();
 
     const auto& binnedHistogram = reads->getBinnedHistogram();
     for (uint64_t bin = 0; bin < binnedHistogram.size(); bin++) {
@@ -232,6 +232,13 @@ void Assembler::adjustCoverage(uint64_t minReadLength, uint64_t desiredCoverage)
 
         newMinReadLength = max(uint64_t(0), bin - 1) * 1000;
         break;
+    }
+
+    if (newMinReadLength == std::numeric_limits<uint64_t>::max()) {
+        throw runtime_error(
+            "Reads.desiredCoverage is set to " + to_string(desiredCoverage) +
+            " which is very low. Please check the value again."
+        );
     }
 
     SHASTA_ASSERT(newMinReadLength >= minReadLength);

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -16,8 +16,8 @@ void Assembler::addReads(
     bool noCache,
     const size_t threadCount)
 {
-    reads.checkReadsAreOpen();
-    reads.checkReadNamesAreOpen();
+    reads->checkReadsAreOpen();
+    reads->checkReadNamesAreOpen();
 
     ReadLoader readLoader(
         fileName,
@@ -26,9 +26,9 @@ void Assembler::addReads(
         threadCount,
         largeDataFileNamePrefix,
         largeDataPageSize,
-        reads);
-
-    reads.checkSanity();
+        *reads);
+    
+    reads->checkSanity();
 
     cout << "Discarded read statistics for file " << fileName << ":" << endl;
     cout << "    Discarded " << readLoader.discardedInvalidBaseReadCount <<
@@ -57,7 +57,8 @@ void Assembler::addReads(
 // in run-length representation.
 void Assembler::histogramReadLength(const string& fileName)
 {
-    reads.computeAndWriteReadLengthHistogram(fileName);
+    reads->computeReadLengthHistogram();
+    reads->writeReadLengthHistogram(fileName);
 
     cout << "Discarded read statistics for all input files:" << endl;;
     cout << "    Discarded " << assemblerInfo->discardedInvalidBaseReadCount <<
@@ -71,31 +72,31 @@ void Assembler::histogramReadLength(const string& fileName)
         " for a total " << assemblerInfo->discardedBadRepeatCountBaseCount << " bases." << endl;
 
     cout << "Read statistics for reads that will be used in this assembly:" << endl;
-    cout << "    Total number of reads is " << reads.readCount() << "." << endl;
-    cout << "    Total number of raw bases is " << reads.getTotalBaseCount() << "." << endl;
-    cout << "    Average read length is " << double(reads.getTotalBaseCount()) / double(reads.readCount());
+    cout << "    Total number of reads is " << reads->readCount() << "." << endl;
+    cout << "    Total number of raw bases is " << reads->getTotalBaseCount() << "." << endl;
+    cout << "    Average read length is " << double(reads->getTotalBaseCount()) / double(reads->readCount());
     cout << " bases." << endl;
-    cout << "    N50 for read length is " << reads.getN50() << " bases." << endl;
+    cout << "    N50 for read length is " << reads->getN50() << " bases." << endl;
     cout << "    The above statistics only include reads that will be used in this assembly." << endl;
     cout << "    Read discarded because they contained invalid bases, were too short or contained repeat counts 256"
         " or more are not counted." << endl;
 
     // Store read statistics in AssemblerInfo.
-    assemblerInfo->readCount = reads.readCount();
-    assemblerInfo->baseCount = reads.getTotalBaseCount();
-    assemblerInfo->readN50 = reads.getN50();
+    assemblerInfo->readCount = reads->readCount();
+    assemblerInfo->baseCount = reads->getTotalBaseCount();
+    assemblerInfo->readN50 = reads->getN50();
 }
 
 
 // Write a csv file with summary information for each read.
 void Assembler::writeReadsSummary()
 {
-    reads.checkReadsAreOpen();
-    reads.checkReadNamesAreOpen();
+    reads->checkReadsAreOpen();
+    reads->checkReadNamesAreOpen();
     SHASTA_ASSERT(markers.isOpen());
 
     // Count the number of alignment candidates for each read.
-    vector<uint64_t> alignmentCandidatesCount(reads.readCount(), 0);
+    vector<uint64_t> alignmentCandidatesCount(reads->readCount(), 0);
     for(const OrientedReadPair& p: alignmentCandidates.candidates) {
         ++alignmentCandidatesCount[p.readIds[0]];
         ++alignmentCandidatesCount[p.readIds[1]];
@@ -108,19 +109,19 @@ void Assembler::writeReadsSummary()
         "Palindromic,Chimeric,"
         "AlignmentCandidates,ReadGraphNeighbors,"
         "VertexCount,VertexDensity,runid,sampleid,read,ch,start_time,\n";
-    for(ReadId readId=0; readId!=reads.readCount(); readId++) {
+    for(ReadId readId=0; readId!=reads->readCount(); readId++) {
         const OrientedReadId orientedReadId(readId, 0);
 
         // Read id.
         csv << readId << ",";
 
         // Read name.
-        const auto readName = reads.getReadName(readId);
+        const auto readName = reads->getReadName(readId);
         copy(readName.begin(), readName.end(), ostream_iterator<char>(csv));
         csv << ",";
 
         // Number of raw bases.
-        const auto repeatCounts = reads.getReadRepeatCounts(readId);
+        const auto repeatCounts = reads->getReadRepeatCounts(readId);
         uint64_t rawBaseCount = 0;
         for(const auto repeatCount: repeatCounts) {
             rawBaseCount += repeatCount;
@@ -128,7 +129,7 @@ void Assembler::writeReadsSummary()
         csv << rawBaseCount << ",";
 
         // Number of RLE bases.
-        const uint64_t rleBaseCount = reads.getRead(readId).baseCount;
+        const uint64_t rleBaseCount = reads->getRead(readId).baseCount;
         csv << rleBaseCount << ",";
 
         // Ratio of raw over RLE base count.
@@ -155,10 +156,10 @@ void Assembler::writeReadsSummary()
         csv << maximumMarkerOffset << ",";
 
         // Palindromic flag.
-        csv << (reads.getFlags(readId).isPalindromic ? "Yes" : "No") << ",";
+        csv << (reads->getFlags(readId).isPalindromic ? "Yes" : "No") << ",";
 
         // Chimeric flag.
-        csv << (reads.getFlags(readId).isChimeric ? "Yes" : "No") << ",";
+        csv << (reads->getFlags(readId).isChimeric ? "Yes" : "No") << ",";
 
         // Alignment candidates
         csv << alignmentCandidatesCount[readId] << ",";
@@ -183,14 +184,83 @@ void Assembler::writeReadsSummary()
         csv << double(vertexCount) / double(markerCount) << ",";
 
         // Oxford Nanopore standard metadata.
-        csv << reads.getMetaData(readId, "runid") << ",";
-        csv << reads.getMetaData(readId, "sampleid") << ",";
-        csv << reads.getMetaData(readId, "read") << ",";
-        csv << reads.getMetaData(readId, "ch") << ",";
-        csv << reads.getMetaData(readId, "start_time") << ",";
+        csv << reads->getMetaData(readId, "runid") << ",";
+        csv << reads->getMetaData(readId, "sampleid") << ",";
+        csv << reads->getMetaData(readId, "read") << ",";
+        csv << reads->getMetaData(readId, "ch") << ",";
+        csv << reads->getMetaData(readId, "start_time") << ",";
 
         // End of the line for this read.
         csv << "\n";
-     }
+    }
+}
+
+
+void Assembler::adjustCoverage(uint64_t minReadLength, uint64_t desiredCoverage) {
+    if (desiredCoverage == 0) {
+        // Not specified. Skip.
+        return;
+    }
+
+    // Need to compute histograms to adjust coverage.
+    reads->computeReadLengthHistogram();
+
+    cout << timestamp << "Adjusting for desired coverage." << endl;
+    cout << "Desired Coverage: " << desiredCoverage << endl;
+    uint64_t cumulativeBaseCount = reads->getTotalBaseCount();
+
+    if (desiredCoverage > cumulativeBaseCount) {
+        throw runtime_error(
+            "With a Reads.minReadLength of " + to_string(minReadLength) + ","
+            "the total available coverage (" + to_string(cumulativeBaseCount) +
+            ") is lesser than the desired coverage (" + to_string(desiredCoverage) +
+            "). Try reducing Reads.minReadLength if appropriate or get more coverage."
+        );
+    }
+
+    uint64_t newMinReadLength = 0;
+
+    const auto& binnedHistogram = reads->getBinnedHistogram();
+    for (uint64_t bin = 0; bin < binnedHistogram.size(); bin++) {
+        const auto& histogramBin = binnedHistogram[bin];
+        const uint64_t baseCount = histogramBin.second;
+
+        if (cumulativeBaseCount > desiredCoverage) {
+            cumulativeBaseCount -= baseCount;
+            continue;
+        }
+
+        newMinReadLength = max(uint64_t(0), bin - 1) * 1000;
+        break;
+    }
+
+    SHASTA_ASSERT(newMinReadLength >= minReadLength);
+
+    cout << "Setting minReadLength to " + to_string(newMinReadLength) + 
+        " to get desired coverage." << endl;
+
+    // Rename existing memory mapped files to avoid overwriting data.
+    reads->renameWithSuffix("-OLD");
+
+    unique_ptr<Reads> newReads = make_unique<Reads>();
+    newReads->createNew(
+        largeDataName("Reads"),
+        largeDataName("ReadNames"),
+        largeDataName("ReadMetaData"),
+        largeDataName("ReadRepeatCounts"),
+        largeDataName("ReadFlags"),
+        largeDataPageSize
+    );
+
+    newReads->copyDataForReadsLongerThan(
+        getReads(),
+        newMinReadLength
+    );
+
+    reads->remove();
+    
+    reads.swap(newReads);
+
+    cout << timestamp << "Done adjusting for desired coverage." << endl;
 }
 

--- a/src/AssemblerSegmentGraph.cpp
+++ b/src/AssemblerSegmentGraph.cpp
@@ -32,10 +32,10 @@ void Assembler::createSegmentGraph()
     // Here we find, for each oriented read, the sequence of assembly graph edges
     // encountered along its marker graph path.
     // This vector is indexed by OrientedReadId::getValue().
-    vector< vector<AssemblyGraph::EdgeId> > orientedReadAssemblyGraphEdges(2*reads.readCount());
+    vector< vector<AssemblyGraph::EdgeId> > orientedReadAssemblyGraphEdges(2*reads->readCount());
     vector<MarkerGraph::EdgeId> markerGraphPath;
     vector< pair<uint32_t, uint32_t> > pathOrdinals;
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             vector<AssemblyGraph::EdgeId>& assemblyGraphEdges =
@@ -86,7 +86,7 @@ void Assembler::createSegmentGraph()
     // Write a csv file with the sequence of assembly graph edges
     // for each oriented read.
     ofstream csv("OrientedReadSegments.csv");
-    for(ReadId readId=0; readId<reads.readCount(); readId++) {
+    for(ReadId readId=0; readId<reads->readCount(); readId++) {
         for(Strand strand=0; strand<2; strand++) {
             const OrientedReadId orientedReadId(readId, strand);
             csv << orientedReadId << ",";
@@ -140,7 +140,7 @@ void Assembler::createSegmentGraph()
         // Follow the sequence of assembly graph edges
         // for each oriented read.
         vector<AssemblyGraph::EdgeId> v;
-        for(ReadId readId=0; readId<reads.readCount(); readId++) {
+        for(ReadId readId=0; readId<reads->readCount(); readId++) {
             for(Strand strand=0; strand<2; strand++) {
                 const OrientedReadId orientedReadId(readId, strand);
 

--- a/src/LongBaseSequence.cpp
+++ b/src/LongBaseSequence.cpp
@@ -23,6 +23,9 @@ void LongBaseSequences::rename(const string& name) {
     if (!name.empty()) {
         baseCount.rename(name + "-BaseCount");
         data.rename(name + "-Bases");
+    } else {
+        SHASTA_ASSERT(baseCount.fileName.empty());
+        SHASTA_ASSERT(data.getName().empty());
     }
 }
 

--- a/src/LongBaseSequence.cpp
+++ b/src/LongBaseSequence.cpp
@@ -16,6 +16,14 @@ void LongBaseSequences::createNew(
         baseCount.createNew(name + "-BaseCount", pageSize);
         data.createNew(name + "-Bases", pageSize);
     }
+    this->name = name;
+}
+
+void LongBaseSequences::rename(const string& name) {
+    if (!name.empty()) {
+        baseCount.rename(name + "-BaseCount");
+        data.rename(name + "-Bases");
+    }
 }
 
 

--- a/src/LongBaseSequence.hpp
+++ b/src/LongBaseSequence.hpp
@@ -286,6 +286,12 @@ public:
         return baseCount.size() == 0;
     }
 
+    string getName() const {
+        return name;
+    }
+
+    void rename(const string& name);
+
     // Append a new sequence at the end.
     void append(const LongBaseSequenceView&);
     void append(const vector<Base>&);
@@ -298,6 +304,8 @@ private:
 
     // The data for all the sequences.
     MemoryMapped::VectorOfVectors<uint64_t, uint64_t> data;
+
+    string name;
 
 };
 

--- a/src/MarkerFinder.hpp
+++ b/src/MarkerFinder.hpp
@@ -41,7 +41,7 @@ private:
     void threadFunction(size_t threadId);
 
     // In pass 1, we count the number of markers for each
-    // read and call reads.incrementCountMultithreaded.
+    // read and call reads->incrementCountMultithreaded.
     // In pass 2, we store the markers.
     size_t pass;
 

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -66,6 +66,8 @@ ReadLoader::ReadLoader(
         "Supported file extensions are .fasta, .fa, .FASTA, .FA.");
 }
 
+
+
 void ReadLoader::adjustThreadCount()
 {
     if(threadCount == 0) {

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -669,7 +669,7 @@ void ReadLoader::processCompressedRunnieFile()
     // Use multithreaded code to store the reads.
     setupLoadBalancing(readIdTable.size(), 1000);
     runThreads(&ReadLoader::processCompressedRunnieFileThreadFunction, threadCount);
-    // compressedRunnieReader = 0;
+    compressedRunnieReader.reset();
 
     const auto t1 = std::chrono::steady_clock::now();
     cout << "Input file read and processed in " <<

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -33,6 +33,8 @@ public:
         size_t pageSize,
         Reads& reads);
 
+    ~ReadLoader();
+    
     // The number of reads and raw bases discarded because the read
     // contained invalid bases.
     uint64_t discardedInvalidBaseReadCount = 0;
@@ -87,10 +89,10 @@ private:
 
     // Vectors where each thread stores the reads it found.
     // Indexed by threadId.
-    vector< shared_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadNames;
-    vector< shared_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadMetaData;
-    vector< shared_ptr<LongBaseSequences> > threadReads;
-    vector< shared_ptr<MemoryMapped::VectorOfVectors<uint8_t, uint64_t> > > threadReadRepeatCounts;
+    vector< unique_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadNames;
+    vector< unique_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadMetaData;
+    vector< unique_ptr<LongBaseSequences> > threadReads;
+    vector< unique_ptr<MemoryMapped::VectorOfVectors<uint8_t, uint64_t> > > threadReadRepeatCounts;
     void allocatePerThreadDataStructures();
     void allocatePerThreadDataStructures(size_t threadId);
 
@@ -119,7 +121,7 @@ private:
     // Functions and data used for compressed runnie files.
     void processCompressedRunnieFile();
     void processCompressedRunnieFileThreadFunction(size_t threadId);
-    shared_ptr<CompressedRunnieReader> compressedRunnieReader;
+    unique_ptr<CompressedRunnieReader> compressedRunnieReader;
 
     // The ReadId corresponding to each index in the Runnie file.
     vector<ReadId> readIdTable;

--- a/src/Reads.cpp
+++ b/src/Reads.cpp
@@ -37,18 +37,30 @@ void Reads::access(
 }
 
 
-void Reads::renameWithSuffix(const string& suffix) {
+void Reads::rename() {
+    const string suffix = "_old";
     const string readsDataName = reads.getName();
     const string readNamesDataName = readNames.getName();
     const string readMetaDataDataName = readMetaData.getName();
     const string readRepeatCountsDataName = readRepeatCounts.getName();
     const string readFlagsDataName = readFlags.fileName;
 
-    reads.rename(readsDataName + suffix);
-    readNames.rename(readNamesDataName + suffix);
-    readMetaData.rename(readMetaDataDataName + suffix);
-    readRepeatCounts.rename(readRepeatCountsDataName + suffix);
-    readFlags.rename(readFlagsDataName + suffix);
+    // No need to rename if anonymous memory mode is used.
+    if (!readsDataName.empty()) {
+        reads.rename(readsDataName + suffix);
+    }
+    if (!readNamesDataName.empty()) {
+        readNames.rename(readNamesDataName + suffix);
+    }
+    if (!readMetaDataDataName.empty()) {
+        readMetaData.rename(readMetaDataDataName + suffix);
+    }
+    if (!readRepeatCountsDataName.empty()) {
+        readRepeatCounts.rename(readRepeatCountsDataName + suffix);
+    }
+    if (!readFlagsDataName.empty()) {
+        readFlags.rename(readFlagsDataName + suffix);
+    }
 }
 
 

--- a/src/Reads.hpp
+++ b/src/Reads.hpp
@@ -243,11 +243,11 @@ public:
         return readRepeatCounts.totalSize();
     }
 
-    inline const vector< pair<uint64_t, uint64_t> > getBinnedHistogram() const {
-        return binnedHistogram;
+    inline const vector<uint64_t>& getReadLengthHistogram() const {
+        return histogram;
     }
 
-    void renameWithSuffix(const string& suffix);
+    void rename();
 
     void copyDataForReadsLongerThan(const Reads& rhs, uint64_t newMinReadLength);
 

--- a/src/Reads.hpp
+++ b/src/Reads.hpp
@@ -140,7 +140,7 @@ public:
     // Return the length of the raw sequence of a read.
     // If using the run-length representation of reads, this counts each
     // base a number of times equal to its repeat count.
-    size_t getReadRawSequenceLength(ReadId) const;
+    uint64_t getReadRawSequenceLength(ReadId) const;
 
     // Get a vector of the raw read positions
     // corresponding to each position in the run-length
@@ -229,7 +229,8 @@ public:
         SHASTA_ASSERT(reads.size() == readFlags.size());
     }
 
-    void computeAndWriteReadLengthHistogram(const string& fileName);
+    void computeReadLengthHistogram();
+    void writeReadLengthHistogram(const string& fileName);
     
     inline uint64_t getTotalBaseCount() const {
         return totalBaseCount;
@@ -241,6 +242,16 @@ public:
     inline uint64_t getRepeatCountsTotalSize() const {
         return readRepeatCounts.totalSize();
     }
+
+    inline const vector< pair<uint64_t, uint64_t> > getBinnedHistogram() const {
+        return binnedHistogram;
+    }
+
+    void renameWithSuffix(const string& suffix);
+
+    void copyDataForReadsLongerThan(const Reads& rhs, uint64_t newMinReadLength);
+
+    void remove();
 
 private:
     LongBaseSequences reads;

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -6,6 +6,8 @@
 namespace shasta {
     using std::make_shared;
     using std::shared_ptr;
+    using std::make_unique;
+    using std::unique_ptr;
 }
 
 #endif

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -482,21 +482,42 @@ void shasta::main::assemble(
             threadCount);
     }
 
-    assembler.adjustCoverage(
-        assemblerOptions.readsOptions.minReadLength,
-        assemblerOptions.readsOptions.desiredCoverage
-    );
-
-    if(assembler.getReads().readCount() == 0) {
+    if (assembler.getReads().readCount() == 0) {
         throw runtime_error("There are no input reads.");
     }
+    
+    if (assemblerOptions.readsOptions.desiredCoverage > 0) {
+        // Write out the read length histogram using provided minReadLength.
+        assembler.histogramReadLength("ExtendedReadLengthHistogram.csv");
+
+        const auto newMinReadLength = assembler.adjustCoverageAndGetNewMinReadLength(
+            assemblerOptions.readsOptions.desiredCoverage);
+
+        const auto oldMinReadLength = assemblerOptions.readsOptions.minReadLength;
+
+        if (newMinReadLength == 0ULL) {
+            throw runtime_error(
+                "With a Reads.minReadLength of " + to_string(oldMinReadLength) + ","
+                " the total available coverage is lesser than the desired coverage. " +
+                "Try reducing Reads.minReadLength if appropriate or get more coverage."
+            ); 
+        }
+
+        if (newMinReadLength == std::numeric_limits<uint64_t>::max()) {
+            throw runtime_error(
+                "Reads.desiredCoverage is set to " +
+                to_string(assemblerOptions.readsOptions.desiredCoverage) +
+                " which is very low. Please check the value again."
+            );
+        }
+    }
+    
+    assembler.histogramReadLength("ReadLengthHistogram.csv");
+
+   
     const auto t1 = steady_clock::now();
     cout << timestamp << "Done loading reads from " << inputFileNames.size() << " files." << endl;
     cout << "Read loading took " << seconds(t1-t0) << "s." << endl;
-
-
-    // Create a histogram of read lengths.
-    assembler.histogramReadLength("ReadLengthHistogram.csv");
 
 
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -481,6 +481,12 @@ void shasta::main::assemble(
             assemblerOptions.readsOptions.noCache,
             threadCount);
     }
+
+    assembler.adjustCoverage(
+        assemblerOptions.readsOptions.minReadLength,
+        assemblerOptions.readsOptions.desiredCoverage
+    );
+
     if(assembler.getReads().readCount() == 0) {
         throw runtime_error("There are no input reads.");
     }


### PR DESCRIPTION
Desired coverage, as a number of bases, can be set using the new configuration parameter - Reads.desiredCoverage. This value will be auto-generated by the GenerateConfig.py script (different PR). 

- If there isn't enough coverage available with reads longer than Reads.minReadLength, the program will abort.
- If more than desired coverage is available with reads longer than Reads.minReadLength, then Shasta will increase the value of minReadLength to arrive close to the desired coverage

`Reads.desiredCoverage` can take values specified as 
- raw number of bases. E.g `--Reads.desiredCoverage 2000000000`
- kilo bases (K, Kb, Kbp). E.g. `--Reads.desiredCoverage 2000000Kb`
- mega bases (M, Mb, Mbp). E.g. `--Reads.desiredCoverage 2000Mb`
- giga bases (G, Gb, Gbp). E.g. `--Reads.desiredCoverage 2Gb`


**Performance hit**: For `HG002-Guppy-3.6.0.fasta` dropping coverage to `120G` adds a little over 2 minutes to the assembly time. 