### PR TITLE
Add filter command to main executable

### DIFF
--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -379,8 +379,10 @@ Used for palindromic read detection.
 
 <tr id='Reads.palindromicReads.detectOnFastqLoad'>
 <td><code>--Reads.palindromicReads.detectOnFastqLoad</code><td class=centered><code>false</code><td>
-Filter reads that have exceptionally poor quality in the second half,
-which is a strong indication of palindromic sequence.
+This is a
+<a href="#BooleanSwitches">Boolean switch</a>
+that enables filtering palindromes from FASTQ files. This method will filter reads that have exceptionally
+poor quality in the second half, which is a strong indication of palindromic sequence.
 
 <tr id='Reads.palindromicReads.qScoreRelativeMeanDifference'>
 <td><code>--Reads.palindromicReads.qScoreRelativeMeanDifference</code><td class=centered><code>0.09</code><td>

--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -248,6 +248,11 @@ when invoking <code>shasta</code>.
 <a class=qm href="#bashCompletion"></a>
 </dd>
 
+
+<dt><code>filterReads</code>
+<dd>Shasta performs read loading and filtering, prints the passing read names to a CSV, and exits.</dd>
+
+
 </dl>
 
 

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -1769,9 +1769,9 @@ public:
     // of processing requests.
     void writeHtmlBegin(ostream&) const;
     void writeHtmlEnd(ostream&) const;
-    void writeAssemblySummary(ostream&);
-    void writeAssemblySummaryBody(ostream&);
-    void writeAssemblySummaryJson(ostream&);
+    void writeAssemblySummary(ostream&, bool readsOnly=false);
+    void writeAssemblySummaryBody(ostream&, bool readsOnly=false);
+    void writeAssemblySummaryJson(ostream&, bool readsOnly=false);
     void writeAssemblyIndex(ostream&) const;
     static void writeStyle(ostream& html);
 

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -650,14 +650,14 @@ void Assembler::writeHtmlEnd(ostream& html) const
 
 
 
-void Assembler::writeAssemblySummary(ostream& html)
+void Assembler::writeAssemblySummary(ostream& html, bool readsOnly)
 {
     writeHtmlBegin(html);
-    writeAssemblySummaryBody(html);
+    writeAssemblySummaryBody(html, readsOnly);
     writeHtmlEnd(html);
 }
 
-void Assembler::writeAssemblySummaryBody(ostream& html)
+void Assembler::writeAssemblySummaryBody(ostream& html, bool readsOnly)
 {
     using std::setprecision;
     AssemblyGraph& assemblyGraph = *assemblyGraphPointer;
@@ -756,9 +756,13 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
         "</table>"
         "<ul><li>Base counts in the above table are raw sequence bases."
         "<li>Here and elsewhere, &quot;raw&quot; refers to the original read sequence, "
-        "as opposed to run-length encoded sequence.</ul>"
+        "as opposed to run-length encoded sequence.</ul>";
 
+    if (readsOnly) {
+        return;
+    }
 
+    html <<
         "<h3>Marker <i>k</i>-mers</h3>"
         "<table>"
         "<tr><td>Length <i>k</i> of <i>k</i>-mers used as markers"
@@ -908,7 +912,7 @@ void Assembler::writeAssemblySummaryBody(ostream& html)
 
 
 
-void Assembler::writeAssemblySummaryJson(ostream& json)
+void Assembler::writeAssemblySummaryJson(ostream& json, bool readsOnly)
 {
     AssemblyGraph& assemblyGraph = *assemblyGraphPointer;
     using std::setprecision;
@@ -1005,10 +1009,13 @@ void Assembler::writeAssemblySummaryJson(ostream& json)
         double(totalDiscardedBaseCount + assemblerInfo->baseCount)
         << "\n"
         "    }\n"
-        "  },\n"
+        "  },\n";
 
+    if (readsOnly) {
+        return;
+    }
 
-
+    json <<
         "  \"Marker k-mers\":\n"
         "  {\n"
         "    \"Length k of k-mers used as markers\": " << assemblerInfo->k << ",\n"

--- a/src/AssemblerOptions.cpp
+++ b/src/AssemblerOptions.cpp
@@ -9,7 +9,7 @@ using namespace shasta;
 
 // Standard library.
 #include "fstream.hpp"
-#include"stdexcept.hpp"
+#include "stdexcept.hpp"
 
 
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -148,7 +148,7 @@ void shasta::main::main(int argumentCount, const char** arguments)
 
     // If getting here, the requested command is invalid.
     throw runtime_error("Invalid command " + assemblerOptions.commandLineOnlyOptions.command +
-        ". Valid commands are: assemble, saveBinaryData, cleanupBinaryData, createBashCompletionScript.");
+        ". Valid commands are: assemble, saveBinaryData, cleanupBinaryData, createBashCompletionScript, filterReads.");
 
 }
 
@@ -1247,7 +1247,7 @@ void shasta::main::createBashCompletionScript(const AssemblerOptions& assemblerO
     }
 
     // Other keywords. This should be modified to only accept them after the appropriate option.
-    file << "assemble saveBinaryData cleanupBinaryData explore createBashCompletionScript \\\n";
+    file << "assemble saveBinaryData cleanupBinaryData explore createBashCompletionScript filterReads\\\n";
     file << "filesystem anonymous \\\n";
     file << "disk 4K 2M \\\n";
     file << "user local unrestricted \\\n";


### PR DESCRIPTION
This enables running shasta's read loader and filtering steps, up to the point of palindrome detection by self-alignment. The reads that remain after filtering are written as pairs of `ReadId,ReadName` in a csv and the assembly is aborted after writing a summary that describes the read stats.

