### PR TITLE
Handle empty downsampled sequences before attempting a SeqAn alignment.

### DIFF
--- a/src/AssemblerAlign3.cpp
+++ b/src/AssemblerAlign3.cpp
@@ -95,8 +95,7 @@ void Assembler::alignOrientedReads3(
 
     }
 
-    if ((downsampledSequences[0].data_begin == downsampledSequences[0].data_end) or
-        (downsampledSequences[1].data_begin == downsampledSequences[1].data_end)) {
+    if (downsampledMarkers[0].empty() or downsampledMarkers[1].empty()) {
         // One of the downsampled sequences is empty. Return an empty alignment.
         alignment.clear();
         alignmentInfo.create(

--- a/src/AssemblerAlign3.cpp
+++ b/src/AssemblerAlign3.cpp
@@ -95,7 +95,14 @@ void Assembler::alignOrientedReads3(
 
     }
 
-
+    if ((downsampledSequences[0].data_begin == downsampledSequences[0].data_end) or
+        (downsampledSequences[1].data_begin == downsampledSequences[1].data_end)) {
+        // One of the downsampled sequences is empty. Return an empty alignment.
+        alignment.clear();
+        alignmentInfo.create(
+            alignment, uint32_t(allMarkers[0].size()), uint32_t(allMarkers[1].size()));
+        return; 
+    }
 
     // Use SeqAn to compute an alignment of the downsampled markers, free at both ends.
     // https://seqan.readthedocs.io/en/master/Tutorial/Algorithms/Alignment/PairwiseSequenceAlignment.html
@@ -116,6 +123,10 @@ void Assembler::alignOrientedReads3(
         cout << "Downsampled alignment score is " << downsampledScore << endl;
     }
 
+    if (downsampledScore == seqan::MinValue<int>::VALUE) {
+        throw runtime_error("SeqAn banded alignment computation failed for downsampled sequences.");
+    }
+
     // Extract the alignment from the graph.
     // This creates a single sequence consisting of the two rows
     // of the alignment, concatenated.
@@ -127,7 +138,6 @@ void Assembler::alignOrientedReads3(
     if(debug) {
         cout << "Downsampled alignment length " << downsampledAlignmentLength << endl;
     }
-
 
 
     // Write the downsampled alignment on its alignment matrix.

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -1520,24 +1520,35 @@ void Assembler::computeAllAlignmentsThreadFunction(size_t threadId)
                 getMarkersSortedByKmerId(orientedReadId1, markersSortedByKmerId[1]);
 
                 // Compute the alignment.
-                if (method == 0) {
-                    const bool debug = false;
-                    alignOrientedReads(
-                        markersSortedByKmerId,
-                        maxSkip, maxDrift, maxMarkerFrequency, debug, graph, alignment, alignmentInfo);
-                } else if (method == 1) {
-                    alignOrientedReads1(
-                        orientedReadId0, orientedReadId1,
-                        matchScore, mismatchScore, gapScore, alignment, alignmentInfo);
-                } else if (method == 3) {
-                    alignOrientedReads3(
-                        orientedReadId0, orientedReadId1,
-                        matchScore, mismatchScore, gapScore,
-                        downsamplingFactor, bandExtend, maxBand,
-                        alignment, alignmentInfo);
-                } else {
-                    SHASTA_ASSERT(0);
+                try {
+                    if (method == 0) {
+                        const bool debug = false;
+                        alignOrientedReads(
+                            markersSortedByKmerId,
+                            maxSkip, maxDrift, maxMarkerFrequency, debug, graph, alignment, alignmentInfo);
+                    } else if (method == 1) {
+                        alignOrientedReads1(
+                            orientedReadId0, orientedReadId1,
+                            matchScore, mismatchScore, gapScore, alignment, alignmentInfo);
+                    } else if (method == 3) {
+                        alignOrientedReads3(
+                            orientedReadId0, orientedReadId1,
+                            matchScore, mismatchScore, gapScore,
+                            downsamplingFactor, bandExtend, maxBand,
+                            alignment, alignmentInfo);
+                    } else {
+                        SHASTA_ASSERT(0);
+                    }
+                } catch (const std::exception& e) {
+                    cout << e.what() << " for reads " << orientedReadId0 << " and " << orientedReadId1 << endl;
+                    continue;
+                } catch (...) {
+                    cout << "An error occurred while computing a marker alignment "
+                        " of oriented reads " << orientedReadId0 << " and " << orientedReadId1 <<
+                        ". This alignment candidate will be skipped. " << endl;
+                    continue;
                 }
+    
 
                 // If the alignment is poor, skip it.
                 if ((alignment.ordinals.size() < minAlignedMarkerCount) ||


### PR DESCRIPTION
Also handle SeqAn error gracefully when computing all alignments in the HTTP server.

### Test Plan
For E-Coli data set, this error condition was triggered for the read pair (1000, 4092). So I was able to test by computing the alignment between those two reads in the HTTP server.