### PR TITLE
Fix Reads N50 computation.

### DIFF
--- a/src/Reads.cpp
+++ b/src/Reads.cpp
@@ -417,7 +417,7 @@ void Reads::writeReadLengthHistogram(const string& fileName) {
                 const double cumulativeReadFraction =
                     double(cumulativeReadCount)/double(totalReadCount);
                 const double comulativeBaseFraction =
-                    double(cumulativeBaseCount)/double(baseCount);
+                    double(cumulativeBaseCount)/double(totalBaseCount);
                 csv << length << "," << frequency << "," << baseCount << ",";
                 csv << cumulativeReadCount << "," << cumulativeBaseCount << ",";
                 csv << cumulativeReadFraction << ",";


### PR DESCRIPTION
Verified that the last column in ReadLengthHistogram.csv is now correct.
Verified that the `Reads N50` logged in AssemblySummary.html/json is now correct.