### PR TITLE
Add palindrome q filter

### DIFF
--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -377,6 +377,26 @@ Used for palindromic read detection.
 <td><code>--Reads.palindromicReads.deltaThreshold</code><td class=centered><code>100</code><td>
 Used for palindromic read detection.
 
+<tr id='Reads.palindromicReads.detectOnFastqLoad'>
+<td><code>--Reads.palindromicReads.detectOnFastqLoad</code><td class=centered><code>false</code><td>
+Filter reads that have exceptionally poor quality in the second half,
+which is a strong indication of palindromic sequence.
+
+<tr id='Reads.palindromicReads.qScoreRelativeMeanDifference'>
+<td><code>--Reads.palindromicReads.qScoreRelativeMeanDifference</code><td class=centered><code>0.09</code><td>
+When filtering palindrome quality, this parameter describes how much
+worse should the right side average p(error) should be.
+
+<tr id='Reads.palindromicReads.qScoreMinimumMean'>
+<td><code>--Reads.palindromicReads.qScoreMinimumMean</code><td class=centered><code>0.15</code><td>
+When filtering palindrome quality, this parameter describes the absolute
+minimum average p(error) in the right half.
+
+<tr id='Reads.palindromicReads.qScoreMinimumVariance'>
+<td><code>--Reads.palindromicReads.qScoreMinimumVariance</code><td class=centered><code>00.25</code><td>
+When filtering palindrome quality, this parameter describes the absolute
+minimum variance in the right half.
+
 <tr id='Kmers.generationMethod'>
 <td><code>--Kmers.generationMethod</code><td class=centered><code>0</code><td>
 Used to select how k-mers to be used as markers are generated.

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -4,6 +4,7 @@
 // Shasta.
 #include "Alignment.hpp"
 #include "AlignmentCandidates.hpp"
+#include "AssemblerOptions.hpp"
 #include "AssembledSegment.hpp"
 #include "AssemblyGraph.hpp"
 #include "Coverage.hpp"
@@ -187,6 +188,7 @@ public:
         const string& fileName,
         uint64_t minReadLength,
         bool noCache,
+        const PalindromicReadOptions& palindromicReadOptions,
         size_t threadCount);
 
     // Create a histogram of read lengths.

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -188,7 +188,10 @@ public:
         const string& fileName,
         uint64_t minReadLength,
         bool noCache,
-        const PalindromicReadOptions& palindromicReadOptions,
+        bool detectPalindromesOnFastqLoad,
+        double qScoreRelativeMeanDifference,
+        double qScoreMinimumMean,
+        double qScoreMinimumVariance,
         size_t threadCount);
 
     // Create a histogram of read lengths.

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -110,6 +110,10 @@ public:
     uint64_t discardedBadRepeatCountReadCount = 0;
     uint64_t discardedBadRepeatCountBaseCount = 0;
 
+    // The number of reads and raw bases discarded because the read
+    // contained repeat counts greater than 255.
+    uint64_t discardedPalindromicReadCount = 0;
+    uint64_t discardedPalindromicBaseCount = 0;
 
 
     // Statistics for the reads kept in the assembly

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -678,11 +678,13 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
     const uint64_t totalDiscardedReadCount =
         assemblerInfo->discardedInvalidBaseReadCount +
         assemblerInfo->discardedShortReadReadCount +
-        assemblerInfo->discardedBadRepeatCountReadCount;
+        assemblerInfo->discardedBadRepeatCountReadCount +
+        assemblerInfo->discardedPalindromicReadCount;
     const uint64_t totalDiscardedBaseCount =
         assemblerInfo->discardedInvalidBaseBaseCount +
         assemblerInfo->discardedShortReadBaseCount +
-        assemblerInfo->discardedBadRepeatCountBaseCount;
+        assemblerInfo->discardedBadRepeatCountBaseCount +
+        assemblerInfo->discardedPalindromicBaseCount;
 
 
     html <<
@@ -708,7 +710,9 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<td class=right>" << reads->getRepeatCountsTotalSize() <<
         "<tr><td>Average length ratio of run-length encoded sequence over raw sequence"
         "<td class=right>" << setprecision(4) << double(reads->getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) <<
-        "<tr><td>Number of reads flagged as palindromic"
+        "<tr><td>Number of reads flagged as palindromic by q score"
+        "<td class=right>" << assemblerInfo->discardedPalindromicReadCount <<
+        "<tr><td>Number of reads flagged as palindromic by self alignment"
         "<td class=right>" << assemblerInfo->palindromicReadCount <<
         "<tr><td>Number of reads flagged as chimeric"
         "<td class=right>" << assemblerInfo->chimericReadCount <<
