### PR TITLE
Best effort auto-selection of MinHash.minBucketSize & MinHash.maxBucketSize if values are not provided.

### DIFF
--- a/src/LowHash0.cpp
+++ b/src/LowHash0.cpp
@@ -2,6 +2,7 @@
 #include "LowHash0.hpp"
 #include "ReadFlags.hpp"
 #include "timestamp.hpp"
+#include "PeakFinder.hpp"
 using namespace shasta;
 
 // Standard library.
@@ -173,10 +174,20 @@ LowHash0::LowHash0(
         buckets.endPass2(false, false);
         computeBucketHistogram();
 
+        const size_t providedMinBucketSize = this->minBucketSize;
+        const size_t providedMaxBucketSize = this->maxBucketSize;
+        if (providedMinBucketSize == 0 || providedMaxBucketSize == 0) {
+            computeBucketSizesIfNotProvided();
+        }
+
         // Pass 3: inspect the buckets to find candidates.
         batchSize = 10000;
         setupLoadBalancing(readCount, batchSize);
         runThreads(&LowHash0::pass3ThreadFunction, threadCount);
+
+        // Restore original bucket sizes.
+        this->minBucketSize = providedMinBucketSize;
+        this->maxBucketSize = providedMaxBucketSize;
 
         // Write a summary for this iteration.
         highFrequency = 0;
@@ -356,6 +367,49 @@ void LowHash0::pass1ThreadFunction(size_t threadId)
 
 }
 
+void LowHash0::computeBucketSizesIfNotProvided() {
+    const double minBucketCutOff = 0.65;
+    const double maxBucketCutOff = 0.9;
+    
+    uint64_t cumulativeFeatureCount = 0;
+    vector<uint64_t> histogram(bucketHistogram.size(), 0);
+    
+    for (uint64_t bucketSize = 0; bucketSize < bucketHistogram.size(); bucketSize++) {
+        const auto frequency = bucketHistogram[bucketSize];
+        histogram[bucketSize] = bucketSize * frequency;
+        cumulativeFeatureCount += histogram[bucketSize];
+    }
+
+    uint64_t runningTotal = 0;
+    if (minBucketSize == 0) {
+        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
+            runningTotal += histogram[bucketSize];
+            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
+            if (fraction < minBucketCutOff) {
+                continue;
+            }
+            minBucketSize = bucketSize;
+            break;
+        }
+        minBucketSize = max(size_t(2), minBucketSize);
+        cout << "Computed minBucketSize = " << minBucketSize << endl;
+    }
+
+    runningTotal = 0;
+    if (maxBucketSize == 0) {
+        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
+            runningTotal += histogram[bucketSize];
+            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
+            if (fraction < maxBucketCutOff) {
+                continue;
+            }
+            maxBucketSize = bucketSize;
+            break;
+        }
+        maxBucketSize = max(size_t(10), maxBucketSize);
+        cout << "Computed maxBucketSize = " << maxBucketSize << endl;
+    }
+}
 
 
 // Pass 2: fill the buckets.
@@ -378,16 +432,6 @@ void LowHash0::pass2ThreadFunction(size_t threadId)
                 for(const uint64_t hash: orientedReadLowHashes) {
                     const uint64_t bucketId = hash & mask;
                     buckets.storeMultithreaded(bucketId, BucketEntry(orientedReadId, hash));
-
-                    // Update statistics for this read.
-                    const uint64_t bucketSize = buckets.size(bucketId);
-                    if(bucketSize < minBucketSize) {
-                        ++readLowHashStatistics[readId][0];
-                    } else if(bucketSize > maxBucketSize) {
-                        ++readLowHashStatistics[readId][2];
-                    } else {
-                        ++readLowHashStatistics[readId][1];
-                    }
                 }
             }
         }
@@ -431,11 +475,16 @@ void LowHash0::pass3ThreadFunction(size_t threadId)
                     const uint64_t bucketId = hash & mask;
                     const span<BucketEntry> bucket = buckets[bucketId];
                     if(bucket.size() < max(size_t(2), minBucketSize)) {
+                        ++readLowHashStatistics[readId0][0];
                         continue;
                     }
                     if(bucket.size() > maxBucketSize) {
+                        ++readLowHashStatistics[readId0][2];
                         continue;   // The bucket is too big. Skip it.
                     }
