### PR TITLE
Undo auto-tuning of MinHash.minBucketSize and MinHash.maxBucketSize

### DIFF
--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -443,16 +443,9 @@ that each read is involved in reaches this value.
 If <code>--MinHash.minHashIterationCount</code> is not 0, this is not used.
 <a class=qm href='ComputationalMethods.html#FindingOverlappingReads'/>
 
-<tr id='MinHash.minBucketSize'>
-<td><code>--MinHash.minBucketSize</code><td class=centered><code>1</code><td>
-The minimum size for a bucket to be used by the MinHash/LowHash algoritm.
-If set to 0, an experimental algorithm is used to select the value automatically.
-<a class=qm href='ComputationalMethods.html#FindingOverlappingReads'/>
-
 <tr id='MinHash.maxBucketSize'>
 <td><code>--MinHash.maxBucketSize</code><td class=centered><code>10</code><td>
 The maximum size for a bucket to be used by the MinHash/LowHash algoritm.
-If set to 0, an experimental algorithm is used to select the value automatically.
 <a class=qm href='ComputationalMethods.html#FindingOverlappingReads'/>
 
 <tr id='MinHash.minFrequency'>

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -324,15 +324,13 @@ void AssemblerOptions::addConfigurableOptions()
 
         ("MinHash.minBucketSize",
         value<int>(&minHashOptions.minBucketSize)->
-        default_value(1),
-        "The minimum bucket size to be used by the LowHash algorithm. "
-        "If set to 0, an experimental algorithm is used to select the value automatically.")
+        default_value(0),
+        "The minimum bucket size to be used by the LowHash algoritm.")
 
         ("MinHash.maxBucketSize",
         value<int>(&minHashOptions.maxBucketSize)->
         default_value(10),
-        "The maximum bucket size to be used by the LowHash algorithm. "
-        "If set to 0, an experimental algorithm is used to select the value automatically.")
+        "The maximum bucket size to be used by the LowHash algoritm.")
 
         ("MinHash.minFrequency",
         value<int>(&minHashOptions.minFrequency)->

--- a/src/LowHash0.cpp
+++ b/src/LowHash0.cpp
@@ -2,7 +2,6 @@
 #include "LowHash0.hpp"
 #include "ReadFlags.hpp"
 #include "timestamp.hpp"
-#include "PeakFinder.hpp"
 using namespace shasta;
 
 // Standard library.
@@ -174,20 +173,10 @@ LowHash0::LowHash0(
         buckets.endPass2(false, false);
         computeBucketHistogram();
 
-        const size_t providedMinBucketSize = this->minBucketSize;
-        const size_t providedMaxBucketSize = this->maxBucketSize;
-        if (providedMinBucketSize == 0 || providedMaxBucketSize == 0) {
-            computeBucketSizesIfNotProvided();
-        }
-
         // Pass 3: inspect the buckets to find candidates.
         batchSize = 10000;
         setupLoadBalancing(readCount, batchSize);
         runThreads(&LowHash0::pass3ThreadFunction, threadCount);
-
-        // Restore original bucket sizes.
-        this->minBucketSize = providedMinBucketSize;
-        this->maxBucketSize = providedMaxBucketSize;
 
         // Write a summary for this iteration.
         highFrequency = 0;
@@ -367,49 +356,6 @@ void LowHash0::pass1ThreadFunction(size_t threadId)
 
 }
 
-void LowHash0::computeBucketSizesIfNotProvided() {
-    const double minBucketCutOff = 0.65;
-    const double maxBucketCutOff = 0.9;
-    
-    uint64_t cumulativeFeatureCount = 0;
-    vector<uint64_t> histogram(bucketHistogram.size(), 0);
-    
-    for (uint64_t bucketSize = 0; bucketSize < bucketHistogram.size(); bucketSize++) {
-        const auto frequency = bucketHistogram[bucketSize];
-        histogram[bucketSize] = bucketSize * frequency;
-        cumulativeFeatureCount += histogram[bucketSize];
-    }
-
-    uint64_t runningTotal = 0;
-    if (minBucketSize == 0) {
-        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
-            runningTotal += histogram[bucketSize];
-            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
-            if (fraction < minBucketCutOff) {
-                continue;
-            }
-            minBucketSize = bucketSize;
-            break;
-        }
-        minBucketSize = max(size_t(2), minBucketSize);
-        cout << "Computed minBucketSize = " << minBucketSize << endl;
-    }
-
-    runningTotal = 0;
-    if (maxBucketSize == 0) {
-        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
-            runningTotal += histogram[bucketSize];
-            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
-            if (fraction < maxBucketCutOff) {
-                continue;
-            }
-            maxBucketSize = bucketSize;
-            break;
-        }
-        maxBucketSize = max(size_t(10), maxBucketSize);
-        cout << "Computed maxBucketSize = " << maxBucketSize << endl;
-    }
-}
 
 
 // Pass 2: fill the buckets.
@@ -432,6 +378,16 @@ void LowHash0::pass2ThreadFunction(size_t threadId)
                 for(const uint64_t hash: orientedReadLowHashes) {
                     const uint64_t bucketId = hash & mask;
                     buckets.storeMultithreaded(bucketId, BucketEntry(orientedReadId, hash));
+
+                    // Update statistics for this read.
+                    const uint64_t bucketSize = buckets.size(bucketId);
+                    if(bucketSize < minBucketSize) {
+                        ++readLowHashStatistics[readId][0];
+                    } else if(bucketSize > maxBucketSize) {
+                        ++readLowHashStatistics[readId][2];
+                    } else {
+                        ++readLowHashStatistics[readId][1];
+                    }
                 }
             }
         }
