### PR TITLE
Add color picker to candidate alignment graph visualization

### DIFF
--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -27,6 +27,171 @@ using std::random_device;
 using std::uniform_int_distribution;
 
 
+/*
+ * COLORS:
+ *   Red        #FF2800
+ *   Orange     #FF9E00
+ *   Yellow     #FFDD00
+ *   Lime       #B8F400
+ *   Green      #00C442
+ *   Blue       #0954B4
+ *   Indigo     #450BBA
+ *   Violet     #C50094
+ */
+
+
+void writeColorPicker(ostream& html, string svgId){
+    // TODO: https://stackoverflow.com/questions/63372047/how-to-call-the-function-with-parameters-when-clicking-on-svg-circle-element
+
+    html << R"stringDelimiter(
+    <script>
+    function setEdgeColor(buttonId, edgeClassName)
+    {
+        color = document.getElementById("edgeColor").value;
+        opacity = document.getElementById("edgeOpacity").value;
+
+        button = document.getElementsById(buttonId);
+        button.setAttribute("fill-color", color);
+        button.setAttribute("fill-opacity", opacity*0.7);
+
+        edges = document.getElementsByClassName(edgeClassName);
+        for (var i = 0; i < edges.length; i++) {
+            edges.item(i).setAttribute("fill-color", color);
+            edges.item(i).setAttribute("fill-opacity", opacity);
+        }
+    }
+    </script>
+    )stringDelimiter";
+
+    html << R"stringDelimiter(
+        <p>
+        <select id="edgeColor" name="Color">
+            <option class="red"     value="#FF2800"> red </option>
+            <option class="orange"  value="#FF9E00"> orange </option>
+            <option class="yellow"  value="#FFDD00"> yellow </option>
+            <option class="lime"    value="#B8F400"> lime </option>
+            <option class="green"   value="#00C442"> green </option>
+            <option class="blue"    value="#0954B4"> blue </option>
+            <option class="indigo"  value="#450BBA"> indigo </option>
+            <option class="violet"  value="#C50094"> violet </option>
+        </select>
+        <p>
+        <label for="edgeOpacity">Opacity [0-1]:</label><br>
+        <input type="number" id="edgeOpacity" name="edgeOpacity" step="0.1" min="0" max="1" value="1.0">
+        <p>
+        )stringDelimiter";
+
+    html << "<p><svg id=" << svgId << " width=\"600\" height=\"450\" viewbox=\"0 0 1200 900\">\n";
+
+    // Alignment Candidates
+    html << R"stringDelimiter(
+
+        <path d="
+	        M 601 112
+	        A 350 350 0 1 0 601 688
+	        A 350 350 0 0 1 526 617
+            A 250 250 0 1 1 526 184
+            A 350 350 0 0 1 601 112
+	        Z
+	        " id="Venn-AlignmentCandidates"
+            " onclick="setEdgeColor("Venn-AlignmentCandidates", "Candidate")"
+            stroke="white" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // Alignment Candidates in Reference
+    html << R"stringDelimiter(
+
+        <path d="
+	        M 601 112
+	        A 350 350 0 0 1 601 688
+	        A 350 350 0 0 1 526 617
+            A 250 250 0 0 0 526 184
+            A 350 350 0 0 1 601 112
+	        Z
+	        " id="Venn-AlignmentCandidatesInReference"
+            " onclick="setEdgeColor("Venn-AlignmentCandidatesInReference", "CandidateInRef")"
+	        " stroke="white" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // Good Alignments
+    html << R"stringDelimiter(
+
+        <path d="
+	        M 526 184
+	        A 250 250 0 1 0 526 617
+            A 350 350 0 0 1 474 530
+            A 150 150 0 1 1 474 271
+            A 350 350 0 0 1 526 184
+	        Z
+	        " id="Venn-GoodAlignments"
+            " onclick="setEdgeColor("Venn-GoodAlignments", "Alignment")"
+	        " stroke="white" fill="#0954B4" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // Good Alignments in Reference
+    html << R"stringDelimiter(
+
+        <path d="
+	        M 526 184
+	        A 250 250 0 0 1 526 617
+	        A 350 350 0 0 1 474 530
+            A 150 150 0 0 0 474 271
+            A 350 350 0 0 1 526 184
+	        Z
+	        " id="Venn-GoodAlignmentsInReference"
+            " onclick="setEdgeColor("Venn-GoodAlignmentsInReference", "AlignmentInRef")"
+	        " stroke="white" fill="#0954B4" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // ReadGraph
+    html << R"stringDelimiter(
+        <path d="
+	        M 474 271
+	        A 150 150 0 1 0 474 530
+	        A 350 350 0 0 1 474 271
+	        Z
+	        " id="Venn-ReadGraph"
+            " onclick="setEdgeColor("Venn-ReadGraph", "ReadGraph")"
+	        " stroke="white" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // ReadGraph in Reference
+    html << R"stringDelimiter(
+        <path d="
+	        M 474 271
+	        A 150 150 0 0 1 474 530
+	        A 350 350 0 0 1 474 271
+	        Z
+	        " id="Venn-ReadGraphInReference"
+            " onclick="setEdgeColor("Venn-ReadGraphInReference", "ReadGraphInRef")"
+	        " stroke="white" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // Reference Only
+    html << R"stringDelimiter(
+
+        <path d="
+	        M 601 112
+	        A 350 350 0 0 1 601 688
+	        A 350 350 0 1 0 601 112
+	        Z
+	        " id="Venn-ReferenceOnly"
+            " onclick="setEdgeColor("Venn-ReferenceOnly", "ReferenceOnly")"
+	        " stroke="white" fill="red" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+        )stringDelimiter";
+
+    // Text labels
+    html << R"stringDelimiter(
+        <text x="290" y="100" font-size="26" font-weight="bold">Shasta Overlaps</text>
+        <text x="280" y="210" font-size="22">Alignment Candidates</text>
+        <text x="300" y="310" font-size="22">Good Alignments</text>
+        <text x="320" y="410" font-size="22">Read Graph</text>
+        <text x="680" y="100" font-size="26" font-weight="bold">Reference Overlaps</text>
+        </svg>
+        )stringDelimiter";
+}
+
+
 void Assembler::exploreAlignmentCandidateGraph(
         const vector<string>& request,
         ostream& html)
