### PR TITLE
Update configs with detangle 2, add oldGuppy

### DIFF
--- a/conf/Nanopore-OldGuppy-Sep2020.conf
+++ b/conf/Nanopore-OldGuppy-Sep2020.conf
@@ -8,18 +8,21 @@
 # - Human genome assembly.
 # - Coverage between 40x and 80x. If you have more coverage than that,
 #   you can use option "--Reads.minReadLength" to adjust coverage as desired.
-# - Reads from Guppy 3.6.0 base caller. If you have reads
-#   from an older version of Guppy, use configuration file
-#   Nanopore-UL-Dec2019.conf instead.
+# - Reads from Guppy 3.0.5 base caller. Also known to work with
+#   reads from other Guppy releases 3.0.x and 3.1.x.
 
 # The automation provided by this config is particularly applicable to
 # low coverage or non-human samples. It also matches or exceeds continuity
-# in human samples, relative to the appropriately chosen 3.6.0 or 3.6.0-UL conf.
-# Automation can be activated with parameters designed for earlier basecallers,
-# if needed, but updating to guppy 3.6.0 or higher will greatly improve assembly
+# in human samples, relative to the appropriately chosen config file.
+# Updating to guppy 3.6.0 or higher will greatly improve assembly
 # quality and is therefore strongly recommended.
 
-# In most cases, for best performance on a large assembly 
+# To use this configuration file, specify Shasta option
+# "--config AbsolutePathToThisFile".
+# If you specify any conflicting values on the command line,
+# the values specified on the command line take precedence.
+
+# In most cases, for best performance on a large assembly
 # you will usually also want to use the following options, which 
 # cannot be specified in a configuration file:
 # --memoryMode filesystem
@@ -43,16 +46,11 @@
 
 [Reads]
 # If you have extra coverage, use this option to adjust coverage.
-minReadLength = 50000
+minReadLength = 10000
 noCache = True
 
-[Kmers]
-# Due to the higher accuracy of Guppy 3.6.0 we use longer
-# markers than usual.
-k = 14
-
 [MinHash]
-minBucketSize = 10
+minBucketSize = 5
 maxBucketSize = 30
 minFrequency = 5
 
@@ -84,7 +82,6 @@ crossEdgeCoverageThreshold = 3
 minCoverage = 0
 
 [Assembly]
-consensusCaller = Bayesian:guppy-3.6.0-a
+consensusCaller = Bayesian:guppy-3.0.5-a
 detangleMethod = 2
-
 

--- a/conf/Nanopore-OldGuppy-Sep2020.conf
+++ b/conf/Nanopore-OldGuppy-Sep2020.conf
@@ -1,6 +1,3 @@
-# DO NOT USE THIS FILE IF YOU HAVE READS CREATED BY A
-# GUPPY VERSION OLDER THAN 3.6.0.
-
 # This file contains Shasta options which attempt to partially automate
 # parameter selection. It is based on an earlier config, which, as of Jun 2020,
 # was known to work with Oxford Nanopore reads under the following circumstances:

--- a/conf/Nanopore-Sep2020.conf
+++ b/conf/Nanopore-Sep2020.conf
@@ -90,6 +90,6 @@ minCoverage = 0
 
 [Assembly]
 consensusCaller = Bayesian:guppy-3.6.0-a
-detangleMethod = 1
+detangleMethod = 2
 
 


### PR DESCRIPTION
All Sep2020 configs now have `detangleMethod 2`, and a config has been created for guppy <3.6.0