### PR TITLE
Log software versions in the InstallPrereq-* scripts.

### DIFF
--- a/scripts/InstallPrerequisites-Ubuntu.sh
+++ b/scripts/InstallPrerequisites-Ubuntu.sh
@@ -100,6 +100,11 @@ make install
 cd 
 rm -rf $tmpDirectoryName
 
+echo "=============================="
+echo " Relevant software versions"
+echo "=============================="
+echo "$(apt list git g++ cmake libseqan2-dev libboost-all-dev libpng-dev graphviz gnuplot ncbi-blast+ python3 python3-pip 2>/dev/null)"
+echo "=============================="
 
 # Make sure the newly created libraries are immediately visible to the loader.
 ldconfig

--- a/scripts/InstallPrerequisites-macOS.sh
+++ b/scripts/InstallPrerequisites-macOS.sh
@@ -44,3 +44,11 @@ cd
 # Remove the temporary directory.
 rm -rf $tmpDirectoryName
 
+echo "==================================="
+echo " Relevant software versions"
+echo "==================================="
+echo "$(brew list --versions cmake boost libpng seqan@2)"
+echo "$(c++ --version | head -n 1)"
+echo "==================================="
+
+


### PR DESCRIPTION
I've often wondered which version of a particular library is installed via APT on different Ubuntu LTS releases. Instead of having to dig through the logs on Github action containers or search online, let's just log this information at the end of the InstallPrerequisite-*.sh scripts. 

Sample outputs on 

**macOS**
```
===================================
 Relevant software versions
===================================
boost 1.73.0
cmake 3.18.2
libpng 1.6.37
seqan@2 2.4.0
Apple clang version 11.0.3 (clang-1103.0.32.62)
===================================
```

**Ubuntu 16.04 LTS**
```
==============================
 Relevant software versions
==============================
Listing...
cmake/xenial-updates,now 3.5.1-1ubuntu3 amd64 [installed]
g++/xenial,now 4:5.3.1-1ubuntu1 amd64 [installed]
git/xenial,now 1:2.28.0-0ppa1~ubuntu16.04.1 amd64 [installed]
gnuplot/xenial,now 4.6.6-3 all [installed]
graphviz/xenial-updates,now 2.38.0-12ubuntu2.1 amd64 [installed]
libboost-all-dev/xenial,now 1.58.0.1ubuntu1 amd64 [installed]
ncbi-blast+/xenial,now 2.2.31-4 amd64 [installed]
python3/xenial,now 3.5.1-3 amd64 [installed]
python3-pip/xenial-updates,now 8.1.1-2ubuntu0.4 all [installed]
==============================
```