### PR TITLE
More parameters for PeakFinder

### DIFF
--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -270,10 +270,10 @@ void Assembler::createMarkerGraphVertices(
         if (minCoverage == 0) {
             try {
                 shasta::PeakFinder p;
-                double minPercentArea = 8;
+                double minAreaFraction = 0.08;
                 uint64_t areaStartIndex = 2;
                 p.findPeaks(histogram);
-                minCoverage = p.findXCutoff(histogram, minPercentArea, areaStartIndex);
+                minCoverage = p.findXCutoff(histogram, minAreaFraction, areaStartIndex);
                 cout << "Automatically selected value of MarkerGraph.minCoverage "
                     "is " << minCoverage << endl;
             }

--- a/src/AssemblerMarkerGraph.cpp
+++ b/src/AssemblerMarkerGraph.cpp
@@ -270,16 +270,22 @@ void Assembler::createMarkerGraphVertices(
         if (minCoverage == 0) {
             try {
                 shasta::PeakFinder p;
+                double minPercentArea = 8;
+                uint64_t areaStartIndex = 2;
                 p.findPeaks(histogram);
-                minCoverage = p.findXCutoff(histogram);
+                minCoverage = p.findXCutoff(histogram, minPercentArea, areaStartIndex);
                 cout << "Automatically selected value of MarkerGraph.minCoverage "
                     "is " << minCoverage << endl;
             }
-            catch (PeakFinderException){
-                throw runtime_error(
+            catch (PeakFinderException& e){
+                minCoverage = 5;
+                cout <<
                     "Unable to automatically select MarkerGraph.minCoverage. "
                     "No significant cutoff found in disjoint sets size distribution. "
-                    "See DisjointSetsHistogram.csv.");
+                    "Observed peak has percent total area of " << e.observedPercentArea << endl <<
+                    "minPercentArea is " << e.minPercentArea << endl <<
+                    "See DisjointSetsHistogram.csv."
+                    "Using MarkerGraph.minCoverage = " << minCoverage << endl;
             }
         }
     }

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -4,9 +4,9 @@
 using namespace shasta;
 
 
-shasta::PeakFinderException::PeakFinderException(double minPercentArea, double observedPercentArea):
-        minPercentArea(minPercentArea),
-        observedPercentArea(observedPercentArea)
+shasta::PeakFinderException::PeakFinderException(double minAreaFraction, double observedAreaFraction):
+        minPercentArea(minAreaFraction),
+        observedPercentArea(observedAreaFraction)
 {}
 
 
@@ -155,10 +155,10 @@ uint64_t PeakFinder::calculateArea(const vector<uint64_t>& y, uint64_t xMin, uin
 }
 
 
-uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y, double minPercentArea, uint64_t percentAreaStartIndex){
+uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y, double minAreaFraction, uint64_t areaFractionStartIndex){
     // First check that there is at least one peak (beyond the expected error peak at x=1)
     if (peaks.size() < 2) {
-        throw PeakFinderException(minPercentArea, 0);
+        throw PeakFinderException(minAreaFraction, 0);
     }
 
     sortByPersistence();
@@ -177,21 +177,21 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y, double minPercentAre
     }
 
     // find the total AUC
-    uint64_t totalArea = calculateArea(y, percentAreaStartIndex, y.size() - 1);
+    uint64_t totalArea = calculateArea(y, areaFractionStartIndex, y.size() - 1);
 
     // Find the AUC inside the bounds of the peak (from y=0 and up)
     uint64_t peakArea = calculateArea(y, leftBound, rightBound);
 
-    double percentArea = 100 * (double(peakArea) / double(totalArea));
+    double areaFraction = (double(peakArea) / double(totalArea));
 
     uint64_t xCutoff;
 
     // Check if second most prominent peak is reasonable size (not a false peak)
-    if (percentArea > minPercentArea){
+    if (areaFraction > minAreaFraction){
         xCutoff = leftBound;
     }
     else{
-        throw PeakFinderException(minPercentArea, percentArea);
+        throw PeakFinderException(minAreaFraction, areaFraction);
     }
 
     return xCutoff;

--- a/src/PeakFinder.cpp
+++ b/src/PeakFinder.cpp
@@ -4,6 +4,12 @@
 using namespace shasta;
 
 
+shasta::PeakFinderException::PeakFinderException(double minPercentArea, double observedPercentArea):
+        minPercentArea(minPercentArea),
+        observedPercentArea(observedPercentArea)
+{}
+
+
 PeakFinder::Peak::Peak(uint64_t start):
         start(start),
         stop(0),
@@ -12,7 +18,6 @@ PeakFinder::Peak::Peak(uint64_t start):
         isMerged(false),
         persistence(0)
 {}
-
 
 
 void PeakFinder::findPeaks(const vector<uint64_t>& y){
@@ -150,10 +155,10 @@ uint64_t PeakFinder::calculateArea(const vector<uint64_t>& y, uint64_t xMin, uin
 }
 
 
-uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
+uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y, double minPercentArea, uint64_t percentAreaStartIndex){
     // First check that there is at least one peak (beyond the expected error peak at x=1)
     if (peaks.size() < 2) {
-        throw PeakFinderException();
+        throw PeakFinderException(minPercentArea, 0);
     }
 
     sortByPersistence();
@@ -161,7 +166,7 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
     uint64_t leftBound;
     uint64_t rightBound;
 
-    // Find the second peak's left bound, in case the error peak is not actually the most persistent
+    // Find the second peak
     if (peaks[1].start < peaks[0].start){
         leftBound = peaks[1].right;
         rightBound = peaks[0].right;
@@ -171,9 +176,8 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
         rightBound = peaks[1].right;
     }
 
-
     // find the total AUC
-    uint64_t totalArea = calculateArea(y, 1, y.size() - 1);
+    uint64_t totalArea = calculateArea(y, percentAreaStartIndex, y.size() - 1);
 
     // Find the AUC inside the bounds of the peak (from y=0 and up)
     uint64_t peakArea = calculateArea(y, leftBound, rightBound);
@@ -183,11 +187,11 @@ uint64_t PeakFinder::findXCutoff(const vector<uint64_t>& y){
     uint64_t xCutoff;
 
     // Check if second most prominent peak is reasonable size (not a false peak)
-    if (percentArea > 1){
+    if (percentArea > minPercentArea){
         xCutoff = leftBound;
     }
     else{
-        throw PeakFinderException();
+        throw PeakFinderException(minPercentArea, percentArea);
     }
 
     return xCutoff;

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -67,7 +67,7 @@ public:
     const double minPercentArea;
     const double observedPercentArea;
 
-    PeakFinderException(double minPercentArea, double observedPercentArea);
+    PeakFinderException(double minAreaFraction, double observedAreaFraction);
 };
 
 
@@ -111,7 +111,7 @@ public:
     void findPeaks(const vector<uint64_t>& y);
 
     void sortByPersistence();
-    uint64_t findXCutoff(const vector<uint64_t>& y, double minPercentArea=8, uint64_t percentAreaStartIndex=2);
+    uint64_t findXCutoff(const vector<uint64_t>& y, double minAreaFraction=0.08, uint64_t areaFractionStartIndex=2);
     uint64_t calculateArea(const vector<uint64_t>& y, uint64_t xMin, uint64_t xMax);
 
 };

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -62,7 +62,13 @@ namespace shasta {
 }
 
 
-class shasta::PeakFinderException{};
+class shasta::PeakFinderException{
+public:
+    const double minPercentArea;
+    const double observedPercentArea;
+
+    PeakFinderException(double minPercentArea, double observedPercentArea);
+};
 
 
 class shasta::PeakFinder {
@@ -105,7 +111,7 @@ public:
     void findPeaks(const vector<uint64_t>& y);
 
     void sortByPersistence();
-    uint64_t findXCutoff(const vector<uint64_t>& y);
+    uint64_t findXCutoff(const vector<uint64_t>& y, double minPercentArea=8, uint64_t percentAreaStartIndex=1);
     uint64_t calculateArea(const vector<uint64_t>& y, uint64_t xMin, uint64_t xMax);
 
 };

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -111,7 +111,7 @@ public:
     void findPeaks(const vector<uint64_t>& y);
 
     void sortByPersistence();
-    uint64_t findXCutoff(const vector<uint64_t>& y, double minPercentArea=8, uint64_t percentAreaStartIndex=1);
+    uint64_t findXCutoff(const vector<uint64_t>& y, double minPercentArea=8, uint64_t percentAreaStartIndex=2);
     uint64_t calculateArea(const vector<uint64_t>& y, uint64_t xMin, uint64_t xMax);
 
 };


### PR DESCRIPTION
This is primarily intended to address a failure in PeakFinder to choose a cutoff when the distribution contains an overwhelmingly large value at x=1. The (temporary?) solution is more configurability for the percent area calculation, allowing x=1 to be omitted.