### PR TITLE
Allow relative path in --Assembly.consensusCaller.

### DIFF
--- a/src/AssemblerOptions.hpp
+++ b/src/AssemblerOptions.hpp
@@ -242,12 +242,17 @@ public:
     public:
         int crossEdgeCoverageThreshold;
         int markerGraphEdgeLengthThresholdForConsensus;
+        string consensusCallerString;
         string consensusCaller;
         bool storeCoverageData;
         int storeCoverageDataCsvLengthThreshold;
         bool writeReadsByAssembledSegment;
         int detangleMethod;
         void write(ostream&) const;
+
+        // If a relative path is provided for a Bayesian consensus caller
+        // replace it with its absolute path.
+        void parseConsensusCallerString();
     };
     AssemblyOptions assemblyOptions;
 

--- a/src/SimpleBayesianConsensusCaller-Builtin.cpp
+++ b/src/SimpleBayesianConsensusCaller-Builtin.cpp
@@ -1,10 +1,19 @@
 #include "SimpleBayesianConsensusCaller.hpp"
 using namespace shasta;
 
-
+// Note: This needs to be kept in sync with constructBuiltin()
+bool SimpleBayesianConsensusCaller::isBuiltIn(const string& constructorString) {
+    return constructorString == "guppy-2.3.1-a" or
+        constructorString == "guppy-2.3.5-a" or
+        constructorString == "guppy-3.0.5-a" or
+        constructorString == "guppy-3.4.4-a" or
+        constructorString == "guppy-3.6.0-a" or
+        constructorString == "r10-guppy-3.4.8-a";
+}
 
 // Attempt to construct interpreting the constructor string as
 // a built-in configuration name.
+// Note: This needs to be kept in sync with isBuiltIn()
 bool SimpleBayesianConsensusCaller::constructBuiltin(const string& constructorString)
 {
     if(constructorString == "guppy-2.3.1-a"){

--- a/src/SimpleBayesianConsensusCaller.cpp
+++ b/src/SimpleBayesianConsensusCaller.cpp
@@ -153,7 +153,8 @@ SimpleBayesianConsensusCaller::SimpleBayesianConsensusCaller(
         if (not matrixFile.good()) {
             const string errorMessage = constructorString + " is not a built-in Bayesian model "
                 "and could not be open as a configuration file. "
-                "Valid built-in choices are: guppy-2.3.1-a, guppy-2.3.5-a, guppy-3.0.5-a";
+                "Valid built-in choices are: guppy-2.3.1-a, guppy-2.3.5-a, guppy-3.0.5-a, "
+                "guppy-3.4.4-a, guppy-3.6.0-a, r10-guppy-3.4.8-a.";
             throw runtime_error(errorMessage);
         }
         validate_text_file(constructorString);

--- a/src/SimpleBayesianConsensusCaller.hpp
+++ b/src/SimpleBayesianConsensusCaller.hpp
@@ -65,6 +65,8 @@ public:
     // run length of the aligned bases at a position
     virtual Consensus operator()(const Coverage&) const;
 
+    static bool isBuiltIn(const string&);
+
 private:
 
     /// ---- Attributes ---- ///


### PR DESCRIPTION
If one wants to use a custom Bayesian consensus caller, they can now specify a relative path as follows ...
`--Assembly.consensusCaller Bayesian:./shasta/conf/SimpleBayesianConsensusCaller-2.csv`

Detecting and replacing the relative path while parsing the configuration options has the added benefit of writing out the absolute path to `shasta.conf`.

### Test Plan
1. `--Assembly.consensusCaller Bayesian:./shasta/conf/SimpleBayesianConsensusCaller-2.csv` <= Custom relative path (Is written out with the absolute path)
2. `--Assembly.consensusCaller Bayesian:/path/from/root/shasta/conf/SimpleBayesianConsensusCaller-2.csv` <= Custom absolute path (is written out as is)
3. `--Assembly.consensusCaller Bayesian:guppy-3.6.0-a`  <= Built-in (is written out as is)
4. `--Assembly.consensusCaller Modal`

