### PR TITLE
Add new browser page for candidate visualization

### DIFF
--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -44,6 +44,7 @@ namespace shasta {
     class CompressedAssemblyGraph;
     class ConsensusCaller;
     class LocalAssemblyGraph;
+    class LocalAlignmentCandidateGraph;
     class LocalAlignmentGraph;
     class LocalReadGraph;
     class Reads;
@@ -712,7 +713,7 @@ private:
         uint32_t maxDistance,           // How far to go from starting oriented read.
         bool allowChimericReads,
         double timeout,                 // Or 0 for no timeout.
-        LocalAlignmentGraph& graph);
+        LocalAlignmentCandidateGraph& graph);
 
     // Compute a marker alignment of two oriented reads.
     void alignOrientedReads(
@@ -1852,6 +1853,7 @@ public:
     void exploreSummary(const vector<string>&, ostream&);
     void exploreRead(const vector<string>&, ostream&);
     void blastRead(const vector<string>&, ostream&);
+    void exploreCandidateGraph(const vector<string>&, ostream&);
     void exploreAlignments(const vector<string>&, ostream&);
     void exploreAlignment(const vector<string>&, ostream&);
     void alignSequencesInBaseRepresentation(const vector<string>&, ostream&);
@@ -1861,6 +1863,7 @@ public:
     void exploreUndirectedReadGraph(const vector<string>&, ostream&);
     void exploreDirectedReadGraph(const vector<string>&, ostream&);
     void exploreCompressedAssemblyGraph(const vector<string>&, ostream&);
+    static bool parseCommaSeparatedReadIDs(string& commaSeparatedReadIds, vector<OrientedReadId>& readIds, ostream& html);
     static void addScaleSvgButtons(ostream&);
     class HttpServerData {
     public:

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -1853,7 +1853,7 @@ public:
     void exploreSummary(const vector<string>&, ostream&);
     void exploreRead(const vector<string>&, ostream&);
     void blastRead(const vector<string>&, ostream&);
-    void exploreCandidateGraph(const vector<string>&, ostream&);
+    void exploreAlignmentCandidateGraph(const vector<string>& request, ostream& html);
     void exploreAlignments(const vector<string>&, ostream&);
     void exploreAlignment(const vector<string>&, ostream&);
     void alignSequencesInBaseRepresentation(const vector<string>&, ostream&);

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -7,6 +7,7 @@
 #include "AlignmentGraph.hpp"
 #include "Histogram.hpp"
 #include "LocalAlignmentGraph.hpp"
+#include "LocalAlignmentCandidateGraph.hpp"
 #include "platformDependent.hpp"
 #include "PngImage.hpp"
 #include "ReadId.hpp"
@@ -24,6 +25,210 @@ using namespace shasta;
 #include "chrono.hpp"
 using std::random_device;
 using std::uniform_int_distribution;
+
+
+void Assembler::exploreCandidateGraph(
+        const vector<string>& request,
+        ostream& html)
+{
+    // Get the parameters.
+    vector<OrientedReadId> readIds;
+    string readIdsString;
+    const bool readIdsArePresent = getParameterValue(request, "readId", readIdsString);
+    const bool readStringsAreValid = parseCommaSeparatedReadIDs(readIdsString, readIds, html);
+
+    uint32_t maxDistance = 2;
+    getParameterValue(request, "maxDistance", maxDistance);
+
+    string allowChimericReadsString;
+    const bool allowChimericReads = getParameterValue(request, "allowChimericReads", allowChimericReadsString);
+
+    string allowCrossStrandEdgesString;
+    const bool allowCrossStrandEdges = getParameterValue(request, "allowCrossStrandEdges", allowCrossStrandEdgesString);
+
+    string layoutMethod = "sfdp";
+    getParameterValue(request, "layoutMethod", layoutMethod);
+
+    uint32_t sizePixels = 600;
+    getParameterValue(request, "sizePixels", sizePixels);
+
+    double vertexScalingFactor = 1.;
+    getParameterValue(request, "vertexScalingFactor", vertexScalingFactor);
+
+    double edgeThicknessScalingFactor = 1.;
+    getParameterValue(request, "edgeThicknessScalingFactor", edgeThicknessScalingFactor);
+
+    double timeout = 30;
+    getParameterValue(request, "timeout", timeout);
+
+
+    // Write the form.
+    string readGraphHeading;
+    if (httpServerData.docsDirectory.empty()) {
+        readGraphHeading = "<h3>Display a local subgraph of the global alignment graph</h3>";
+    } else {
+        readGraphHeading =
+                "<h3>Display a local subgraph of the <a href='docs/ComputationalMethods.html#ReadGraph'>read graph</a></h3>";
+    }
+    html << readGraphHeading <<
+         "<form>"
+         "<div style='clear:both; display:table;'>"
+         "<div style='float:left;margin:10px;'>"
+         "<table>"
+
+         "<tr title='Read id between 0 and " << reads->readCount() - 1 << "'>"
+                                                                          "<td style=\"white-space:pre-wrap; word-wrap:break-word\">"
+                                                                          "Start vertex reads\n"
+                                                                          "The oriented read should be in the form <code>readId-strand</code>\n"
+                                                                          "where strand is 0 or 1. For example, <code>\"1345871-1</code>\".\n"
+                                                                          "To add multiple start points, use a comma separator."
+                                                                          "<td><input type=text required name=readId size=8 style='text-align:center'"
+         << (readIdsArePresent ? ("value='" + readIdsString + "'") : "") <<
+         ">";
+
+
+    html <<
+         "<tr title='Maximum distance from start vertex (number of edges)'>"
+         "<td>Maximum distance"
+         "<td><input type=text required name=maxDistance size=8 style='text-align:center'"
+         " value='" << maxDistance <<
+         "'>"
+
+         "<tr title='Allow reads marked as chimeric to be included in the local read graph.'>"
+         "<td>Allow chimeric reads"
+         "<td class=centered><input type=checkbox name=allowChimericReads" <<
+         (allowChimericReads ? " checked" : "") <<
+         ">"
+
+         "<tr title='Allow edges that skip across strands.'>"
+         "<td>Allow cross-strand edges"
+         "<td class=centered><input type=checkbox name=allowCrossStrandEdges" <<
+         (allowCrossStrandEdges ? " checked" : "") <<
+         ">"
+
+         "<tr>"
+         "<td>Layout method"
+         "<td class=centered>"
+         "<input type=radio required name=layoutMethod value='sfdp'" <<
+         (layoutMethod == "sfdp" ? " checked=on" : "") <<
+         ">sfdp"
+         "<br><input type=radio required name=layoutMethod value='fdp'" <<
+         (layoutMethod == "fdp" ? " checked=on" : "") <<
+         ">fdp"
+         "<br><input type=radio required name=layoutMethod value='neato'" <<
+         (layoutMethod == "neato" ? " checked=on" : "") <<
+         ">neato"
+
+         "<tr title='Graphics size in pixels. "
+         "Changing this works better than zooming. Make it larger if the graph is too crowded."
+         " Ok to make it much larger than screen size.'>"
+         "<td>Graphics size in pixels"
+         "<td><input type=text required name=sizePixels size=8 style='text-align:center'" <<
+         " value='" << sizePixels <<
+         "'>"
+
+         "<tr>"
+         "<td>Vertex scaling factor"
+         "<td><input type=text required name=vertexScalingFactor size=8 style='text-align:center'" <<
+         " value='" << vertexScalingFactor <<
+         "'>"
+
+         "<tr>"
+         "<td>Edge thickness scaling factor"
+         "<td><input type=text required name=edgeThicknessScalingFactor size=8 style='text-align:center'" <<
+         " value='" << edgeThicknessScalingFactor <<
+         "'>"
+
+         "<tr title='Maximum time (in seconds) allowed for graph creation and layout'>"
+         "<td>Timeout (seconds) for graph layout"
+         "<td><input type=text required name=timeout size=8 style='text-align:center'" <<
+         " value='" << timeout <<
+         "'>"
+
+         "</table>"
+         "</div>"
+         "</div>"
+         "<br><input type=submit value='Display'>"
+         "</form>";
+
+
+    // If any necessary values are missing, stop here.
+    if (not readIdsArePresent) {
+        return;
+    }
+
+    // If there was a failure to parse comma separated readId-strand tokens, stop here
+    if (not readStringsAreValid) {
+        return;
+    }
+
+    // Validity checks.
+    for (auto &readId: readIds){
+        if (readId.getReadId() > reads->readCount()) {
+            html << "<p>Invalid read id " << readId;
+            html << ". Must be between 0 and " << reads->readCount() - 1 << ".";
+            return;
+        }
+    }
+
+    // As of yet the candidate table is not used during assembly, so it may need to be created
+    if (not alignmentCandidates.candidateTable.isOpen()){
+        alignmentCandidates.computeCandidateTable(
+                reads->readCount(),
+                largeDataName("CandidateTable"),
+                largeDataPageSize);
+    }
+
+    // Create the local read graph.
+    LocalAlignmentCandidateGraph graph;
+    if(!createLocalCandidateGraph(
+            readIds,
+            maxDistance,
+            allowChimericReads,
+            timeout,
+            graph
+    )) {
+        html << "<p>Timeout for graph creation exceeded. Increase the timeout or reduce the maximum distance from the start vertex.";
+        return;
+    }
+    html << "<p>The local read graph has " << num_vertices(graph);
+    html << " vertices and " << num_edges(graph) << " edges.";
+
+
+    // Write a title.
+    html <<
+         "<h1 style='line-height:10px'>Read graph near oriented read(s) " << readIdsString << "</h1>";
+
+
+    // Allow manually highlighting selected vertices.
+    html << R"stringDelimiter(
+        <script>
+        function highlight_vertex()
+        {
+            vertex = document.getElementById("highlight").value;
+            document.getElementById("highlight").value = "";
+            element = document.getElementById("Vertex-" + vertex);
+            element.setAttribute("fill", "#ff00ff");
+        }
+        </script>
+        <p>
+        <input id=highlight type=text onchange="highlight_vertex()" size=10>
+        Enter an oriented read to highlight, then press Enter. The oriented read should be
+        in the form <code>readId-strand</code> where strand is 0 or 1 (for example, <code>"1345871-1</code>").
+        To highlight multiple oriented reads, enter them one at a time in the same way.
+        <p>
+        )stringDelimiter";
+
+    // Buttons to resize the svg locally.
+    addScaleSvgButtons(html);
+
+    // Write the graph to svg directly, without using Graphviz rendering.
+    graph.computeLayout(layoutMethod, timeout);
+    graph.writeSvg("svg", sizePixels, sizePixels,
+                   vertexScalingFactor, edgeThicknessScalingFactor, maxDistance, html);
+
+
+}
 
 
 

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -27,7 +27,7 @@ using std::random_device;
 using std::uniform_int_distribution;
 
 
-void Assembler::exploreCandidateGraph(
+void Assembler::exploreAlignmentCandidateGraph(
         const vector<string>& request,
         ostream& html)
 {

--- a/src/AssemblerHttpServer-ReadGraph.cpp
+++ b/src/AssemblerHttpServer-ReadGraph.cpp
@@ -30,7 +30,7 @@ void Assembler::exploreReadGraph(
 }
 
 
-bool parseCommaSeparatedReadIDs(string& commaSeparatedReadIds, vector<OrientedReadId>& readIds, ostream& html){
+bool Assembler::parseCommaSeparatedReadIDs(string& commaSeparatedReadIds, vector<OrientedReadId>& readIds, ostream& html){
     readIds.clear();
     string token;
 

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -31,6 +31,7 @@ void Assembler::fillServerFunctionTable()
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignments);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignment);
     SHASTA_ADD_TO_FUNCTION_TABLE(computeAllAlignments);
+    SHASTA_ADD_TO_FUNCTION_TABLE(exploreCandidateGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignmentGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(alignSequencesInBaseRepresentation);
     SHASTA_ADD_TO_FUNCTION_TABLE(alignSequencesInMarkerRepresentation);
@@ -218,6 +219,7 @@ void Assembler::writeNavigation(ostream& html) const
         {"Reads", "exploreRead"},
         });
     writeNavigation(html, "Alignments", {
+        {"Candidate graph", "exploreCandidateGraph"},
         {"Stored alignments", "exploreAlignments"},
         {"Align two reads", "exploreAlignment"},
         {"Align one read with all", "computeAllAlignments"},

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -31,7 +31,7 @@ void Assembler::fillServerFunctionTable()
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignments);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignment);
     SHASTA_ADD_TO_FUNCTION_TABLE(computeAllAlignments);
-    SHASTA_ADD_TO_FUNCTION_TABLE(exploreCandidateGraph);
+    SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignmentCandidateGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(exploreAlignmentGraph);
     SHASTA_ADD_TO_FUNCTION_TABLE(alignSequencesInBaseRepresentation);
     SHASTA_ADD_TO_FUNCTION_TABLE(alignSequencesInMarkerRepresentation);
@@ -219,7 +219,7 @@ void Assembler::writeNavigation(ostream& html) const
         {"Reads", "exploreRead"},
         });
     writeNavigation(html, "Alignments", {
-        {"Candidate graph", "exploreCandidateGraph"},
+        {"Candidate graph", "exploreAlignmentCandidateGraph"},
         {"Stored alignments", "exploreAlignments"},
         {"Align two reads", "exploreAlignment"},
         {"Align one read with all", "computeAllAlignments"},

--- a/src/LocalAlignmentCandidateGraph.cpp
+++ b/src/LocalAlignmentCandidateGraph.cpp
@@ -1,5 +1,5 @@
 // Shasta.
-#include "LocalAlignmentGraph.hpp"
+#include "LocalAlignmentCandidateGraph.hpp"
 #include "writeGraph.hpp"
 using namespace shasta;
 
@@ -12,7 +12,7 @@ using namespace shasta;
 
 
 
-void LocalAlignmentGraph::addVertex(
+void LocalAlignmentCandidateGraph::addVertex(
     OrientedReadId orientedReadId,
     uint32_t baseCount,
     uint32_t distance)
@@ -21,7 +21,7 @@ void LocalAlignmentGraph::addVertex(
     SHASTA_ASSERT(vertexMap.find(orientedReadId) == vertexMap.end());
 
     // Create the vertex.
-    const vertex_descriptor v = add_vertex(LocalAlignmentGraphVertex(orientedReadId, baseCount, distance), *this);
+    const vertex_descriptor v = add_vertex(LocalAlignmentCandidateGraphVertex(orientedReadId, baseCount, distance), *this);
 
     // Store it in the vertex map.
     vertexMap.insert(make_pair(orientedReadId, v));
@@ -29,10 +29,12 @@ void LocalAlignmentGraph::addVertex(
 
 
 
-void LocalAlignmentGraph::addEdge(
+void LocalAlignmentCandidateGraph::addEdge(
     OrientedReadId orientedReadId0,
     OrientedReadId orientedReadId1,
-    const AlignmentInfo& alignmentInfo)
+    bool inAlignments,
+    bool inReadgraph,
+    bool inReferenceAlignments)
 {
     // Find the vertices corresponding to these two OrientedReadId.
     const auto it0 = vertexMap.find(orientedReadId0);
@@ -43,12 +45,12 @@ void LocalAlignmentGraph::addEdge(
     const vertex_descriptor v1 = it1->second;
 
     // Add the edge.
-    add_edge(v0, v1, LocalAlignmentGraphEdge(alignmentInfo), *this);
+    add_edge(v0, v1, LocalAlignmentCandidateGraphEdge(inAlignments, inReadgraph, inReferenceAlignments), *this);
 }
 
 
 
-uint32_t LocalAlignmentGraph::getDistance(OrientedReadId orientedReadId) const
+uint32_t LocalAlignmentCandidateGraph::getDistance(OrientedReadId orientedReadId) const
 {
     const auto it = vertexMap.find(orientedReadId);
     SHASTA_ASSERT(it != vertexMap.end());
@@ -58,7 +60,7 @@ uint32_t LocalAlignmentGraph::getDistance(OrientedReadId orientedReadId) const
 
 
 
-bool LocalAlignmentGraph::vertexExists(OrientedReadId orientedReadId) const
+bool LocalAlignmentCandidateGraph::vertexExists(OrientedReadId orientedReadId) const
 {
    return vertexMap.find(orientedReadId) != vertexMap.end();
 }
@@ -66,7 +68,7 @@ bool LocalAlignmentGraph::vertexExists(OrientedReadId orientedReadId) const
 
 
 // Write the graph in Graphviz format.
-void LocalAlignmentGraph::write(const string& fileName, uint32_t maxDistance) const
+void LocalAlignmentCandidateGraph::write(const string& fileName, uint32_t maxDistance) const
 {
     ofstream outputFileStream(fileName);
     if(!outputFileStream) {
@@ -74,15 +76,18 @@ void LocalAlignmentGraph::write(const string& fileName, uint32_t maxDistance) co
     }
     write(outputFileStream, maxDistance);
 }
-void LocalAlignmentGraph::write(ostream& s, uint32_t maxDistance) const
+
+
+void LocalAlignmentCandidateGraph::write(ostream& s, uint32_t maxDistance) const
 {
     Writer writer(*this, maxDistance);
     boost::write_graphviz(s, *this, writer, writer, writer,
-        boost::get(&LocalAlignmentGraphVertex::orientedReadId, *this));
+        boost::get(&LocalAlignmentCandidateGraphVertex::orientedReadId, *this));
 }
 
-LocalAlignmentGraph::Writer::Writer(
-    const LocalAlignmentGraph& graph,
+
+LocalAlignmentCandidateGraph::Writer::Writer(
+    const LocalAlignmentCandidateGraph& graph,
     uint32_t maxDistance) :
     graph(graph),
     maxDistance(maxDistance)
@@ -91,7 +96,7 @@ LocalAlignmentGraph::Writer::Writer(
 
 
 
-void LocalAlignmentGraph::Writer::operator()(std::ostream& s) const
+void LocalAlignmentCandidateGraph::Writer::operator()(std::ostream& s) const
 {
     s << "layout=sfdp;\n";
     s << "ratio=expand;\n";
@@ -103,9 +108,9 @@ void LocalAlignmentGraph::Writer::operator()(std::ostream& s) const
 }
 
 
-void LocalAlignmentGraph::Writer::operator()(std::ostream& s, vertex_descriptor v) const
+void LocalAlignmentCandidateGraph::Writer::operator()(std::ostream& s, vertex_descriptor v) const
 {
-    const LocalAlignmentGraphVertex& vertex = graph[v];
+    const LocalAlignmentCandidateGraphVertex& vertex = graph[v];
     const OrientedReadId orientedReadId(vertex.orientedReadId);
 
     s << "[";
@@ -123,18 +128,17 @@ void LocalAlignmentGraph::Writer::operator()(std::ostream& s, vertex_descriptor 
 
 
 
-void LocalAlignmentGraph::Writer::operator()(std::ostream& s, edge_descriptor e) const
+void LocalAlignmentCandidateGraph::Writer::operator()(std::ostream& s, edge_descriptor e) const
 {
-    const LocalAlignmentGraphEdge& edge = graph[e];
+//    const LocalAlignmentCandidateGraphEdge& edge = graph[e];
     const vertex_descriptor v0 = source(e, graph);
     const vertex_descriptor v1 = target(e, graph);
-    const LocalAlignmentGraphVertex& vertex0 = graph[v0];
-    const LocalAlignmentGraphVertex& vertex1 = graph[v1];
+    const LocalAlignmentCandidateGraphVertex& vertex0 = graph[v0];
+    const LocalAlignmentCandidateGraphVertex& vertex1 = graph[v1];
 
     s << "[";
     s << "tooltip=\"" << OrientedReadId(vertex0.orientedReadId) << " ";
-    s << OrientedReadId(vertex1.orientedReadId) << " ";
-    s << edge.alignmentInfo.markerCount << "\"";
+    s << OrientedReadId(vertex1.orientedReadId) << "\"";
     s << "]";
 }
 
@@ -143,11 +147,11 @@ void LocalAlignmentGraph::Writer::operator()(std::ostream& s, edge_descriptor e)
 
 // Compute sfdp layout using graphviz and store the results
 // in the vertex positions.
-ComputeLayoutReturnCode LocalAlignmentGraph::computeLayout(
+ComputeLayoutReturnCode LocalAlignmentCandidateGraph::computeLayout(
     const string& layoutMethod,
     double timeout)
 {
-    LocalAlignmentGraph& graph = *this;
+    LocalAlignmentCandidateGraph& graph = *this;
 
     // Compute the layout.
     std::map<vertex_descriptor, array<double, 2> > positionMap;
@@ -158,7 +162,7 @@ ComputeLayoutReturnCode LocalAlignmentGraph::computeLayout(
     }
 
     // Store it in the vertices.
-    BGL_FORALL_VERTICES(v, graph, LocalAlignmentGraph) {
+    BGL_FORALL_VERTICES(v, graph, LocalAlignmentCandidateGraph) {
         const auto it = positionMap.find(v);
         SHASTA_ASSERT(it != positionMap.end());
         graph[v].position = it->second;
@@ -167,11 +171,20 @@ ComputeLayoutReturnCode LocalAlignmentGraph::computeLayout(
 }
 
 
+uint8_t LocalAlignmentCandidateGraphEdge::getSvgOrdering() const{
+    return  inAlignments + inReadGraph + inReferenceAlignments;
+}
+
+
+uint8_t LocalAlignmentCandidateGraphVertex::getSvgOrdering() const{
+    return 0;
+}
+
 
 // Write directly to svg, without using Graphviz rendering.
 // This assumes that the layout was already computed
 // and stored in the vertices.
-void LocalAlignmentGraph::writeSvg(
+void LocalAlignmentCandidateGraph::writeSvg(
     const string& svgId,
     uint64_t width,
     uint64_t height,
@@ -180,11 +193,10 @@ void LocalAlignmentGraph::writeSvg(
     uint64_t maxDistance,
     ostream& svg) const
 {
-    using Graph = LocalAlignmentGraph;
+    using Graph = LocalAlignmentCandidateGraph;
     using VertexAttributes = WriteGraph::VertexAttributes;
     using EdgeAttributes = WriteGraph::EdgeAttributes;
     const Graph& graph = *this;
-
 
 
     // Fill in vertex attributes.
@@ -213,11 +225,10 @@ void LocalAlignmentGraph::writeSvg(
     }
 
 
-
     // Fill in edge attributes.
     std::map<edge_descriptor, EdgeAttributes> edgeAttributes;
     BGL_FORALL_EDGES(e, graph, Graph) {
-        // const auto& edge = graph[e];
+        const auto& edge = graph[e];
         const vertex_descriptor v0 = source(e, graph);
         const vertex_descriptor v1 = target(e, graph);
         const auto& vertex0 = graph[v0];
@@ -226,7 +237,16 @@ void LocalAlignmentGraph::writeSvg(
         EdgeAttributes attributes;
 
         attributes.thickness = edgeThicknessScalingFactor * 2.e-3;
-        attributes.color = "midnightblue";
+
+        // Ratchet up the color towards green for each successive filter it passes (candidate -> alignment -> readgraph)
+        attributes.color = "#0E29BA";
+
+        if (edge.inAlignments){
+            attributes.color = "#047FAD";
+        }
+        if (edge.inReadGraph){
+            attributes.color = "#00C349";
+        }
 
         attributes.tooltip =
             OrientedReadId(vertex0.orientedReadId).getString() + " " +
@@ -236,6 +256,6 @@ void LocalAlignmentGraph::writeSvg(
     }
 
     // Write to svg.
-    WriteGraph::writeSvg(graph, svgId, width, height,
+    WriteGraph::writeOrderedSvg(graph, svgId, width, height,
         vertexAttributes, edgeAttributes, svg);
 }

--- a/src/LocalAlignmentCandidateGraph.cpp
+++ b/src/LocalAlignmentCandidateGraph.cpp
@@ -239,13 +239,13 @@ void LocalAlignmentCandidateGraph::writeSvg(
         attributes.thickness = edgeThicknessScalingFactor * 2.e-3;
 
         // Ratchet up the color towards green for each successive filter it passes (candidate -> alignment -> readgraph)
-        attributes.color = "#0E29BA";
+        attributes.color = "#450BBA";
 
         if (edge.inAlignments){
-            attributes.color = "#047FAD";
+            attributes.color = "#0954B4";
         }
         if (edge.inReadGraph){
-            attributes.color = "#00C349";
+            attributes.color = "#00C442";
         }
 
         attributes.tooltip =

--- a/src/LocalAlignmentCandidateGraph.hpp
+++ b/src/LocalAlignmentCandidateGraph.hpp
@@ -1,0 +1,172 @@
+#ifndef SHASTA_LOCAL_ALIGNMENT_CANDIDATE_GRAPH_HPP
+#define SHASTA_LOCAL_ALIGNMENT_CANDIDATE_GRAPH_HPP
+
+
+
+/*******************************************************************************
+
+The local candidate graph is a local subgraph of the global candidate pairs,
+starting at a given oriented read and going out up to a specified distance.
+It is an undirected graph in which each vertex corresponds to a read.
+An edge is created between two vertices if the corresponding
+oriented reads have a stored alignment.
+
+It has been augmented from the LocalAlignmentGraph to include additional
+attributes that describe whether each edge exists in the AlignmentGraph,
+the ReadGraph, or (optionally) whether an overlap is inferred to exist in a
+reference alignment of reads.
+*******************************************************************************/
+
+// Shasta.
+#include "Alignment.hpp"
+#include "computeLayout.hpp"
+#include "OrientedReadPair.hpp"
+
+// Boost libraries.
+#include <boost/graph/adjacency_list.hpp>
+
+// Standard libraries.
+#include <map>
+
+namespace shasta {
+
+    class LocalAlignmentCandidateGraphVertex;
+    class LocalAlignmentCandidateGraphEdge;
+    class LocalAlignmentCandidateGraph;
+    using LocalAlignmentCandidateGraphBaseClass = boost::adjacency_list<
+        boost::setS,
+        boost::listS,
+        boost::undirectedS,
+        LocalAlignmentCandidateGraphVertex,
+        LocalAlignmentCandidateGraphEdge
+        >;
+
+}
+
+
+class shasta::LocalAlignmentCandidateGraphVertex {
+public:
+
+    // The OrientedReadId that this vertex corresponds to.
+    // We store it as OrientedRead::Int so we can also use
+    // it as a vertex id for graphviz output.
+    OrientedReadId::Int orientedReadId;
+
+    // The number of bases in this read.
+    uint32_t baseCount;
+
+    // Layout position of this vertex, for display.
+    array<double, 2> position;
+
+    // The distance of this vertex from the starting vertex.
+    uint32_t distance;
+
+    uint8_t getSvgOrdering() const;
+
+    LocalAlignmentCandidateGraphVertex(
+        OrientedReadId orientedReadId,
+        uint32_t baseCount,
+        uint32_t distance) :
+        orientedReadId(orientedReadId.getValue()),
+        baseCount(baseCount),
+        distance(distance)
+        {}
+
+};
+
+
+
+class shasta::LocalAlignmentCandidateGraphEdge {
+public:
+
+    bool inAlignments;
+    bool inReadGraph;
+    bool inReferenceAlignments;
+
+    uint8_t getSvgOrdering() const;
+
+    LocalAlignmentCandidateGraphEdge(
+        bool inAlignments,
+        bool inReadgraph,
+        bool inReferenceAlignments) :
+            inAlignments(inAlignments),
+            inReadGraph(inReadgraph),
+            inReferenceAlignments(inReferenceAlignments)
+    {};
+
+    LocalAlignmentCandidateGraphEdge():
+            inAlignments(false),
+            inReadGraph(false),
+            inReferenceAlignments(false)
+    {};
+};
+
+
+
+class shasta::LocalAlignmentCandidateGraph :
+    public LocalAlignmentCandidateGraphBaseClass {
+public:
+
+    void addVertex(
+        OrientedReadId orientedReadId,
+        uint32_t baseCount,
+        uint32_t distance);
+
+    void addEdge(
+        OrientedReadId orientedReadId0,
+        OrientedReadId orientedReadId1,
+        bool inAlignments,
+        bool inReadgraph,
+        bool inReferenceAlignments);
+
+    // Find out if a vertex with a given OrientedId exists.
+    bool vertexExists(OrientedReadId) const;
+
+    // Get the distance of an existing vertex from the start vertex.
+    uint32_t getDistance(OrientedReadId) const;
+
+    // Compute sfdp layout using graphviz and store the results
+    // in the vertex positions.
+    ComputeLayoutReturnCode computeLayout(
+        const string& layoutMethod,
+        double timeout);
+
+    // Write directly to svg, without using Graphviz rendering.
+    // This assumes that the layout was already computed
+    // and stored in the vertices.
+    void writeSvg(
+        const string& svgId,
+        uint64_t width,
+        uint64_t height,
+        double vertexScalingFactor,
+        double edgeThicknessScalingFactor,
+        uint64_t maxDistance,
+        ostream& svg) const;
+
+    // Write in Graphviz format.
+    void write(ostream&, uint32_t maxDistance) const;
+    void write(const string& fileName, uint32_t maxDistance) const;
+
+    uint8_t getEdgeOrdering(const LocalAlignmentCandidateGraphEdge& e);
+    uint8_t getVertexOrdering(const LocalAlignmentCandidateGraphVertex& v);
+
+private:
+
+    // Map that gives the vertex corresponding to an OrientedReadId.
+    std::map<OrientedReadId, vertex_descriptor> vertexMap;
+
+    // Graphviz writer.
+    class Writer {
+    public:
+        Writer(const LocalAlignmentCandidateGraph&, uint32_t maxDistance);
+        void operator()(ostream&) const;
+        void operator()(ostream&, vertex_descriptor) const;
+        void operator()(ostream&, edge_descriptor) const;
+        const LocalAlignmentCandidateGraph& graph;
+        uint32_t maxDistance;
+    };
+};
+
+
+
+#endif

--- a/src/writeGraph.hpp
+++ b/src/writeGraph.hpp
@@ -45,6 +45,14 @@ namespace shasta {
             const std::map<typename Graph::edge_descriptor, EdgeAttributes>&,
             ostream&);
 
+        // This method expands on the writeSvg method to allow the Graph Vertex/Edge classes to dictate a numeric
+        // ordering with a getSvgOrdering() member function. Since SVG uses the written order of objects to determine
+        // the render order of shapes, Edges/Vertexes with lower ordinals will end up underneath those with higher
+        // ordinals.
+        // Graph - expected to be a graph with edges and vertexes that are accessible by their descriptor objects
+        //         using the [] operator. e.g. the boost::adjacency_list
+        // svgId - labels the DOM object
+        // width and height - the size of the figure in pixels
         template<class Graph> void writeOrderedSvg(
                 const Graph& graph,
                 const string& svgId,

--- a/src/writeGraph.hpp
+++ b/src/writeGraph.hpp
@@ -9,6 +9,7 @@
 
 // Standard library.
 #include "iostream.hpp"
+#include <functional>
 #include <limits>
 #include <map>
 #include "string.hpp"
@@ -43,9 +44,17 @@ namespace shasta {
             const std::map<typename Graph::vertex_descriptor, VertexAttributes>&,
             const std::map<typename Graph::edge_descriptor, EdgeAttributes>&,
             ostream&);
+
+        template<class Graph> void writeOrderedSvg(
+                const Graph& graph,
+                const string& svgId,
+                uint64_t width,
+                uint64_t height,
+                const std::map<typename Graph::vertex_descriptor, VertexAttributes>& vertexAttributes,
+                const std::map<typename Graph::edge_descriptor, EdgeAttributes>& edgeAttributes,
+                ostream& svg);
     }
 }
-
 
 
 template<class Graph> void shasta::WriteGraph::writeSvg(
@@ -164,6 +173,148 @@ template<class Graph> void shasta::WriteGraph::writeSvg(
     }
     svg << "</g>\n";
 
+
+
+    // End the svg.
+    svg << "</svg>\n";
+}
+
+
+template<class Graph> void shasta::WriteGraph::writeOrderedSvg(
+        const Graph& graph,
+        const string& svgId,
+        uint64_t width,
+        uint64_t height,
+        const std::map<typename Graph::vertex_descriptor, VertexAttributes>& vertexAttributes,
+        const std::map<typename Graph::edge_descriptor, EdgeAttributes>& edgeAttributes,
+        ostream& svg)
+{
+    using vertex_descriptor = typename Graph::vertex_descriptor;
+    using edge_descriptor = typename Graph::edge_descriptor;
+
+    // Compute the view box.
+    double xMin = std::numeric_limits<double>::max();
+    double xMax = std::numeric_limits<double>::min();
+    double yMin = std::numeric_limits<double>::max();
+    double yMax = std::numeric_limits<double>::min();
+    BGL_FORALL_VERTICES_T(v, graph, Graph) {
+        const auto& position = graph[v].position;
+        VertexAttributes attributes;
+        auto it = vertexAttributes.find(v);
+        if(it != vertexAttributes.end()) {
+            attributes = it->second;
+        }
+        const double radius = attributes.radius;
+
+        // Update the view box to include this vertex.
+        xMin = min(xMin, position[0] - radius);
+        xMax = max(xMax, position[0] + radius);
+        yMin = min(yMin, position[1] - radius);
+        yMax = max(yMax, position[1] + radius);
+    }
+
+    // Begin the svg.
+    svg << "<svg id='" << svgId << "' width='" << width << "' height='" << height <<
+        "' viewbox='" << xMin << " " << yMin << " " << xMax-xMin << " " << yMax-yMin <<
+        "'>\n";
+
+    // Accumulate all the edge data
+    std::multimap <uint8_t, pair<edge_descriptor, EdgeAttributes> > orderedEdgeAttributes;
+    BGL_FORALL_EDGES_T(e, graph, Graph) {
+        // Get the attributes for this edge.
+        EdgeAttributes attributes;
+        auto it = edgeAttributes.find(e);
+        if(it != edgeAttributes.end()) {
+            attributes = it->second;
+        }
+
+        // Find an ordering using the passed-in function
+        auto edge = graph[e];
+        auto info = std::make_pair(e, attributes);
+
+        orderedEdgeAttributes.emplace(edge.getSvgOrdering(), info);
+    }
+
+    // Write the edges first, so they don't cover the vertices.
+    svg << "<g id='" << svgId << "-edges'>\n";
+    for(const auto& item: orderedEdgeAttributes) {
+        const edge_descriptor& e = item.second.first;
+        const EdgeAttributes& attributes = item.second.second;
+
+        // Get vertex positions.
+        const vertex_descriptor v1 = source(e, graph);
+        const vertex_descriptor v2 = target(e, graph);
+        const auto& position1 = graph[v1].position;
+        const auto& position2 = graph[v2].position;
+
+        svg << "<line x1='" << position1[0] << "' y1='" << position1[1] <<
+            "' x2='" << position2[0] << "' y2='" << position2[1];
+
+        if(not attributes.id.empty()) {
+            svg << " id='" << attributes.id << "'";
+        }
+
+        svg << "' stroke='" << attributes.color <<
+            "' stroke-width='" << attributes.thickness <<
+            "'>";
+
+        if(not attributes.tooltip.empty()) {
+            svg << "<title>" << attributes.tooltip << "</title>";
+        }
+
+        svg << "</line>\n";
+    }
+    svg << "</g>\n";
+
+    // Accumulate all the vertex data
+    std::multimap <uint8_t, pair<vertex_descriptor, VertexAttributes> > orderedVertexAttributes;
+    BGL_FORALL_VERTICES_T(v, graph, Graph) {
+        VertexAttributes attributes;
+        auto it = vertexAttributes.find(v);
+        if (it != vertexAttributes.end()) {
+            attributes = it->second;
+        }
+
+        // Find an ordering using the passed-in function
+        auto vertex = graph[v];
+        auto info = std::make_pair(v, attributes);
+
+        orderedVertexAttributes.emplace(vertex.getSvgOrdering(), info);
+    }
+
+    // Write the vertices.
+    svg << "<g id='" << svgId << "-vertices' stroke='none'>\n";
+    for (const auto& item: orderedVertexAttributes){
+        const vertex_descriptor& v = item.second.first;
+        const VertexAttributes& attributes = item.second.second;
+
+        const auto& position = graph[v].position;
+
+        if(not attributes.url.empty()) {
+            svg << "<a href='" << attributes.url << "'>";
+        }
+
+        svg << "<circle cx='" << position[0] << "' cy='" << position[1] <<
+            "' r='" << attributes.radius << "'";
+
+        if(not attributes.id.empty()) {
+            svg << " id='" << attributes.id << "'";
+        }
+
+        svg << " fill='" << attributes.color << "'>";
+
+        if(not attributes.tooltip.empty()) {
+            svg << "<title>" << attributes.tooltip << "</title>";
+        }
+
+        svg << "</circle>";
+
+        if(not attributes.url.empty()) {
+            svg << "</a>";
+        }
+        svg << "\n";
+    }
+    svg << "</g>\n";
 
 
     // End the svg.

--- a/src/writeGraph.hpp
+++ b/src/writeGraph.hpp
@@ -228,7 +228,7 @@ template<class Graph> void shasta::WriteGraph::writeOrderedSvg(
             attributes = it->second;
         }
 
-        // Find an ordering using the passed-in function
+        // Find an ordering specified by the Edge class itself
         auto edge = graph[e];
         auto info = std::make_pair(e, attributes);
 
@@ -275,7 +275,7 @@ template<class Graph> void shasta::WriteGraph::writeOrderedSvg(
             attributes = it->second;
         }
 
-        // Find an ordering using the passed-in function
+        // Find an ordering specified by the Vertex class itself
         auto vertex = graph[v];
         auto info = std::make_pair(v, attributes);
 


### PR DESCRIPTION
This creates a new page under the Alignments tab that enables exploring the candidate graph, and visualizing how candidates are filtered at each step of graph refinement, up to the ReadGraph. It reuses code from The ReadGraph and Alignment visualization pages.

This also adds a method for ordering SVGs based on the templated Graph class. The Edge/Vertex members of Graph are expected to provide a method for finding their numeric ordering.

