### PR TITLE
Fixes bugs with code that adjusts coverage based on Reads.desiredCoverage

### DIFF
--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -601,7 +601,7 @@ void AssemblerOptions::ReadsOptions::write(ostream& s) const
 {
     s << "[Reads]\n";
     s << "minReadLength = " << minReadLength << "\n";
-    s << "desiredCoverage = " << desiredCoverage << "\n";
+    s << "desiredCoverage = " << desiredCoverageString << "\n";
     s << "noCache = " <<
         convertBoolToPythonString(noCache) << "\n";
     palindromicReads.write(s);

--- a/src/Reads.cpp
+++ b/src/Reads.cpp
@@ -64,10 +64,15 @@ void Reads::rename() {
 }
 
 
-void Reads::copyDataForReadsLongerThan(const Reads& rhs, uint64_t newMinReadLength) {
+void Reads::copyDataForReadsLongerThan(
+    const Reads& rhs,
+    uint64_t newMinReadLength,
+    uint64_t& discardedShortReadCount,
+    uint64_t& discardedShortReadBases
+) {
     for(ReadId id = 0; id < rhs.readCount(); id++) {
         const auto len = rhs.getReadRawSequenceLength(id);
-        if (len > newMinReadLength) {
+        if (len >= newMinReadLength) {
             // Copy over stuff.
             readNames.appendVector(rhs.readNames.begin(id), rhs.readNames.end(id));
             readMetaData.appendVector(rhs.readMetaData.begin(id), rhs.readMetaData.end(id));
@@ -79,6 +84,9 @@ void Reads::copyDataForReadsLongerThan(const Reads& rhs, uint64_t newMinReadLeng
                 rhs.readRepeatCounts.end(id),
                 readRepeatCounts.begin(j)
             );
+        } else {
+            discardedShortReadCount++;
+            discardedShortReadBases += len;
         }
     }
 

--- a/src/Reads.hpp
+++ b/src/Reads.hpp
@@ -249,7 +249,12 @@ public:
 
     void rename();
 
-    void copyDataForReadsLongerThan(const Reads& rhs, uint64_t newMinReadLength);
+    void copyDataForReadsLongerThan(
+        const Reads& rhs,
+        uint64_t newMinReadLength,
+        uint64_t& discardedShortReadCount,
+        uint64_t& discardedShortReadBases
+    );
 
     void remove();
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -493,7 +493,7 @@ void shasta::main::assemble(
         const auto newMinReadLength = assembler.adjustCoverageAndGetNewMinReadLength(
             assemblerOptions.readsOptions.desiredCoverage);
 
-        const auto oldMinReadLength = assemblerOptions.readsOptions.minReadLength;
+        const auto oldMinReadLength = uint64_t(assemblerOptions.readsOptions.minReadLength);
 
         if (newMinReadLength == 0ULL) {
             throw runtime_error(
@@ -503,13 +503,8 @@ void shasta::main::assemble(
             ); 
         }
 
-        if (newMinReadLength == std::numeric_limits<uint64_t>::max()) {
-            throw runtime_error(
-                "Reads.desiredCoverage is set to " +
-                to_string(assemblerOptions.readsOptions.desiredCoverage) +
-                " which is very low. Please check the value again."
-            );
-        }
+        // Adjusting coverage should only ever reduce coverage if necessary.
+        SHASTA_ASSERT(newMinReadLength >= oldMinReadLength);
     }
     
     assembler.histogramReadLength("ReadLengthHistogram.csv");


### PR DESCRIPTION
### Test Plan

**Run 1**
`./shasta-build/staticExecutable/shasta --input /data/reads/r94_ec_rad2.181119.60x-10kb.fasta --memoryMode filesystem --memoryBacking 2M --Reads.minReadLength 10000 --Reads.desiredCoverage 227Mb --assemblyDirectory ShastaEColi3`

Adjusting for desired coverage increased the minReadLength to **12704**

**Run 2**
`./shasta-build/staticExecutable/shasta --input /data/reads/r94_ec_rad2.181119.60x-10kb.fasta --memoryMode filesystem --memoryBacking 2M --Reads.minReadLength 12704 --assemblyDirectory ShastaEColi2`

Then compared the assembly summary using `diff` as follows ...
`diff --suppress-common-lines -y ShastaEColi3/AssemblySummary.json ShastaEColi2/`

Verified that summary information about reads was the same.