@@ -475,16 +431,11 @@ void LowHash0::pass3ThreadFunction(size_t threadId)
                     const uint64_t bucketId = hash & mask;
                     const span<BucketEntry> bucket = buckets[bucketId];
                     if(bucket.size() < max(size_t(2), minBucketSize)) {
-                        ++readLowHashStatistics[readId0][0];
                         continue;
                     }
                     if(bucket.size() > maxBucketSize) {
-                        ++readLowHashStatistics[readId0][2];
                         continue;   // The bucket is too big. Skip it.
                     }
-
-                    ++readLowHashStatistics[readId0][1];
-                    
                     for(const BucketEntry& bucketEntry: bucket) {
                         if(bucketEntry.hashHighBits != hashHighBits) {
                             continue;   // Collision.
@@ -622,10 +573,7 @@ void LowHash0::computeBucketHistogram()
     for(const vector<uint64_t>& histogram: threadBucketHistogram) {
         largestBucketSize = max(largestBucketSize, uint64_t(histogram.size()));
     }
-    
-    bucketHistogram.resize(largestBucketSize);
-    fill(bucketHistogram.begin(), bucketHistogram.end(), uint64_t(0));
-
+    vector<uint64_t> bucketHistogram(largestBucketSize, 0);
     for(const vector<uint64_t>& histogram: threadBucketHistogram) {
         for(uint64_t bucketSize=0; bucketSize<histogram.size(); bucketSize++) {
             bucketHistogram[bucketSize] += histogram[bucketSize];
@@ -642,9 +590,9 @@ void LowHash0::computeBucketHistogram()
                 bucketSize*frequency << "\n";
         }
     }
+
+
 }
-
-
 void LowHash0::computeBucketHistogramThreadFunction(size_t threadId)
 {
     vector<uint64_t>& histogram = threadBucketHistogram[threadId];

--- a/src/LowHash0.cpp
+++ b/src/LowHash0.cpp
@@ -368,6 +368,9 @@ void LowHash0::pass1ThreadFunction(size_t threadId)
 }
 
 void LowHash0::computeBucketSizesIfNotProvided() {
+    const double minBucketCutOff = 0.65;
+    const double maxBucketCutOff = 0.9;
+    
     uint64_t cumulativeFeatureCount = 0;
     vector<uint64_t> histogram(bucketHistogram.size(), 0);
     
@@ -379,23 +382,14 @@ void LowHash0::computeBucketSizesIfNotProvided() {
 
     uint64_t runningTotal = 0;
     if (minBucketSize == 0) {
-        try {
-            shasta::PeakFinder p;
-            p.findPeaks(histogram);
-            minBucketSize = p.findXCutoff(histogram);
-            cout << "PeakFinder computed minBucketSize = " << minBucketSize << endl;
-        } catch (PeakFinderException) {
-            const double minBucketCutOff = 0.65;
-            
-            for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
-                runningTotal += histogram[bucketSize];
-                double fraction = double(runningTotal) / double(cumulativeFeatureCount);
-                if (fraction < minBucketCutOff) {
-                    continue;
-                }
-                minBucketSize = bucketSize;
-                break;
+        for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
+            runningTotal += histogram[bucketSize];
+            double fraction = double(runningTotal) / double(cumulativeFeatureCount);
+            if (fraction < minBucketCutOff) {
+                continue;
             }
+            minBucketSize = bucketSize;
+            break;
         }
         minBucketSize = max(size_t(2), minBucketSize);
         cout << "Computed minBucketSize = " << minBucketSize << endl;
@@ -403,8 +397,6 @@ void LowHash0::computeBucketSizesIfNotProvided() {
 
     runningTotal = 0;
     if (maxBucketSize == 0) {
-        const double maxBucketCutOff = 0.9;
-   
         for (uint64_t bucketSize = 0; bucketSize < histogram.size(); bucketSize++) {
             runningTotal += histogram[bucketSize];
             double fraction = double(runningTotal) / double(cumulativeFeatureCount);

--- a/src/LowHash0.hpp
+++ b/src/LowHash0.hpp
@@ -179,7 +179,6 @@ private:
     void computeBucketHistogram();
     void computeBucketHistogramThreadFunction(size_t threadId);
     vector< vector<uint64_t> > threadBucketHistogram;
-    vector<uint64_t> bucketHistogram;
     ofstream histogramCsv;
 
 
@@ -195,8 +194,6 @@ private:
 
     // Pass 3: inspect the buckets to find candidates.
     void pass3ThreadFunction(size_t threadId);
-
-    void computeBucketSizesIfNotProvided();
 
 };
 

--- a/src/LowHash1.hpp
+++ b/src/LowHash1.hpp
@@ -108,10 +108,9 @@ private:
     void computeBucketHistogram();
     void computeBucketHistogramThreadFunction(size_t threadId);
     vector< vector<uint64_t> > threadBucketHistogram;
-    vector<uint64_t> bucketHistogram;
     ofstream histogramCsv;
 
-    void computeBucketSizesIfNotProvided();
+
 
     // When two oriented reads appear in the same bucket, we
     // check if that happens by chance or because we found a


### PR DESCRIPTION
We need to go back to the drawing board for this. 