### PR TITLE
Palindrome quality classifier

### DIFF
--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -1,6 +1,4 @@
 #include "PalindromeQuality.hpp"
-
-#include <iostream>
 #include <stdexcept>
 #include "span.hpp"
 
@@ -47,7 +45,7 @@ bool shasta::classify_palindromic_q_scores(span<char> qualities){
     float right_mean = mean(right_stats);
     float right_variance = variance(right_stats);
 
-    // Compare the mean and variance using thresholds derived empirically from some palindormic reads
+    // Compare the mean and variance using thresholds derived empirically from some palindromic reads
     if (right_mean - left_mean > 0.09 and right_mean >= 0.15){
         if (right_variance > left_variance and right_variance > 0.025){
             is_palindromic = true;

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -1,0 +1,47 @@
+#include "PalindromeQuality.hpp"
+
+
+bool shasta::classify_palindromic_q_scores(span<char> qualities){
+    bool is_palindromic = false;
+
+    stats_accumulator left_stats;
+    stats_accumulator right_stats;
+
+    auto length = qualities.size();
+
+    // Don't bother classifying any reads that would have less than 3 scores per side
+    if (length < 6){
+        return false;
+    }
+
+    size_t midpoint = length/2;
+
+    for (size_t i=0; i<midpoint; i++){
+        auto q = qualities[i];
+        auto p = quality_char_to_error_probability(q);
+
+        left_stats(p);
+    }
+
+    for (size_t i=midpoint; i<length; i++){
+        auto q = qualities[i];
+        auto p = quality_char_to_error_probability(q);
+
+        right_stats(p);
+    }
+
+    float left_mean = mean(left_stats);
+    float left_variance = variance(left_stats);
+
+    float right_mean = mean(right_stats);
+    float right_variance = variance(right_stats);
+
+    // Compare the mean and variance using thresholds derived empirically from some palindormic reads
+    if (right_mean - left_mean > 0.09 and right_mean >= 0.15){
+        if (right_variance > left_variance and right_variance > 0.025){
+            is_palindromic = true;
+        }
+    }
+
+    return is_palindromic;
+}

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -9,6 +9,10 @@ using std::cerr;
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
 
+using namespace boost::accumulators;
+
+typedef accumulator_set<float, features<tag::count, tag::mean, tag::variance>> stats_accumulator;
+
 
 bool shasta::classify_palindromic_q_scores(span<char> qualities){
     bool is_palindromic = false;

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -1,5 +1,16 @@
 #include "PalindromeQuality.hpp"
 
+#include <iostream>
+#include <stdexcept>
+#include "span.hpp"
+
+using std::runtime_error;
+using std::cout;
+using std::cerr;
+
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+
 
 bool shasta::classify_palindromic_q_scores(span<char> qualities){
     bool is_palindromic = false;

--- a/src/PalindromeQuality.hpp
+++ b/src/PalindromeQuality.hpp
@@ -3,7 +3,7 @@
 
 namespace shasta {
 
-bool classify_palindromic_q_scores(span<char> qualities);
+bool classifyPalindromicQScores(span<char> qualities);
 
 }
 

--- a/src/PalindromeQuality.hpp
+++ b/src/PalindromeQuality.hpp
@@ -1,0 +1,10 @@
+#ifndef SHASTA_PALINDROMEQUALITY_HPP
+#define SHASTA_PALINDROMEQUALITY_HPP
+
+namespace shasta {
+
+bool classify_palindromic_q_scores(span<char> qualities);
+
+}
+
+#endif //SHASTA_PALINDROMEQUALITY_HPP


### PR DESCRIPTION
This adds a method to detect palindromes with an obvious deviation in quality in the second strand, as with the picture below:

![image](https://user-images.githubusercontent.com/28764332/109581291-e6cd9e80-7ab0-11eb-8952-e3209aa54e2a.png)

However, some palindromes exist that do not have this quality signature