### PR TITLE
Prepare for release v0.6.0

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -17,8 +17,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.5.1 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.5.1" 
+        # cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.6.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.6.0" 
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-20.04
@@ -50,8 +50,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.5.1 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.5.1" 
+        # cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.6.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.6.0" 
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-18.04
@@ -79,8 +79,8 @@ jobs:
         lsb_release -a
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.5.1 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.5.1"
+        # cmake .. -DBUILD_ID="Shasta unreleased test build newer than release 0.6.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.6.0"
         make -j 2 all
         make install/strip
         mv shasta-install shasta-Ubuntu-16.04
@@ -112,8 +112,8 @@ jobs:
       run: |
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.14 newer than release 0.5.1 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.5.1 for MacOS-10.14"
+        # cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.14 newer than release 0.6.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.6.0 for MacOS-10.14"
         make VERBOSE=1 -j 2 all
         make install/strip
         # See what libraries the executable depends on.
@@ -136,8 +136,8 @@ jobs:
       run: |
         mkdir shasta-build
         cd shasta-build 
-        cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.15 newer than release 0.5.1 at commit "$GITHUB_SHA
-        # cmake .. -DBUILD_ID="Shasta Release 0.5.1 for MacOS-10.15"
+        # cmake .. -DBUILD_ID="Shasta unreleased test build for MacOS-10.15 newer than release 0.6.0 at commit "$GITHUB_SHA
+        cmake .. -DBUILD_ID="Shasta Release 0.6.0 for MacOS-10.15 & MacOS-10.14"
         make VERBOSE=1 -j 2 all
         make install/strip
         # See what libraries the executable depends on.

--- a/conf/Nanopore-OldGuppy-Sep2020.conf
+++ b/conf/Nanopore-OldGuppy-Sep2020.conf
@@ -72,7 +72,6 @@ creationMethod = 2
 
 [MarkerGraph]
 simplifyMaxLength = 10,100,1000,10000,100000
-refineThreshold = 6
 crossEdgeCoverageThreshold = 3
 
 # Automatically determine this using PeakFinder

--- a/conf/Nanopore-Sep2020.conf
+++ b/conf/Nanopore-Sep2020.conf
@@ -82,7 +82,6 @@ creationMethod = 2
 
 [MarkerGraph]
 simplifyMaxLength = 10,100,1000,10000,100000
-refineThreshold = 6
 crossEdgeCoverageThreshold = 3
 
 # Automatically determine this using PeakFinder

--- a/conf/Nanopore-UL-Sep2020.conf
+++ b/conf/Nanopore-UL-Sep2020.conf
@@ -77,7 +77,6 @@ creationMethod = 2
 
 [MarkerGraph]
 simplifyMaxLength = 10,100,1000,10000,100000
-refineThreshold = 6
 crossEdgeCoverageThreshold = 3
 
 # Automatically determine this using PeakFinder

--- a/conf/Nanopore-UL-iterative-Sep2020.conf
+++ b/conf/Nanopore-UL-iterative-Sep2020.conf
@@ -37,7 +37,6 @@ creationMethod = 2
 [MarkerGraph]
 minCoveragePerStrand = 3
 simplifyMaxLength = 10,100
-refineThreshold = 0
 crossEdgeCoverageThreshold = 3 
 
 [Assembly]

--- a/docs/MakeRelease.html
+++ b/docs/MakeRelease.html
@@ -47,10 +47,10 @@ Wait for that build to complete.
 sudo ./shasta/scripts/InstallPrerequisites-Ubuntu.sh
 mkdir -p shasta-build
 cd shasta-build
-cmake ../shasta
+cmake ../shasta -DBUILD_ID="Shasta Release X.Y.Z for 64 bit ARM"
 make install -j
 </code></li>
-<li>Download the <code>aarch64</code> Shasta binary (using <code>scp</code>) and rename it to <code>shasta-Linux-aarch64-X.Y.Z</code>. This is the seventh artifact for the release.</li>
+<li>Download the <code>aarch64</code> Shasta binary (using <code>scp</code>) and rename it to <code>shasta-Linux-ARM-X.Y.Z</code>. This is the seventh artifact for the release.</li>
 </ul>
 </li>
 

--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -21,13 +21,13 @@ See below for more information, including some small changes required for macOS 
 You can use the following commands to download the executable from the latest release and run an assembly:
 <pre>
 # Download the executable for the latest release.
-curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.5.1/shasta-Linux-0.5.1
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.6.0/shasta-Linux-0.6.0
 
 # Grant necessary permissions.
-chmod ugo+x shasta-Linux-0.5.1
+chmod ugo+x shasta-Linux-0.6.0
 
 # Run an assembly.
-./shasta-Linux-0.5.1 --input input.fasta
+./shasta-Linux-0.6.0 --input input.fasta
 </pre>
 
 <p>
@@ -67,17 +67,16 @@ to achieve maximum performance.
 
 <pre>
 # Download the executable for the latest release.
-curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.5.1/shasta-macOS-10.15-0.5.1
+curl -O -L https://github.com/chanzuckerberg/shasta/releases/download/0.6.0/shasta-macOS-0.6.0
 
 # Grant necessary permissions.
-chmod ugo+x shasta-macOS-10.15-0.5.1
+chmod ugo+x shasta-macOS-0.6.0
 
 # Run an assembly.
-./shasta-macOS-10.15-0.5.1 --input input.fasta
+./shasta-macOS-0.6.0 --input input.fasta
 </pre>
-The above assumes that you are on macOS 10.15 (<i>Catalina</i>).
-If you are on macOS 10.14 (<i>Mojave</i>), change the name of the executable 
-accordingly in the 3 above commands.
+The macOS executable has been tested on macOS 10.15 (<i>Catalina</i>) and
+macOS 10.14 (<i>Mojave</i>).
 
 <h2 id="QuickStartWindows">Windows</h2>
 <ul>

--- a/docs/Running.html
+++ b/docs/Running.html
@@ -656,10 +656,10 @@ See
 <h2 id=Errors>Dealing with errors</h2>
 <ul>
 <li> <code>FATAL: kernel too old</code> : If you get this error when using
-<code>shasta-Linux-0.5.1</code>, then you should retry with <code>shasta-OldLinux-0.5.1</code>, which is a version of Shasta built for older kernels.
+<code>shasta-Linux-0.6.0</code>, then you should retry with <code>shasta-OldLinux-0.6.0</code>, which is a version of Shasta built for older kernels.
 You can find out the kernel version on your system by running <code>uname -a</code>.
 Compare it with the minimum required kernel version for the Shasta executable by running
-<code>file shasta-Linux-0.5.1</code> or <code>file shasta-OldLinux-0.5.1</code>.
+<code>file shasta-Linux-0.6.0</code> or <code>file shasta-OldLinux-0.6.0</code>.
 
 <li> <code>sh: 1: cannot create /sys/kernel/mm/hugepages/hugepages-2048kB/nr_overcommit_hugepages: Read-only file system</code>: Shasta needs root privilege to use the `hugetlbfs` filesystem. If you're running this in a Docker container, you need to
 use the Docker option <code>--privileged</code>.  	


### PR DESCRIPTION
Updating version numbers in documentation and in Github actions build file. Note the changes to the BUILD_ID for macOS-10.15 build. We have verified that Shasta built on 10.15, runs without issues on 10.14. So the executable built on macOS-10.15 will be released as `shasta-macOS-0.6.0`.