### PR TITLE
Handle O_DIRECT errors gracefully.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         sudo apt install gzip
         gunzip tests/TinyTest.fasta.gz
-        shasta-build/shasta-Ubuntu-20.04/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta
+        shasta-build/shasta-Ubuntu-20.04/bin/shasta --Align.alignMethod 3 --input tests/TinyTest.fasta --Reads.noCache
         ls -l ShastaRun/Assembly.fasta
     
        

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -528,10 +528,9 @@ void ReadLoader::readFile()
 #ifdef __linux__
     if(noCache) {
         flags = tryDirectIO(fileName);
-        if (flags == (O_RDONLY | O_DIRECT)) {
-            cout << "O_DIRECT flag supported by the file system." << endl;
-        } else {
-            cout << "O_DIRECT flag not supported by file system." << endl;
+        if (flags != (O_RDONLY | O_DIRECT)) {
+            cout << "--Reads.noCache was turned off for " << fileName
+                << " because it is not supported by the filesystem." << endl;
         }
     }
 #endif

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -126,7 +126,9 @@ private:
     // The ReadId corresponding to each index in the Runnie file.
     vector<ReadId> readIdTable;
 
-
+#ifdef __linux__
+    int tryDirectIO(const string& fileName);
+#endif
 };
 
 


### PR DESCRIPTION
Since O_DIRECT related read failures can happen at file `open` as well `read`, I open and read (a pageSize worth of data) from the file to confirm that O_DIRECT actually works. 