@@ -734,6 +738,9 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "<tr><td>Reads discarded on input because they contained repeat counts greater than 255"
         "<td class=right>" << assemblerInfo->discardedBadRepeatCountReadCount <<
         "<td class=right>" << assemblerInfo->discardedBadRepeatCountBaseCount <<
+        "<tr><td>Reads discarded on input because they had quality scores indicative of palindromic sequence"
+        "<td class=right>" << assemblerInfo->discardedPalindromicReadCount <<
+        "<td class=right>" << assemblerInfo->discardedPalindromicBaseCount <<
         "<tr><td>Reads discarded on input, total"
         "<td class=right>" <<totalDiscardedReadCount <<
         "<td class=right>" <<totalDiscardedBaseCount <<

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -930,10 +930,12 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
     const uint64_t totalDiscardedReadCount =
         assemblerInfo->discardedInvalidBaseReadCount +
         assemblerInfo->discardedShortReadReadCount +
+        assemblerInfo->discardedPalindromicReadCount +
         assemblerInfo->discardedBadRepeatCountReadCount;
     const uint64_t totalDiscardedBaseCount =
         assemblerInfo->discardedInvalidBaseBaseCount +
         assemblerInfo->discardedShortReadBaseCount +
+        assemblerInfo->discardedPalindromicBaseCount +
         assemblerInfo->discardedBadRepeatCountBaseCount;
 
 
@@ -958,7 +960,8 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    \"Number of run-length encoded bases\": " << reads->getRepeatCountsTotalSize() << ",\n"
         "    \"Average length ratio of run-length encoded sequence over raw sequence\": " <<
         setprecision(4) << double(reads->getRepeatCountsTotalSize()) / double(assemblerInfo->baseCount) << ",\n"
-        "    \"Number of reads flagged as palindromic\": " << assemblerInfo->palindromicReadCount << ",\n"
+        "    \"Number of reads flagged as palindromic by quality\": " << assemblerInfo->discardedPalindromicReadCount << ",\n"
+        "    \"Number of reads flagged as palindromic by self alignment\": " << assemblerInfo->palindromicReadCount << ",\n"
         "    \"Number of reads flagged as chimeric\": " << assemblerInfo->chimericReadCount << "\n"
         "  },\n"
 
@@ -980,6 +983,11 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         "    {\n"
         "      \"Reads\": " << assemblerInfo->discardedBadRepeatCountReadCount << ",\n"
         "      \"Bases\": " << assemblerInfo->discardedBadRepeatCountBaseCount << "\n"
+        "    },\n"
+        "    \"Reads discarded on input because they they had quality scores indicative of palindromic sequence\":\n"
+        "    {\n"
+        "      \"Reads\": " << assemblerInfo->discardedPalindromicReadCount << ",\n"
+        "      \"Bases\": " << assemblerInfo->discardedPalindromicBaseCount << "\n"
         "    },\n"
         "    \"Reads discarded on input, total\":\n"
         "    {\n"

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -268,6 +268,30 @@ void AssemblerOptions::addConfigurableOptions()
          default_value(100),
          "Used for palindromic read detection.")
 
