### PR TITLE
Browser updates - reference comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/doxygen/latex
 .idea
 
 cmake-build-debug/
+build/

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -12,6 +12,7 @@
 #include "HttpServer.hpp"
 #include "InducedAlignment.hpp"
 #include "Kmer.hpp"
+#include "LocalAlignmentCandidateGraph.hpp"
 #include "LongBaseSequence.hpp"
 #include "Marker.hpp"
 #include "MarkerGraph.hpp"
@@ -22,6 +23,7 @@
 #include "ReadFlags.hpp"
 #include "ReadId.hpp"
 #include "Reads.hpp"
+#include "ReferenceOverlapMap.hpp"
 
 // Standard library.
 #include "memory.hpp"
@@ -655,7 +657,7 @@ private:
     MemoryMapped::Vector< array<uint64_t, 3> > readLowHashStatistics;
     void accessReadLowHashStatistics();
 
-    bool createLocalCandidateGraph(
+    bool createLocalAlignmentCandidateGraph(
         vector<OrientedReadId>& starts,
         uint32_t maxDistance,           // How far to go from starting oriented read.
         bool allowChimericReads,
@@ -1768,6 +1770,7 @@ public:
     static void addScaleSvgButtons(ostream&);
     class HttpServerData {
     public:
+        LocalAlignmentCandidateGraph referenceOverlapGraph;
 
         using ServerFunction = void (Assembler::*) (
             const vector<string>& request,
@@ -1778,13 +1781,16 @@ public:
 
         const AssemblerOptions* assemblerOptions = 0;
 
-        // For the display of the alignment candidate graph, we can optionally
-        // specify a paf file containing alignments of reads to the reference.
-        // Add here any data structures to store this information.
-        void loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePath);
+        void createGraphEdgesFromOverlapMap(const ReferenceOverlapMap& overlapMap);
 
     };
     HttpServerData httpServerData;
+
+    // For the display of the alignment candidate graph, we can optionally
+    // specify a PAF file containing alignments of reads to the reference.
+    // Persistent data structures from loading the PAF are stored as
+    // members of HttpServerData
+    void loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePath);
 
     // Display alignments in an html table.
     void displayAlignments(

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -669,6 +669,16 @@ private:
         double timeout,                 // Or 0 for no timeout.
         LocalAlignmentCandidateGraph& graph);
 
+    // This method is used as an alternative to createLocalAlignmentCandidateGraph, in the case that the user
+    // wants to see only the edges that are inferred from the PAF, and none others. Coloring/labelling w.r.t.
+    // the different subgroups still applies (candidate, good alignment, read graph)
+    bool createLocalReferenceGraph(
+        vector<OrientedReadId>& starts,
+        uint32_t maxDistance,           // How far to go from starting oriented read.
+        bool allowChimericReads,
+        double timeout,                 // Or 0 for no timeout.
+        LocalAlignmentCandidateGraph& graph);
+
     // Compute a marker alignment of two oriented reads.
     void alignOrientedReads(
         OrientedReadId,

--- a/src/AssemblerAlignmentCandidates.cpp
+++ b/src/AssemblerAlignmentCandidates.cpp
@@ -8,7 +8,7 @@ using namespace shasta;
 
 
 
-bool Assembler::createLocalCandidateGraph(
+bool Assembler::createLocalAlignmentCandidateGraph(
         vector<OrientedReadId>& starts,
         uint32_t maxDistance,           // How far to go from starting oriented read.
         bool allowChimericReads,

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -471,7 +471,7 @@ void Assembler::HttpServerData::createGraphEdgesFromOverlapMap(const ReferenceOv
         auto& prevReadSet = emptySet;
 
         for (auto i = begin(overlaps), e = end(overlaps); i!=e; ++i){
-            const auto& interval = i->first;
+//            const auto& interval = i->first;
             auto& readSet = i->second;
 
             for (const auto& id: readSet){
@@ -480,13 +480,13 @@ void Assembler::HttpServerData::createGraphEdgesFromOverlapMap(const ReferenceOv
                     for (const auto& otherId: readSet){
                         if (otherId != id){
                             // Won't duplicate edges if boost::adjacency_list is initialized with OutEdgesList as 'setS'
-                            referenceOverlapGraph.addEdge(id, otherId, false, false, true);
+                            referenceOverlapGraph.addEdge(id, otherId, false, false, false, false);
 
                             // Need to make the graph double stranded
                             auto idFlipped = OrientedReadId(id.getReadId(), 1 - id.getStrand());
                             auto otherIdFlipped = OrientedReadId(otherId.getReadId(), 1 - otherId.getStrand());
 
-                            referenceOverlapGraph.addEdge(idFlipped, otherIdFlipped, false, false, true);
+                            referenceOverlapGraph.addEdge(idFlipped, otherIdFlipped, false, false, false, false);
                         }
                     }
                 }
@@ -517,10 +517,10 @@ void Assembler::loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePat
     string token;
     string regionName;
     string readName;
-    bool isReverse;
     uint32_t start;
     uint32_t stop;
     uint32_t quality;
+    bool isReverse = false;
 
     uint64_t nDelimiters = 0;
     uint64_t nLines = 0;
@@ -555,6 +555,7 @@ void Assembler::loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePat
                     OrientedReadId reverseId(id, 1);
 
                     if (id != invalidReadId) {
+                        // Update the overlap map
                         if (isReverse){
                             overlapMap.insert(regionName, start, stop, reverseId);
                         }
@@ -562,6 +563,7 @@ void Assembler::loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePat
                             overlapMap.insert(regionName, start, stop, forwardId);
                         }
 
+                        // Create the forward and reverse sequence nodes
                         if(!httpServerData.referenceOverlapGraph.vertexExists(forwardId)){
                             httpServerData.referenceOverlapGraph.addVertex(forwardId, 0, 0);
                         }

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -22,9 +22,18 @@ using namespace shasta;
 #include <seqan/align.h>
 
 // Standard library.
-#include "chrono.hpp"
+#include <chrono>
+#include <unordered_map>
+#include <ostream>
+#include <string>
+#include <set>
+
 using std::random_device;
 using std::uniform_int_distribution;
+using std::unordered_map;
+using std::ostream;
+using std::string;
+using std::set;
 
 
 /*
@@ -360,7 +369,7 @@ void Assembler::exploreAlignmentCandidateGraph(
 
     // Create the local graph.
     LocalAlignmentCandidateGraph graph;
-    if(!createLocalCandidateGraph(
+    if(!createLocalAlignmentCandidateGraph(
             readIds,
             maxDistance,
             allowChimericReads,
@@ -424,13 +433,163 @@ void Assembler::exploreAlignmentCandidateGraph(
 }
 
 
+/// Given an overlap map with the structure: [interval_start, interval_stop) -> {read_id_0, read_id_1, ... },
+/// build the edges of a graph, one edge for each inferred overlap.
+/// Graph must have existing nodes, stored by the read ID in a vector.
+///
+/// Method:
+/// Iterate the interval:set pairs in order and add any edges that don't exist yet in the graph
+///
+/// Case 1:
+/// s1 = {a,b,c}
+/// s2 = {a,b,c,d}
+///
+/// s2 - s1 = {d}
+/// add all edges from (s2 - s1) -> s2
+///
+///
+/// Case 2:
+/// s1 = {a,b,c,d}
+/// s2 = {a,b,c}
+///
+/// s2 - s1 = {}
+/// Do nothing
+///
+///
+/// Case 3:
+/// s1 = {a,b,c}
+/// s2 = {a,b,d}
+///
+/// s2 - s1 = {d}
+/// add all edges from (s2 - s1) -> s2
+///
+void Assembler::HttpServerData::createGraphEdgesFromOverlapMap(const ReferenceOverlapMap& overlapMap){
+    set<OrientedReadId> emptySet = {};
+
+    for (auto& item: overlapMap.intervals){
+        const auto& overlaps = item.second;
+        auto& prevReadSet = emptySet;
+
+        for (auto i = begin(overlaps), e = end(overlaps); i!=e; ++i){
+            const auto& interval = i->first;
+            auto& readSet = i->second;
+
+            for (const auto& id: readSet){
+                // If this read id is not in the previous set, it indicates that more edges need to be built
+                if (prevReadSet.count(id) == 0){
+                    for (const auto& otherId: readSet){
+                        if (otherId != id){
+                            // Won't duplicate edges if boost::adjacency_list is initialized with OutEdgesList as 'setS'
+                            referenceOverlapGraph.addEdge(id, otherId, false, false, true);
+
+                            // Need to make the graph double stranded
+                            auto idFlipped = OrientedReadId(id.getReadId(), 1 - id.getStrand());
+                            auto otherIdFlipped = OrientedReadId(otherId.getReadId(), 1 - otherId.getStrand());
+
+                            referenceOverlapGraph.addEdge(idFlipped, otherIdFlipped, false, false, true);
+                        }
+                    }
+                }
+            }
+            prevReadSet = readSet;
+        }
+    }
+}
+
 
 // For the display of the alignment candidate graph, we can optionally
 // specify a paf file containing alignments of reads to the reference.
-// Add here any data structures to store this information.
-void Assembler::HttpServerData::loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePath)
+// Persistent data structures from loading the PAF are stored as
+// members of HttpServerData
+void Assembler::loadAlignmentsPafFile(const string& alignmentsPafFileAbsolutePath)
 {
-    throw runtime_error("PAF file functionality is not yet implemented.");
+    // TODO: parameterize this? add browser field?
+    uint32_t minQuality = 50;
+
+    ifstream pafFile(alignmentsPafFileAbsolutePath);
+
+    if (not pafFile.good()){
+        throw runtime_error("ERROR: could not open input file: " + alignmentsPafFileAbsolutePath);
+    }
+
+    ReferenceOverlapMap overlapMap;
+
+    string token;
+    string regionName;
+    string readName;
+    bool isReverse;
+    uint32_t start;
+    uint32_t stop;
+    uint32_t quality;
+
+    uint64_t nDelimiters = 0;
+    uint64_t nLines = 0;
+    char c;
+
+    while (pafFile.get(c)) {
+        if (c == '\t') {
+            if (nDelimiters == 0) {
+                readName = token;
+            }
+            else if (nDelimiters == 4) {
+                isReverse = (token == "-");
+            }
+            else if (nDelimiters == 5) {
+                regionName = token;
+            }
+            else if (nDelimiters == 7) {
+                start = stoi(token);
+            }
+            else if (nDelimiters == 8) {
+                stop = stoi(token);
+            }
+            else if (nDelimiters == 11) {
+                quality = stoi(token);
+
+                cerr << regionName << " " << start << " " << stop << '\n';
+
+                if (quality >= minQuality) {
+
+                    ReadId id = getReads().getReadId(readName);
+                    OrientedReadId forwardId(id, 0);
+                    OrientedReadId reverseId(id, 1);
+
+                    if (id != invalidReadId) {
+                        if (isReverse){
+                            overlapMap.insert(regionName, start, stop, reverseId);
+                        }
+                        else{
+                            overlapMap.insert(regionName, start, stop, forwardId);
+                        }
+
+                        if(!httpServerData.referenceOverlapGraph.vertexExists(forwardId)){
+                            httpServerData.referenceOverlapGraph.addVertex(forwardId, 0, 0);
+                        }
+                        if(!httpServerData.referenceOverlapGraph.vertexExists(reverseId)){
+                            httpServerData.referenceOverlapGraph.addVertex(reverseId, 0, 0);
+                        }
+                    }
+                    else{
+                        cerr << "WARNING: skipping read not used in shasta assembly: " << readName << '\n';
+                    }
+                }
+            }
+
+            token.resize(0);
+            nDelimiters++;
+        }
+        else if (c == '\n'){
+            token.resize(0);
+            nDelimiters = 0;
+            nLines++;
+        }
+        else {
+            token += c;
+        }
+    }
+
+    httpServerData.createGraphEdgesFromOverlapMap(overlapMap);
+
 }
 
 

--- a/src/LocalAlignmentCandidateGraph.cpp
+++ b/src/LocalAlignmentCandidateGraph.cpp
@@ -5,6 +5,7 @@ using namespace shasta;
 
 // Boost libraries.
 #include <boost/graph/graphviz.hpp>
+using boost::edge;
 
 // Standard library.
 #include "fstream.hpp"
@@ -65,6 +66,19 @@ bool LocalAlignmentCandidateGraph::vertexExists(OrientedReadId orientedReadId) c
    return vertexMap.find(orientedReadId) != vertexMap.end();
 }
 
+
+bool LocalAlignmentCandidateGraph::edgeExists(OrientedReadId a, OrientedReadId b) const
+{
+    auto resultA = vertexMap.find(a);
+    auto resultB = vertexMap.find(b);
+
+    bool exists = false;
+    if (resultA != vertexMap.end() and resultB != vertexMap.end()){
+        exists = edge(resultA->second, resultB->second, *this).second;
+    }
+
+    return exists;
+}
 
 
 // Write the graph in Graphviz format.

--- a/src/LocalAlignmentCandidateGraph.cpp
+++ b/src/LocalAlignmentCandidateGraph.cpp
@@ -65,20 +65,11 @@ void LocalAlignmentCandidateGraph::getAdjacentReadIds(OrientedReadId id, vector<
     if (it != vertexMap.end()) {
         const vertex_descriptor v = it->second;
 
-//        // The derived class LocalAlignmentCandidateGraph can specify the type of boost adjacency_list by inheritance
-//        graph_traits<LocalAlignmentCandidateGraph>::vertex_iterator iter;
-//        graph_traits<LocalAlignmentCandidateGraph>::vertex_iterator end;
-//
-//        for (tie(iter, end) = adjacent_vertices(v, *this); iter != end; ++iter) {
-//            OrientedReadId otherId(graph[*iter].orientedReadId);
-//            adjacentReadIds.push_back(otherId);
-//        }
-
         BGL_FORALL_ADJ(v, v2, graph, LocalAlignmentCandidateGraph){
             OrientedReadId otherId(graph[v2].orientedReadId);
             adjacentReadIds.push_back(otherId);
 
-        };
+        }
     }
 }
 
@@ -330,6 +321,9 @@ void LocalAlignmentCandidateGraph::writeSvg(
         }
         if (edge.inReadGraph){
             attributes.color = "#00C442";
+        }
+        if (edge.inReferenceAlignments and not edge.inCandidates){
+            attributes.color = "#FF2800";
         }
 
         attributes.tooltip =

--- a/src/LocalAlignmentCandidateGraph.hpp
+++ b/src/LocalAlignmentCandidateGraph.hpp
@@ -28,6 +28,7 @@ reference alignment of reads.
 // Standard libraries.
 #include <map>
 
+
 namespace shasta {
 
     class LocalAlignmentCandidateGraphVertex;
@@ -79,6 +80,7 @@ public:
 class shasta::LocalAlignmentCandidateGraphEdge {
 public:
 
+    bool inCandidates;
     bool inAlignments;
     bool inReadGraph;
     bool inReferenceAlignments;
@@ -88,15 +90,18 @@ public:
     string getSvgClassName() const;
 
     LocalAlignmentCandidateGraphEdge(
+        bool inCandidates,
         bool inAlignments,
         bool inReadgraph,
         bool inReferenceAlignments) :
+            inCandidates(inCandidates),
             inAlignments(inAlignments),
             inReadGraph(inReadgraph),
             inReferenceAlignments(inReferenceAlignments)
     {};
 
     LocalAlignmentCandidateGraphEdge():
+            inCandidates(false),
             inAlignments(false),
             inReadGraph(false),
             inReferenceAlignments(false)
@@ -117,6 +122,7 @@ public:
     void addEdge(
         OrientedReadId orientedReadId0,
         OrientedReadId orientedReadId1,
+        bool inCandidates,
         bool inAlignments,
         bool inReadgraph,
         bool inReferenceAlignments);
@@ -126,7 +132,9 @@ public:
 
     bool edgeExists(OrientedReadId a, OrientedReadId b) const;
 
-    // Get the distance of an existing vertex from the start vertex.
+    void getAdjacentReadIds(OrientedReadId id, vector<OrientedReadId>& adjacentReadIds);
+
+        // Get the distance of an existing vertex from the start vertex.
     uint32_t getDistance(OrientedReadId) const;
 
     // Compute sfdp layout using graphviz and store the results
@@ -150,10 +158,6 @@ public:
     // Write in Graphviz format.
     void write(ostream&, uint32_t maxDistance) const;
     void write(const string& fileName, uint32_t maxDistance) const;
-
-    uint8_t getEdgeOrdering(const LocalAlignmentCandidateGraphEdge& e);
-    uint8_t getVertexOrdering(const LocalAlignmentCandidateGraphVertex& v);
-
 
 
 private:

--- a/src/LocalAlignmentCandidateGraph.hpp
+++ b/src/LocalAlignmentCandidateGraph.hpp
@@ -124,6 +124,8 @@ public:
     // Find out if a vertex with a given OrientedId exists.
     bool vertexExists(OrientedReadId) const;
 
+    bool edgeExists(OrientedReadId a, OrientedReadId b) const;
+
     // Get the distance of an existing vertex from the start vertex.
     uint32_t getDistance(OrientedReadId) const;
 
@@ -151,6 +153,8 @@ public:
 
     uint8_t getEdgeOrdering(const LocalAlignmentCandidateGraphEdge& e);
     uint8_t getVertexOrdering(const LocalAlignmentCandidateGraphVertex& v);
+
+
 
 private:
 

--- a/src/ReferenceOverlapMap.cpp
+++ b/src/ReferenceOverlapMap.cpp
@@ -1,0 +1,38 @@
+#include "ReferenceOverlapMap.hpp"
+
+
+void shasta::ReferenceOverlapMap::insert(string& region_name, uint32_t start, uint32_t stop, OrientedReadId id) {
+    // Check if this reference contig has been encountered before, and initialize it if needed
+    if (intervals.count(region_name) == 0){
+        interval_map <uint32_t, set<OrientedReadId>, total_enricher> empty_interval_map;
+        intervals.emplace(region_name, empty_interval_map);
+    }
+
+    // Construct a Boost interval for this numeric range/coord
+    auto a = interval<uint32_t>::right_open(start, stop);
+    set<OrientedReadId> b = {id};
+
+    // Within this reference contig, add the numeric interval
+    intervals.at(region_name).add({a, b});
+    size++;
+}
+
+
+void shasta::ReferenceOverlapMap::print(ostream& out){
+    for (auto& item: intervals){
+        out << item.first << '\n';
+        for (auto& item1: item.second){
+            out << item1.first << " -> ";
+            for (auto& item2: item1.second){
+                out << item2 << " " ;
+            }
+            out << '\n';
+        }
+    }
+}
+
+
+shasta::ReferenceOverlapMap::ReferenceOverlapMap():
+        intervals(),
+        size(0)
+{}

--- a/src/ReferenceOverlapMap.hpp
+++ b/src/ReferenceOverlapMap.hpp
@@ -1,0 +1,40 @@
+#ifndef SHASTA_REFERENCEOVERLAPMAP_HPP
+#define SHASTA_REFERENCEOVERLAPMAP_HPP
+
+#include <boost/icl/split_interval_map.hpp>
+#include <boost/icl/interval_map.hpp>
+#include <boost/icl/interval.hpp>
+
+using boost::icl::total_enricher;
+using boost::icl::interval_map;
+using boost::icl::interval;
+
+#include <unordered_map>
+#include <set>
+
+using std::unordered_map;
+using std::set;
+
+
+namespace shasta{
+    class ReferenceOverlapMap;
+}
+
+// The overlap map is based on a boost interval map. The interval map performs an "aggregation" operation whenever
+// multiple intervals share space on the number line, combining values for those key:value pairs, and splitting the
+// intervals at all boundaries.
+class shasta::ReferenceOverlapMap {
+public:
+    unordered_map <string, interval_map <uint32_t, set<OrientedReadId>, total_enricher> > intervals;
+    size_t size;
+
+    void insert(string& region_name, uint32_t start, uint32_t stop, OrientedReadId id);
+
+    ReferenceOverlapMap();
+
+    void print(ostream& out);
+};
+
+
+
+#endif //SHASTA_REFERENCEOVERLAPMAP_HPP

--- a/src/ReferenceOverlapMap.hpp
+++ b/src/ReferenceOverlapMap.hpp
@@ -1,6 +1,8 @@
 #ifndef SHASTA_REFERENCEOVERLAPMAP_HPP
 #define SHASTA_REFERENCEOVERLAPMAP_HPP
 
+#include "ReadId.hpp"
+
 #include <boost/icl/split_interval_map.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <boost/icl/interval.hpp>
@@ -10,9 +12,11 @@ using boost::icl::interval_map;
 using boost::icl::interval;
 
 #include <unordered_map>
+#include <string>
 #include <set>
 
 using std::unordered_map;
+using std::string;
 using std::set;
 
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -1150,7 +1150,7 @@ void shasta::main::explore(
 
     // Load the paf file, if one was specified.
     if(not alignmentsPafFileAbsolutePath.empty()) {
-        assembler.httpServerData.loadAlignmentsPafFile(alignmentsPafFileAbsolutePath);
+        assembler.loadAlignmentsPafFile(alignmentsPafFileAbsolutePath);
     }
 
     // Start the http server.


### PR DESCRIPTION
This adds some methods to load a PAF as a graph, and integrates edge labeling into the AlignmentCandidateGraph. Additionally, a feature has been added to the Candidates page which allows the user to only visualize the reference graph edges.

An example of the reference graph, colored by inclusion in reference only (red), candidates (purple), good alignments (blue), and read graph edges (green):
![image](https://user-images.githubusercontent.com/28764332/106683169-e0fba080-6578-11eb-9c15-46fe763ff240.png)