+
+                    ++readLowHashStatistics[readId0][1];
+                    
                     for(const BucketEntry& bucketEntry: bucket) {
                         if(bucketEntry.hashHighBits != hashHighBits) {
                             continue;   // Collision.
@@ -573,7 +622,10 @@ void LowHash0::computeBucketHistogram()
     for(const vector<uint64_t>& histogram: threadBucketHistogram) {
         largestBucketSize = max(largestBucketSize, uint64_t(histogram.size()));
     }
-    vector<uint64_t> bucketHistogram(largestBucketSize, 0);
+    
+    bucketHistogram.resize(largestBucketSize);
+    fill(bucketHistogram.begin(), bucketHistogram.end(), uint64_t(0));
+
     for(const vector<uint64_t>& histogram: threadBucketHistogram) {
         for(uint64_t bucketSize=0; bucketSize<histogram.size(); bucketSize++) {
             bucketHistogram[bucketSize] += histogram[bucketSize];
@@ -590,9 +642,9 @@ void LowHash0::computeBucketHistogram()
                 bucketSize*frequency << "\n";
         }
     }
-
-
 }
+
+
 void LowHash0::computeBucketHistogramThreadFunction(size_t threadId)
 {
     vector<uint64_t>& histogram = threadBucketHistogram[threadId];

--- a/src/LowHash0.hpp
+++ b/src/LowHash0.hpp
@@ -179,6 +179,7 @@ private:
     void computeBucketHistogram();
     void computeBucketHistogramThreadFunction(size_t threadId);
     vector< vector<uint64_t> > threadBucketHistogram;
+    vector<uint64_t> bucketHistogram;
     ofstream histogramCsv;
 
 
@@ -194,6 +195,8 @@ private:
 
     // Pass 3: inspect the buckets to find candidates.
     void pass3ThreadFunction(size_t threadId);
+
+    void computeBucketSizesIfNotProvided();
 
 };
 

--- a/src/LowHash1.cpp
+++ b/src/LowHash1.cpp
@@ -2,6 +2,7 @@
 #include "LowHash1.hpp"
 #include "AlignmentCandidates.hpp"
 #include "Marker.hpp"
+#include "PeakFinder.hpp"
 using namespace shasta;
 
 // Standad library.
@@ -129,6 +130,12 @@ LowHash1::LowHash1(
             double(buckets.totalSize()) / double(buckets.size()) << endl;
         computeBucketHistogram();
 
+        const size_t providedMinBucketSize = this->minBucketSize;
+        const size_t providedMaxBucketSize = this->maxBucketSize;
+        if (providedMinBucketSize == 0 || providedMaxBucketSize == 0) {
+            computeBucketSizesIfNotProvided();
+        }
+
         // Scan the buckets to find common features.
         // Each thread stores the common features it finds in its own vector.
         const uint64_t oldCommonFeatureCount = countTotalThreadCommonFeatures();
@@ -138,6 +145,10 @@ LowHash1::LowHash1(
         const uint64_t newCommonFeatureCount = countTotalThreadCommonFeatures();
         cout << "Stored " << newCommonFeatureCount-oldCommonFeatureCount <<
             " common features at this iteration." << endl;
+    
+        // Restore original bucket sizes.
+        this->minBucketSize = providedMinBucketSize;
+        this->maxBucketSize = providedMaxBucketSize;
     }
 
     // Gather together all the common features found by all threads.
@@ -276,6 +287,50 @@ void LowHash1::computeHashesThreadFunction(size_t threadId)
 }
 
 
+void LowHash1::computeBucketSizesIfNotProvided() {
+    const double minBucketCutOff = 0.65;
+    const double maxBucketCutOff = 0.9;
+    
+    uint64_t cumulativeFeatureCount = 0;
+    vector<uint64_t> histogram(bucketHistogram.size(), 0);
+    
+    for (uint64_t bucketSize = 0; bucketSize < bucketHistogram.size(); bucketSize++) {
+        const auto frequency = bucketHistogram[bucketSize];
+        histogram[bucketSize] = bucketSize * frequency;
+        cumulativeFeatureCount += histogram[bucketSize];
+    }
+
+    uint64_t runningTotal = 0;
+    if (minBucketSize == 0) {
+        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
+            runningTotal += histogram[bucketSize];
+            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
+            if (fraction < minBucketCutOff) {
+                continue;
+            }
+            minBucketSize = bucketSize;
+            break;
+        }
+        minBucketSize = max(size_t(2), minBucketSize);
+        cout << "Computed minBucketSize = " << minBucketSize << endl;
+    }
+
+    runningTotal = 0;
+    if (maxBucketSize == 0) {
+        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
+            runningTotal += histogram[bucketSize];
+            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
+            if (fraction < maxBucketCutOff) {
+                continue;
+            }
+            maxBucketSize = bucketSize;
+            break;
+        }
+        maxBucketSize = max(size_t(10), maxBucketSize);
+        cout << "Computed maxBucketSize = " << maxBucketSize << endl;
+    }
+}
+
 
 // Thread function to fill the buckets.
 void LowHash1::fillBucketsThreadFunction(size_t threadId)