@@ -151,7 +316,6 @@ void Assembler::exploreAlignmentCandidateGraph(
          "<br><input type=submit value='Display'>"
          "</form>";
 
-
     // If any necessary values are missing, stop here.
     if (not readIdsArePresent) {
         return;
@@ -227,6 +391,7 @@ void Assembler::exploreAlignmentCandidateGraph(
     graph.writeSvg("svg", sizePixels, sizePixels,
                    vertexScalingFactor, edgeThicknessScalingFactor, maxDistance, html);
 
+    writeColorPicker(html, "colorPicker");
 
 }
 

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -98,7 +98,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-AlignmentCandidates"
             onclick="setEdgeColor('Venn-AlignmentCandidates', 'Candidate')"
-            stroke="gray" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+            stroke="gray" fill="#450BBA" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Alignment Candidates in Reference
@@ -115,7 +115,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-AlignmentCandidatesInReference"
             onclick="setEdgeColor('Venn-AlignmentCandidatesInReference', 'CandidateInRef')"
-	        stroke="gray" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        stroke="gray" fill="#450BBA" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Good Alignments
@@ -132,7 +132,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-GoodAlignments"
             onclick="setEdgeColor('Venn-GoodAlignments', 'Alignment')"
-	        stroke="gray" fill="#0658C2" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        stroke="gray" fill="#0658C2" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Good Alignments in Reference
@@ -149,7 +149,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-GoodAlignmentsInReference"
             onclick="setEdgeColor('Venn-GoodAlignmentsInReference', 'AlignmentInRef')"
-	        stroke="gray" fill="#0658C2" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        stroke="gray" fill="#0658C2" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // ReadGraph
@@ -163,7 +163,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-ReadGraph"
             onclick="setEdgeColor('Venn-ReadGraph', 'ReadGraph')"
-	        stroke="gray" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        stroke="gray" fill="#00C442" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // ReadGraph in Reference
@@ -177,7 +177,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-ReadGraphInReference"
             onclick="setEdgeColor('Venn-ReadGraphInReference', 'ReadGraphInRef')"
-	        stroke="gray" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        stroke="gray" fill="#00C442" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Reference Only
@@ -192,7 +192,7 @@ void writeColorPicker(ostream& html, string svgId){
 	        "
             id="Venn-ReferenceOnly"
             onclick="setEdgeColor('Venn-ReferenceOnly', 'ReferenceOnly')"
-	        stroke="gray" fill="red" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        stroke="gray" fill="red" stroke-width="2" fill-opacity="1" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Text labels

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -34,15 +34,16 @@ using std::uniform_int_distribution;
  *   Yellow     #FFDD00
  *   Lime       #B8F400
  *   Green      #00C442
- *   Blue       #0954B4
+ *   Blue       #0658C2
  *   Indigo     #450BBA
  *   Violet     #C50094
  */
 
 
 void writeColorPicker(ostream& html, string svgId){
-    // TODO: https://stackoverflow.com/questions/63372047/how-to-call-the-function-with-parameters-when-clicking-on-svg-circle-element
-
+    html << "<h4>Color configuration</h4>\n";
+    html << "<p>Select a color configuration by setting the color and opacity, then click a region of "
+            "the venn diagram to apply it to the graph edges.</p>\n";
     html << R"stringDelimiter(
     <script>
     function setEdgeColor(buttonId, edgeClassName)
@@ -50,14 +51,14 @@ void writeColorPicker(ostream& html, string svgId){
         color = document.getElementById("edgeColor").value;
         opacity = document.getElementById("edgeOpacity").value;
 
-        button = document.getElementsById(buttonId);
-        button.setAttribute("fill-color", color);
-        button.setAttribute("fill-opacity", opacity*0.7);
+        button = document.getElementById(buttonId);
+        button.setAttribute("fill", color);
+        button.setAttribute("fill-opacity", opacity);
 
         edges = document.getElementsByClassName(edgeClassName);
         for (var i = 0; i < edges.length; i++) {
-            edges.item(i).setAttribute("fill-color", color);
-            edges.item(i).setAttribute("fill-opacity", opacity);
+            edges.item(i).setAttribute("stroke", color);
+            edges.item(i).setAttribute("stroke-opacity", opacity);
         }
     }
     </script>
@@ -66,118 +67,132 @@ void writeColorPicker(ostream& html, string svgId){
     html << R"stringDelimiter(
         <p>
         <select id="edgeColor" name="Color">
-            <option class="red"     value="#FF2800"> red </option>
-            <option class="orange"  value="#FF9E00"> orange </option>
-            <option class="yellow"  value="#FFDD00"> yellow </option>
-            <option class="lime"    value="#B8F400"> lime </option>
-            <option class="green"   value="#00C442"> green </option>
-            <option class="blue"    value="#0954B4"> blue </option>
-            <option class="indigo"  value="#450BBA"> indigo </option>
-            <option class="violet"  value="#C50094"> violet </option>
+            <option class="red"             value="#FF2800"> red </option>
+            <option class="orange"          value="#FF9E00"> orange </option>
+            <option class="yellow"          value="#FFDD00"> yellow </option>
+            <option class="chartreuse"      value="#B8F400"> chartreuse </option>
+            <option class="green"           value="#00C442"> green </option>
+            <option class="blue"            value="#0658C2"> blue </option>
+            <option class="indigo"          value="#450BBA"> indigo </option>
+            <option class="violet"          value="#C50094"> violet </option>
         </select>
+        </p>
         <p>
         <label for="edgeOpacity">Opacity [0-1]:</label><br>
         <input type="number" id="edgeOpacity" name="edgeOpacity" step="0.1" min="0" max="1" value="1.0">
-        <p>
+        </p>
         )stringDelimiter";
 
     html << "<p><svg id=" << svgId << " width=\"600\" height=\"450\" viewbox=\"0 0 1200 900\">\n";
 
     // Alignment Candidates
     html << R"stringDelimiter(
-
-        <path d="
+        <path d=
+            "
 	        M 601 112
 	        A 350 350 0 1 0 601 688
 	        A 350 350 0 0 1 526 617
             A 250 250 0 1 1 526 184
             A 350 350 0 0 1 601 112
 	        Z
-	        " id="Venn-AlignmentCandidates"
-            " onclick="setEdgeColor("Venn-AlignmentCandidates", "Candidate")"
-            stroke="white" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-AlignmentCandidates"
+            onclick="setEdgeColor('Venn-AlignmentCandidates', 'Candidate')"
+            stroke="gray" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Alignment Candidates in Reference
     html << R"stringDelimiter(
 
-        <path d="
+        <path d=
+            "
 	        M 601 112
 	        A 350 350 0 0 1 601 688
 	        A 350 350 0 0 1 526 617
             A 250 250 0 0 0 526 184
             A 350 350 0 0 1 601 112
 	        Z
-	        " id="Venn-AlignmentCandidatesInReference"
-            " onclick="setEdgeColor("Venn-AlignmentCandidatesInReference", "CandidateInRef")"
-	        " stroke="white" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-AlignmentCandidatesInReference"
+            onclick="setEdgeColor('Venn-AlignmentCandidatesInReference', 'CandidateInRef')"
+	        stroke="gray" fill="#450BBA" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Good Alignments
     html << R"stringDelimiter(
 
-        <path d="
+        <path d=
+            "
 	        M 526 184
 	        A 250 250 0 1 0 526 617
             A 350 350 0 0 1 474 530
             A 150 150 0 1 1 474 271
             A 350 350 0 0 1 526 184
 	        Z
-	        " id="Venn-GoodAlignments"
-            " onclick="setEdgeColor("Venn-GoodAlignments", "Alignment")"
-	        " stroke="white" fill="#0954B4" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-GoodAlignments"
+            onclick="setEdgeColor('Venn-GoodAlignments', 'Alignment')"
+	        stroke="gray" fill="#0658C2" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Good Alignments in Reference
     html << R"stringDelimiter(
 
-        <path d="
+        <path d=
+            "
 	        M 526 184
 	        A 250 250 0 0 1 526 617
 	        A 350 350 0 0 1 474 530
             A 150 150 0 0 0 474 271
             A 350 350 0 0 1 526 184
 	        Z
-	        " id="Venn-GoodAlignmentsInReference"
-            " onclick="setEdgeColor("Venn-GoodAlignmentsInReference", "AlignmentInRef")"
-	        " stroke="white" fill="#0954B4" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-GoodAlignmentsInReference"
+            onclick="setEdgeColor('Venn-GoodAlignmentsInReference', 'AlignmentInRef')"
+	        stroke="gray" fill="#0658C2" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // ReadGraph
     html << R"stringDelimiter(
-        <path d="
+        <path d=
+            "
 	        M 474 271
 	        A 150 150 0 1 0 474 530
 	        A 350 350 0 0 1 474 271
 	        Z
-	        " id="Venn-ReadGraph"
-            " onclick="setEdgeColor("Venn-ReadGraph", "ReadGraph")"
-	        " stroke="white" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-ReadGraph"
+            onclick="setEdgeColor('Venn-ReadGraph', 'ReadGraph')"
+	        stroke="gray" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // ReadGraph in Reference
     html << R"stringDelimiter(
-        <path d="
+        <path d=
+            "
 	        M 474 271
 	        A 150 150 0 0 1 474 530
 	        A 350 350 0 0 1 474 271
 	        Z
-	        " id="Venn-ReadGraphInReference"
-            " onclick="setEdgeColor("Venn-ReadGraphInReference", "ReadGraphInRef")"
-	        " stroke="white" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-ReadGraphInReference"
+            onclick="setEdgeColor('Venn-ReadGraphInReference', 'ReadGraphInRef')"
+	        stroke="gray" fill="#00C442" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Reference Only
     html << R"stringDelimiter(
 
-        <path d="
+        <path d=
+            "
 	        M 601 112
 	        A 350 350 0 0 1 601 688
 	        A 350 350 0 1 0 601 112
 	        Z
-	        " id="Venn-ReferenceOnly"
-            " onclick="setEdgeColor("Venn-ReferenceOnly", "ReferenceOnly")"
-	        " stroke="white" fill="red" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
+	        "
+            id="Venn-ReferenceOnly"
+            onclick="setEdgeColor('Venn-ReferenceOnly', 'ReferenceOnly')"
+	        stroke="gray" fill="red" stroke-width="2" fill-opacity="0.7" transform="translate(0,100)"/>
         )stringDelimiter";
 
     // Text labels
@@ -185,7 +200,7 @@ void writeColorPicker(ostream& html, string svgId){
         <text x="290" y="100" font-size="26" font-weight="bold">Shasta Overlaps</text>
         <text x="280" y="210" font-size="22">Alignment Candidates</text>
         <text x="300" y="310" font-size="22">Good Alignments</text>
-        <text x="320" y="410" font-size="22">Read Graph</text>
+        <text x="330" y="410" font-size="22">Read Graph</text>
         <text x="680" y="100" font-size="26" font-weight="bold">Reference Overlaps</text>
         </svg>
         )stringDelimiter";
@@ -217,10 +232,10 @@ void Assembler::exploreAlignmentCandidateGraph(
     uint32_t sizePixels = 600;
     getParameterValue(request, "sizePixels", sizePixels);
 
-    double vertexScalingFactor = 1.;
+    double vertexScalingFactor = 0.3;
     getParameterValue(request, "vertexScalingFactor", vertexScalingFactor);
 
-    double edgeThicknessScalingFactor = 1.;
+    double edgeThicknessScalingFactor = 1.5;
     getParameterValue(request, "edgeThicknessScalingFactor", edgeThicknessScalingFactor);
 
     double timeout = 30;

--- a/src/LocalAlignmentCandidateGraph.cpp
+++ b/src/LocalAlignmentCandidateGraph.cpp
@@ -171,6 +171,37 @@ ComputeLayoutReturnCode LocalAlignmentCandidateGraph::computeLayout(
 }
 
 
+string LocalAlignmentCandidateGraphEdge::getSvgClassName() const{
+    string className;
+
+    if (inReadGraph){
+        if (inReferenceAlignments){
+            className = "ReadGraphInRef";
+        }
+        else{
+            className = "ReadGraph";
+        }
+    }
+    else if (inAlignments){
+        if (inReferenceAlignments){
+            className = "AlignmentInRef";
+        }
+        else{
+            className = "Alignment";
+        }
+    }
+    else {
+        if (inReferenceAlignments){
+            className = "CandidateInRef";
+        }
+        else{
+            className = "Candidate";
+        }
+    }
+
+    return className;
+}
+
 uint8_t LocalAlignmentCandidateGraphEdge::getSvgOrdering() const{
     return  inAlignments + inReadGraph + inReferenceAlignments;
 }

--- a/src/LocalAlignmentCandidateGraph.cpp
+++ b/src/LocalAlignmentCandidateGraph.cpp
@@ -203,7 +203,7 @@ string LocalAlignmentCandidateGraphEdge::getSvgClassName() const{
 }
 
 uint8_t LocalAlignmentCandidateGraphEdge::getSvgOrdering() const{
-    return  inAlignments + inReadGraph + inReferenceAlignments;
+    return  uint8_t(int(inAlignments) + int(inReadGraph) + int(inReferenceAlignments));
 }
 
 
@@ -273,7 +273,7 @@ void LocalAlignmentCandidateGraph::writeSvg(
         attributes.color = "#450BBA";
 
         if (edge.inAlignments){
-            attributes.color = "#0954B4";
+            attributes.color = "#0658C2";
         }
         if (edge.inReadGraph){
             attributes.color = "#00C442";

--- a/src/LocalAlignmentCandidateGraph.hpp
+++ b/src/LocalAlignmentCandidateGraph.hpp
@@ -85,6 +85,8 @@ public:
 
     uint8_t getSvgOrdering() const;
 
+    string getSvgClassName() const;
+
     LocalAlignmentCandidateGraphEdge(
         bool inAlignments,
         bool inReadgraph,

--- a/src/writeGraph.hpp
+++ b/src/writeGraph.hpp
@@ -255,7 +255,10 @@ template<class Graph> void shasta::WriteGraph::writeOrderedSvg(
         const auto& position1 = graph[v1].position;
         const auto& position2 = graph[v2].position;
 
-        svg << "<line x1='" << position1[0] << "' y1='" << position1[1] <<
+        auto edge = graph[e];
+        string svgClassName = edge.getSvgClassName();
+
+        svg << "<line class= '" << svgClassName << "'x1='" << position1[0] << "' y1='" << position1[1] <<
             "' x2='" << position2[0] << "' y2='" << position2[1];
 
         if(not attributes.id.empty()) {


### PR DESCRIPTION
This adds a color picker that informs the user of the current color configuration and gives a venn diagram visualization of the relationship between Alignment Candidates, Good Alignments, Read Graph edges, and reference overlaps.

![image](https://user-images.githubusercontent.com/28764332/102729722-ba461b00-42e6-11eb-8d3e-1b25c022762b.png)
![image](https://user-images.githubusercontent.com/28764332/102729689-9f73a680-42e6-11eb-893f-87d323143bc9.png)
