### PR TITLE
Handle O_DIRECT errors gracefully.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         sudo apt install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shasta-Ubuntu-20.04/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta
+        shasta-build/shasta-Ubuntu-20.04/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta --Reads.noCache
         ls -l ShastaRun/Assembly.fasta
     
        

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -488,7 +488,27 @@ void ReadLoader::processFastqFileThreadFunction(size_t threadId)
     }
 }
 
+#ifdef __linux__
+int ReadLoader::tryDirectIO(const string& fileName) {
+    auto fd = ::open(fileName.c_str(), O_RDONLY | O_DIRECT);
+    if (fd == -1) {
+        // This could happen for a variety of reasons. If the file is readable and it still cannot
+        // be opened, it is likely that the volume/file-system does not support the O_DIRECT flag.
+        return O_RDONLY;
+    }
+    
+    // Verify that the O_DIRECT flag is actually supported. Sometimes the error shows up in the read call.
+    char byte;
+    auto bytesRead = ::read(fd, &byte, 1);
+    ::close(fd);
+    if (bytesRead == -1) {
+        return O_RDONLY;
+    }
 
+    // File can be opened and read using Direct IO.
+    return O_RDONLY | O_DIRECT;
+}
+#endif
 
 // Read an entire file into a buffer,
 // using threadCountForReading threads.
@@ -507,7 +527,12 @@ void ReadLoader::readFile()
     int flags = O_RDONLY;
 #ifdef __linux__
     if(noCache) {
-        flags |= O_DIRECT;
+        flags = tryDirectIO(fileName);
+        if (flags == (O_RDONLY | O_DIRECT)) {
+            cout << "O_DIRECT flag supported by the file system." << endl;
+        } else {
+            cout << "O_DIRECT flag not supported by file system." << endl;
+        }
     }
 #endif
     const int fileDescriptor = ::open(fileName.c_str(), flags);

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -126,7 +126,9 @@ private:
     // The ReadId corresponding to each index in the Runnie file.
     vector<ReadId> readIdTable;
 
-
+#ifdef __linux__
+    int tryDirectIO(const string& fileName);
+#endif
 };
 
 


### PR DESCRIPTION
If O_DIRECT flag is not supported by the file system, Shasta will fall back to using regular file IO. 