+        ("Reads.PalindromicReadOptions.detectOnFastqLoad",
+         bool_switch(&readsOptions.palindromicReads.detectOnFastqLoad)->
+         default_value(false),
+        "Filter reads that have exceptionally poor quality in the second half, "
+        "which is a strong indication of palindromic sequence.")
+
+        ("Reads.palindromicReads.qScoreRelativeMeanDifference",
+        value<double>(&readsOptions.palindromicReads.qScoreRelativeMeanDifference)->
+        default_value(0.09, "0.09"),
+        "When filtering palindrome quality, this parameter describes how much "
+        "worse should the right side average p(error) should be.")
+
+        ("Reads.palindromicReads.qScoreMinimumMean",
+        value<double>(&readsOptions.palindromicReads.qScoreMinimumMean)->
+        default_value(0.15, "0.15"),
+        "When filtering palindrome quality, this parameter describes the absolute "
+        "minimum average p(error) in the right half.")
+
+        ("Reads.palindromicReads.qScoreMinimumVariance",
+         value<double>(&readsOptions.palindromicReads.qScoreMinimumVariance)->
+         default_value(0.025, "0.025"),
+         "When filtering palindrome quality, this parameter describes the absolute "
+         "minimum variance in the right half.")
+
          ("Kmers.generationMethod",
          value<int>(&kmersOptions.generationMethod)->
          default_value(0),
@@ -742,7 +766,7 @@ void AssemblerOptions::addConfigurableOptions()
 
 
 
-void ReadsOptions::PalindromicReadOptions::write(ostream& s) const
+void PalindromicReadOptions::write(ostream& s) const
 {
     s << "palindromicReads.skipFlagging = " << convertBoolToPythonString(skipFlagging) << "\n";
     s << "palindromicReads.maxSkip = " << maxSkip << "\n";
@@ -751,6 +775,9 @@ void ReadsOptions::PalindromicReadOptions::write(ostream& s) const
     s << "palindromicReads.alignedFractionThreshold = " << alignedFractionThreshold << "\n";
     s << "palindromicReads.nearDiagonalFractionThreshold = " << nearDiagonalFractionThreshold << "\n";
     s << "palindromicReads.deltaThreshold = " << deltaThreshold << "\n";
+    s << "palindromicReads.qScoreRelativeMeanDifference = " << qScoreRelativeMeanDifference << "\n";
+    s << "palindromicReads.qScoreMinimumMean = " << qScoreMinimumMean << "\n";
+    s << "palindromicReads.qScoreMinimumVariance = " << qScoreMinimumVariance << "\n";
 }
 
 

--- a/src/AssemblerOptions.hpp
+++ b/src/AssemblerOptions.hpp
@@ -30,7 +30,7 @@ If the option is a Boolean switch, use True or False as the optionValue.
 ADDING A NEW CONFIGURABLE OPTION
 
 1. Add the option to the class corresponding to the desired section.
-2. Modify the write function to that class to also write the newly added option.3.
+2. Modify the write function to that class to also write the newly added option.
 3. Modify AssemblerOptions::addCommandLineOnlyOptions to reflect the new option,
    making sure to include a default value and at least a minimal help message.
 4. Add the option to shasta/conf/shasta.conf with a short comment
@@ -77,6 +77,7 @@ namespace shasta {
     class KmersOptions;
     class MarkerGraphOptions;
     class MinHashOptions;
+    class PalindromicReadOptions;
     class ReadsOptions;
     class ReadGraphOptions;
 
@@ -105,6 +106,22 @@ public:
 };
 
 
+class shasta::PalindromicReadOptions {
+public:
+    bool skipFlagging;
+    int maxSkip;
+    int maxDrift;
+    int maxMarkerFrequency;
+    double alignedFractionThreshold;
+    double nearDiagonalFractionThreshold;
+    int deltaThreshold;
+    bool detectOnFastqLoad;
+    double qScoreRelativeMeanDifference;
+    double qScoreMinimumMean;
+    double qScoreMinimumVariance;
+    void write(ostream&) const;
+};
+
 
 // Options in the [Reads] section of the configuration file.
 // Can also be entered on the command line with option names
@@ -115,17 +132,6 @@ public:
     bool noCache;
     string desiredCoverageString;
     uint64_t desiredCoverage;
-    class PalindromicReadOptions {
-    public:
-        bool skipFlagging;
-        int maxSkip;
-        int maxDrift;
-        int maxMarkerFrequency;
-        double alignedFractionThreshold;
-        double nearDiagonalFractionThreshold;
-        int deltaThreshold;
-        void write(ostream&) const;
-    };
     PalindromicReadOptions palindromicReads;
 
     void write(ostream&) const;

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -1,5 +1,6 @@
 // Shasta.
 #include "Assembler.hpp"
+#include "AssemblerOptions.hpp"
 #include "ReadLoader.hpp"
 using namespace shasta;
 
@@ -14,6 +15,7 @@ void Assembler::addReads(
     const string& fileName,
     uint64_t minReadLength,
     bool noCache,
+    const PalindromicReadOptions& palindromicReadOptions,
     const size_t threadCount)
 {
     reads->checkReadsAreOpen();
@@ -26,6 +28,7 @@ void Assembler::addReads(
         threadCount,
         largeDataFileNamePrefix,
         largeDataPageSize,
+        palindromicReadOptions,
         *reads);
     
     reads->checkSanity();

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -41,6 +41,9 @@ void Assembler::addReads(
     cout << "    Discarded " << readLoader.discardedBadRepeatCountReadCount <<
         " reads containing repeat counts 256 or more" <<
         " for a total " << readLoader.discardedBadRepeatCountBaseCount << " bases." << endl;
+    cout << "    Discarded " << readLoader.discardedPalindromicReadCount <<
+         " reads with palindromic quality scores" <<
+         " for a total " << readLoader.discardedPalindromicBaseCount << " bases." << endl;
 
     // Increment the discarded reads statistics.
     assemblerInfo->discardedInvalidBaseReadCount += readLoader.discardedInvalidBaseReadCount;
@@ -49,6 +52,8 @@ void Assembler::addReads(
     assemblerInfo->discardedShortReadBaseCount += readLoader.discardedShortReadBaseCount;
     assemblerInfo->discardedBadRepeatCountReadCount += readLoader.discardedBadRepeatCountReadCount;
     assemblerInfo->discardedBadRepeatCountBaseCount += readLoader.discardedBadRepeatCountBaseCount;
+    assemblerInfo->discardedPalindromicReadCount += readLoader.discardedPalindromicReadCount;
+    assemblerInfo->discardedPalindromicBaseCount += readLoader.discardedPalindromicBaseCount;
     assemblerInfo->minReadLength = minReadLength;
 }
 

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -1,6 +1,5 @@
 // Shasta.
 #include "Assembler.hpp"
-#include "AssemblerOptions.hpp"
 #include "ReadLoader.hpp"
 using namespace shasta;
 
@@ -15,7 +14,10 @@ void Assembler::addReads(
     const string& fileName,
     uint64_t minReadLength,
     bool noCache,
-    const PalindromicReadOptions& palindromicReadOptions,
+    bool detectPalindromesOnFastqLoad,
+    double qScoreRelativeMeanDifference,
+    double qScoreMinimumMean,
+    double qScoreMinimumVariance,
     const size_t threadCount)
 {
     reads->checkReadsAreOpen();
@@ -28,7 +30,10 @@ void Assembler::addReads(
         threadCount,
         largeDataFileNamePrefix,
         largeDataPageSize,
-        palindromicReadOptions,
+        detectPalindromesOnFastqLoad,
+        qScoreRelativeMeanDifference,
+        qScoreMinimumMean,
+        qScoreMinimumVariance,
         *reads);
     
     reads->checkSanity();

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -1,5 +1,4 @@
 #include "PalindromeQuality.hpp"
-#include <stdexcept>
 #include "span.hpp"
 #include <cmath>
 
@@ -12,6 +11,7 @@ using std::pow;
 #include <boost/accumulators/statistics.hpp>
 
 using namespace boost::accumulators;
+using namespace shasta;
 
 typedef accumulator_set<float, features<tag::count, tag::mean, tag::variance>> stats_accumulator;
 
@@ -21,7 +21,7 @@ double qualityCharToErrorProbability(char q) {
 }
 
 
-bool shasta::classifyPalindromicQScores(span<char> qualities){
+bool shasta::isPalindromic(span<char> qualities){
     double relativeMeanDifference = 0.09;
     double minimumMean = 0.15;
     double minimumVariance = 0.025;

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -26,10 +26,6 @@ bool shasta::isPalindromic(span<char> qualities,
                            double minimumMean,
                            double minimumVariance){
 
-//    double relativeMeanDifference = 0.09;
-//    double minimumMean = 0.15;
-//    double minimumVariance = 0.025;
-
     bool isPalindromic = false;
 
     stats_accumulator leftStats;

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -13,7 +13,7 @@ using std::pow;
 using namespace boost::accumulators;
 using namespace shasta;
 
-typedef accumulator_set<float, features<tag::count, tag::mean, tag::variance>> stats_accumulator;
+using stats_accumulator = accumulator_set<float, features<tag::count, tag::mean, tag::variance>>;
 
 
 double qualityCharToErrorProbability(char q) {
@@ -21,10 +21,14 @@ double qualityCharToErrorProbability(char q) {
 }
 
 
-bool shasta::isPalindromic(span<char> qualities){
-    double relativeMeanDifference = 0.09;
-    double minimumMean = 0.15;
-    double minimumVariance = 0.025;
+bool shasta::isPalindromic(span<char> qualities,
+                           double relativeMeanDifference,
+                           double minimumMean,
+                           double minimumVariance){
+
+//    double relativeMeanDifference = 0.09;
+//    double minimumMean = 0.15;
+//    double minimumVariance = 0.025;
 
     bool isPalindromic = false;
 
@@ -41,14 +45,14 @@ bool shasta::isPalindromic(span<char> qualities){
     size_t midpoint = length/2;
 
     for (size_t i=0; i<midpoint; i++){
-        auto q = qualities[i];
+        const auto q = qualities[i];
         auto p = qualityCharToErrorProbability(q);
 
         leftStats(p);
     }
 
     for (size_t i=midpoint; i<length; i++){
-        auto q = qualities[i];
+        const auto q = qualities[i];
         auto p = qualityCharToErrorProbability(q);
 
         rightStats(p);

--- a/src/PalindromeQuality.cpp
+++ b/src/PalindromeQuality.cpp
@@ -21,10 +21,12 @@ double qualityCharToErrorProbability(char q) {
 }
 
 
-bool shasta::isPalindromic(span<char> qualities,
-                           double relativeMeanDifference,
-                           double minimumMean,
-                           double minimumVariance){
+bool shasta::isPalindromic(
+        span<char> qualities,
+        double relativeMeanDifference,
+        double minimumMean,
+        double minimumVariance
+){
 
     bool isPalindromic = false;
 

--- a/src/PalindromeQuality.hpp
+++ b/src/PalindromeQuality.hpp
@@ -5,7 +5,7 @@
 
 namespace shasta {
 
-bool classifyPalindromicQScores(span<char> qualities);
+bool isPalindromic(span<char> qualities);
 
 }
 

--- a/src/PalindromeQuality.hpp
+++ b/src/PalindromeQuality.hpp
@@ -5,7 +5,10 @@
 
 namespace shasta {
 
-bool isPalindromic(span<char> qualities);
+bool isPalindromic(span<char> qualities,
+                   double relativeMeanDifference,
+                   double minimumMean,
+                   double minimumVariance);
 
 }
 

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -470,8 +470,9 @@ void ReadLoader::processFastqFileThreadFunction(size_t threadId)
         // Skip if the q scores have an obvious palindromic characteristic
         span <char> scores(scoresBegin, scoresEnd);
         if (isPalindromic(scores)){
-            __sync_fetch_and_add(&discardedPalindromicReadReadCount, 1);
-            __sync_fetch_and_add(&discardedPalindromicReadBaseCount, read.size());
+            __sync_fetch_and_add(&discardedPalindromicReadCount, 1);
+            __sync_fetch_and_add(&discardedPalindromicReadCount, 1);
+            __sync_fetch_and_add(&discardedPalindromicBaseCount, read.size());
             continue;
         }
 

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -470,8 +470,8 @@ void ReadLoader::processFastqFileThreadFunction(size_t threadId)
         // Skip if the q scores have an obvious palindromic characteristic
         span <char> scores(scoresBegin, scoresEnd);
         if (isPalindromic(scores)){
-            __sync_fetch_and_add(&discardedShortReadReadCount, 1);
-            __sync_fetch_and_add(&discardedShortReadBaseCount, read.size());
+            __sync_fetch_and_add(&discardedPalindromicReadReadCount, 1);
+            __sync_fetch_and_add(&discardedPalindromicReadBaseCount, read.size());
             continue;
         }
 

--- a/src/ReadLoader.cpp
+++ b/src/ReadLoader.cpp
@@ -467,6 +467,14 @@ void ReadLoader::processFastqFileThreadFunction(size_t threadId)
             continue;
         }
 
+        // Skip if the q scores have an obvious palindromic characteristic
+        span <char> scores(scoresBegin, scoresEnd);
+        if (isPalindromic(scores)){
+            __sync_fetch_and_add(&discardedShortReadReadCount, 1);
+            __sync_fetch_and_add(&discardedShortReadBaseCount, read.size());
+            continue;
+        }
+
         // Store the read.
         if(computeRunLengthRepresentation(read, runLengthRead, readRepeatCount)) {
             thisThreadReadNames.appendVector(readName.begin(), readName.end());

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -2,6 +2,7 @@
 #define SHASTA_READ_LOADER_HPP
 
 // shasta
+#include "AssemblerOptions.hpp"
 #include "PalindromeQuality.hpp"
 #include "LongBaseSequence.hpp"
 #include "MemoryMappedObject.hpp"
@@ -31,6 +32,7 @@ public:
         size_t threadCount,
         const string& dataNamePrefix,
         size_t pageSize,
+        const PalindromicReadOptions& palindromicReadOptions,
         Reads& reads);
 
     ~ReadLoader();
@@ -77,9 +79,14 @@ private:
     const string& dataNamePrefix;
     const size_t pageSize;
 
+    // This object is copied for convenience to specify the following:
+    //   - Boolean switch to use quality scores to skip reads that have an indication of palindromic sequence
+    //   - Each of the 3 thresholds necessary for calling isPalindromic()
+    PalindromicReadOptions palindromicReadOptions;
+
     // The data structure that the reads will be added to.
     Reads& reads;
-    
+
     // Create the name to be used for a MemoryMapped object.
     string dataName(
         const string& dataName) const;

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -2,6 +2,7 @@
 #define SHASTA_READ_LOADER_HPP
 
 // shasta
+#include "PalindromeQuality.hpp"
 #include "LongBaseSequence.hpp"
 #include "MemoryMappedObject.hpp"
 #include "MultithreadedObject.hpp"

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -47,8 +47,8 @@ public:
 
     // The number of reads and raw bases discarded because the read had
     // a q score distribution that was indicative of a palindrome.
-    uint64_t discardedPalindromicReadReadCount = 0;
-    uint64_t discardedPalindromicReadBaseCount = 0;
+    uint64_t discardedPalindromicReadCount = 0;
+    uint64_t discardedPalindromicBaseCount = 0;
 
     // The number of reads and raw bases discarded because the read
     // contained repeat counts greater than 255.

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -32,7 +32,10 @@ public:
         size_t threadCount,
         const string& dataNamePrefix,
         size_t pageSize,
-        const PalindromicReadOptions& palindromicReadOptions,
+        bool detectPalindromesOnFastqLoad,
+        double qScoreRelativeMeanDifference,
+        double qScoreMinimumMean,
+        double qScoreMinimumVariance,
         Reads& reads);
 
     ~ReadLoader();
@@ -79,10 +82,13 @@ private:
     const string& dataNamePrefix;
     const size_t pageSize;
 
-    // This object is copied for convenience to specify the following:
-    //   - Boolean switch to use quality scores to skip reads that have an indication of palindromic sequence
-    //   - Each of the 3 thresholds necessary for calling isPalindromic()
-    PalindromicReadOptions palindromicReadOptions;
+    // Boolean switch to use quality scores to skip reads that have an indication of palindromic sequence
+    bool detectPalindromesOnFastqLoad;
+
+    // Each of the 3 thresholds necessary for calling isPalindromic()
+    double qScoreRelativeMeanDifference;
+    double qScoreMinimumMean;
+    double qScoreMinimumVariance;
 
     // The data structure that the reads will be added to.
     Reads& reads;

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -2,7 +2,6 @@
 #define SHASTA_READ_LOADER_HPP
 
 // shasta
-#include "AssemblerOptions.hpp"
 #include "PalindromeQuality.hpp"
 #include "LongBaseSequence.hpp"
 #include "MemoryMappedObject.hpp"

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -45,6 +45,11 @@ public:
     uint64_t discardedShortReadReadCount = 0;
     uint64_t discardedShortReadBaseCount = 0;
 
+    // The number of reads and raw bases discarded because the read had
+    // a q score distribution that was indicative of a palindrome.
+    uint64_t discardedPalindromicReadReadCount = 0;
+    uint64_t discardedPalindromicReadBaseCount = 0;
+
     // The number of reads and raw bases discarded because the read
     // contained repeat counts greater than 255.
     uint64_t discardedBadRepeatCountReadCount = 0;

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -486,7 +486,10 @@ void shasta::main::assemble(
             inputFileName,
             assemblerOptions.readsOptions.minReadLength,
             assemblerOptions.readsOptions.noCache,
-            assemblerOptions.readsOptions.palindromicReads,
+            assemblerOptions.readsOptions.palindromicReads.detectOnFastqLoad,
+            assemblerOptions.readsOptions.palindromicReads.qScoreRelativeMeanDifference,
+            assemblerOptions.readsOptions.palindromicReads.qScoreMinimumMean,
+            assemblerOptions.readsOptions.palindromicReads.qScoreMinimumVariance,
             threadCount);
     }
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -486,6 +486,7 @@ void shasta::main::assemble(
             inputFileName,
             assemblerOptions.readsOptions.minReadLength,
             assemblerOptions.readsOptions.noCache,
+            assemblerOptions.readsOptions.palindromicReads,
             threadCount);
     }
 


### PR DESCRIPTION
First commit has been tested on a fastq containing only palindromes with identifiable q scores. The result is that no reads are loaded. Next step is adding config options