### PR TITLE
Write palindrome names separately to CSV

### DIFF
--- a/docs/CommandLineOptions.html
+++ b/docs/CommandLineOptions.html
@@ -250,7 +250,10 @@ when invoking <code>shasta</code>.
 
 
 <dt><code>filterReads</code>
-<dd>Shasta performs read loading and filtering, prints the passing read names to a CSV, and exits.</dd>
+<dd>
+Shasta performs read loading and filtering, prints the passing read names to a CSV, and exits.
+If palindromes are detected, their read names are written separately to PalindromicReads.csv
+</dd>
 
 
 </dl>

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -192,6 +192,7 @@ public:
         double qScoreRelativeMeanDifference,
         double qScoreMinimumMean,
         double qScoreMinimumVariance,
+        bool writePalindromicReadsToCsv,
         size_t threadCount);
 
     // Create a histogram of read lengths.
@@ -546,6 +547,7 @@ public:
         double alignedFractionThreshold,
         double nearDiagonalFractionThreshold,
         uint32_t deltaThreshold,
+        bool writeToCsv,
         size_t threadCount);
 private:
     void flagPalindromicReadsThreadFunction(size_t threadId);

--- a/src/AssemblerAlign.cpp
+++ b/src/AssemblerAlign.cpp
@@ -646,6 +646,7 @@ void Assembler::flagPalindromicReads(
     double alignedFractionThreshold,
     double nearDiagonalFractionThreshold,
     uint32_t deltaThreshold,
+    bool writeToCsv,
     size_t threadCount)
 {
     cout << timestamp << "Finding palindromic reads." << endl;
@@ -688,13 +689,18 @@ void Assembler::flagPalindromicReads(
         double(palindromicReadCount)/double(readCount) << endl;
 
 
-    // Write a csv file with the list of palindromic reads.
+    // Write a csv file with the list of palindromic reads
+    // if shasta is running in "filterReads" mode.
     // This should not too big as the typical rate of
     // palindromic reads is around 1e-4.
-    ofstream csvOut("PalindromicReads.csv");
-    for(ReadId readId=0; readId<readCount; readId++) {
-        if(reads->getFlags(readId).isPalindromic) {
-            csvOut << readId << "\n";
+    if(writeToCsv) {
+        // Open the file in "append" mode because it may already have
+        // been created during read loading
+        ofstream csvOut("PalindromicReads.csv", std::ofstream::app);
+        for(ReadId readId = 0; readId < readCount; readId++) {
+            if(reads->getFlags(readId).isPalindromic) {
+                csvOut << reads->getReadName(readId) << "\n";
+            }
         }
     }
 }

--- a/src/AssemblerReads.cpp
+++ b/src/AssemblerReads.cpp
@@ -18,6 +18,7 @@ void Assembler::addReads(
     double qScoreRelativeMeanDifference,
     double qScoreMinimumMean,
     double qScoreMinimumVariance,
+    bool writePalindromicReadsToCsv,
     const size_t threadCount)
 {
     reads->checkReadsAreOpen();
@@ -34,6 +35,7 @@ void Assembler::addReads(
         qScoreRelativeMeanDifference,
         qScoreMinimumMean,
         qScoreMinimumVariance,
+        writePalindromicReadsToCsv,
         *reads);
     
     reads->checkSanity();

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -216,6 +216,7 @@ PYBIND11_MODULE(shasta, module)
             arg("alignedFractionThreshold"),
             arg("nearDiagonalFractionThreshold"),
             arg("deltaThreshold"),
+            arg("writeTocsv") = false,
             arg("threadCount") = 0)
 
         // Alignments.

--- a/src/ReadLoader.hpp
+++ b/src/ReadLoader.hpp
@@ -35,6 +35,7 @@ public:
         double qScoreRelativeMeanDifference,
         double qScoreMinimumMean,
         double qScoreMinimumVariance,
+        bool writePalindromesToCsv,
         Reads& reads);
 
     ~ReadLoader();
@@ -89,6 +90,9 @@ private:
     double qScoreMinimumMean;
     double qScoreMinimumVariance;
 
+    // This is true if shasta was run with command "filterReads"
+    bool writePalindromesToCsv;
+
     // The data structure that the reads will be added to.
     Reads& reads;
 
@@ -110,6 +114,7 @@ private:
     vector< unique_ptr<MemoryMapped::VectorOfVectors<char, uint64_t> > > threadReadMetaData;
     vector< unique_ptr<LongBaseSequences> > threadReads;
     vector< unique_ptr<MemoryMapped::VectorOfVectors<uint8_t, uint64_t> > > threadReadRepeatCounts;
+    vector< vector<string> > threadPalindromicReadNames;
     void allocatePerThreadDataStructures();
     void allocatePerThreadDataStructures(size_t threadId);
 

--- a/srcMain/main.cpp
+++ b/srcMain/main.cpp
@@ -484,6 +484,11 @@ void shasta::main::assemble(
     cout << timestamp << "Begin loading reads from " << inputFileNames.size() << " files." << endl;
     const auto t0 = steady_clock::now();
     for(const string& inputFileName: inputFileNames) {
+        // Only dump the palindromes to a separate csv if running in filter mode.
+        // Otherwise ReadSummary.csv already contains the palindromic reads that were identified
+        // by self alignment (but not the palindromes identified by Q score)
+        bool writeToCsv = (assemblerOptions.commandLineOnlyOptions.command == "filterReads");
+
         assembler.addReads(
             inputFileName,
             assemblerOptions.readsOptions.minReadLength,
@@ -492,6 +497,7 @@ void shasta::main::assemble(
             assemblerOptions.readsOptions.palindromicReads.qScoreRelativeMeanDifference,
             assemblerOptions.readsOptions.palindromicReads.qScoreMinimumMean,
             assemblerOptions.readsOptions.palindromicReads.qScoreMinimumVariance,
+            writeToCsv,
             threadCount);
     }
 
@@ -633,6 +639,11 @@ void shasta::main::assemble(
     assembler.findMarkers(0);
 
     if(!assemblerOptions.readsOptions.palindromicReads.skipFlagging) {
+        // Only dump the palindromes to a separate csv if running in filter mode.
+        // Otherwise ReadSummary.csv already contains the palindromic reads that were identified
+        // by self alignment (but not the palindromes identified by Q score)
+        bool writeToCsv = (assemblerOptions.commandLineOnlyOptions.command == "filterReads");
+
         // Flag palindromic reads.
         // These will be excluded from further processing.
         assembler.flagPalindromicReads(
@@ -642,6 +653,7 @@ void shasta::main::assemble(
             assemblerOptions.readsOptions.palindromicReads.alignedFractionThreshold,
             assemblerOptions.readsOptions.palindromicReads.nearDiagonalFractionThreshold,
             assemblerOptions.readsOptions.palindromicReads.deltaThreshold,
+            writeToCsv,
             threadCount);
     }
 


### PR DESCRIPTION
When running with command `filterReads`, dump the names of all palindromes detected by Q method or self alignment