@@ -320,7 +375,10 @@ void LowHash1::computeBucketHistogram()
     for(const vector<uint64_t>& histogram: threadBucketHistogram) {
         largestBucketSize = max(largestBucketSize, uint64_t(histogram.size()));
     }
-    vector<uint64_t> bucketHistogram(largestBucketSize, 0);
+
+    bucketHistogram.resize(largestBucketSize);
+    fill(bucketHistogram.begin(), bucketHistogram.end(), uint64_t(0));
+    
     for(const vector<uint64_t>& histogram: threadBucketHistogram) {
         for(uint64_t bucketSize=0; bucketSize<histogram.size(); bucketSize++) {
             bucketHistogram[bucketSize] += histogram[bucketSize];

--- a/src/LowHash1.cpp
+++ b/src/LowHash1.cpp
@@ -288,10 +288,7 @@ void LowHash1::computeHashesThreadFunction(size_t threadId)
 
 
 void LowHash1::computeBucketSizesIfNotProvided() {
-    const double minBucketCutOff = 0.65;
-    const double maxBucketCutOff = 0.9;
-    
-    uint64_t cumulativeFeatureCount = 0;
+uint64_t cumulativeFeatureCount = 0;
     vector<uint64_t> histogram(bucketHistogram.size(), 0);
     
     for (uint64_t bucketSize = 0; bucketSize < bucketHistogram.size(); bucketSize++) {
@@ -302,14 +299,23 @@ void LowHash1::computeBucketSizesIfNotProvided() {
 
     uint64_t runningTotal = 0;
     if (minBucketSize == 0) {
-        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
-            runningTotal += histogram[bucketSize];
-            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
-            if (fraction < minBucketCutOff) {
-                continue;
+        try {
+            shasta::PeakFinder p;
+            p.findPeaks(histogram);
+            minBucketSize = p.findXCutoff(histogram);
+            cout << "PeakFinder computed minBucketSize = " << minBucketSize << endl;
+        } catch (PeakFinderException) {
+            const double minBucketCutOff = 0.65;
+            
+            for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
+                runningTotal += histogram[bucketSize];
+                double fraction = double(runningTotal) / double(cumulativeFeatureCount);
+                if (fraction < minBucketCutOff) {
+                    continue;
+                }
+                minBucketSize = bucketSize;
+                break;
             }
-            minBucketSize = bucketSize;
-            break;
         }
         minBucketSize = max(size_t(2), minBucketSize);
         cout << "Computed minBucketSize = " << minBucketSize << endl;
@@ -317,6 +323,8 @@ void LowHash1::computeBucketSizesIfNotProvided() {
 
     runningTotal = 0;
     if (maxBucketSize == 0) {
+        const double maxBucketCutOff = 0.9;
+   
         for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
             runningTotal += histogram[bucketSize];
             double fraction = double(runningTotal) / double(cumulativeFeatureCount);

--- a/src/LowHash1.hpp
+++ b/src/LowHash1.hpp
@@ -108,9 +108,10 @@ private:
     void computeBucketHistogram();
     void computeBucketHistogramThreadFunction(size_t threadId);
     vector< vector<uint64_t> > threadBucketHistogram;
+    vector<uint64_t> bucketHistogram;
     ofstream histogramCsv;
 
-
+    void computeBucketSizesIfNotProvided();
 
     // When two oriented reads appear in the same bucket, we
     // check if that happens by chance or because we found a


### PR DESCRIPTION
It's tricky picking a good value for `minBucketSize` & `maxBucketSize` for new data/genome. If `minBucketSize` is set too low, then poor quality alignment candidates are let through. If it is set too high, then Shasta misses out on some good alignment candidates. One of the first pieces of feedback when someone assembles a genome using Shasta is to adjust this value so as to get better results. Turns out that we can use simple heuristics to find a **_not-terrible starting value_**.


### Test Plan
Ran an E-Coli assembly before and after this change with `MinHash.minBucketSize = 5`. Verified that the relevant csv files were identical. 

Ran an E-Coli assembly by passing in `MinHash.minBucketSize = 0`. Verified that a new value of minBucketSize was computed and used for each iteration.

Ran an HG002 assembly by passing in `MinHash.minBucketSize = 0` and `MinHash.maxBucketSize = 0`. Verified that reasonable values were selected for both in every min hash iteration.

Tested only LowHash0. 