### PR TITLE
Add write methods/scripts for candidates and read graph edges

### DIFF
--- a/scripts/WriteAlignmentCandidates.py
+++ b/scripts/WriteAlignmentCandidates.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import shasta
+import sys
+
+helpMessage = """
+Write all alignment candidates (pairs of ReadId) to a file named AlignmentCandidates.csv. Takes no arguments.
+"""
+
+if not len(sys.argv) == 1:
+    print(helpMessage)
+    exit(1)
+
+
+a = shasta.Assembler()
+print("Accessing data ...")
+a.accessMarkers()
+a.accessAlignmentCandidates()
+print("Writing to AlignmentCandidates.csv ...")
+a.writeAlignmentCandidates()
+print("Done")

--- a/scripts/WriteReadGraphEdges.py
+++ b/scripts/WriteReadGraphEdges.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import shasta
+import sys
+
+helpMessage = """
+Write all read graph edges (pairs of ReadId) to a file named ReadGraphEdges.csv. Takes no arguments.
+"""
+
+if not len(sys.argv) == 1:
+    print(helpMessage)
+    exit(1)
+
+
+a = shasta.Assembler()
+print("Accessing data ...")
+a.accessReadGraph()
+print("Writing to ReadGraphEdges.csv ...")
+a.writeReadGraphEdges()
+print("Done")

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -934,6 +934,7 @@ public:
     void removeReadGraphBridges(uint64_t maxDistance);
     void analyzeReadGraph();
     void readGraphClustering();
+    void writeReadGraphEdges() const;
 
 
 

--- a/src/AssemblerReadGraph2.cpp
+++ b/src/AssemblerReadGraph2.cpp
@@ -23,6 +23,25 @@ using namespace shasta;
 *******************************************************************************/
 
 
+void Assembler::writeReadGraphEdges() const{
+    string path = "ReadGraphEdges.csv";
+    path = filesystem::getAbsolutePath(path);
+    ofstream file(path);
+
+    if (not file.good()){
+        throw runtime_error("ERROR: file could not be written: " + path);
+    }
+
+    file << "ReadId0,ReadId1,SameStrand\n";
+
+    // Loop over readgraph edges
+    for (const ReadGraphEdge& edge: readGraph.edges){
+        file << edge.orientedReadIds[0].getReadId() << ','
+            << edge.orientedReadIds[1].getReadId() << ','
+            << (edge.crossesStrands ? "No" : "Yes") << '\n';
+    }
+}
+
 
 void Assembler::createReadGraph2(
     uint32_t maxAlignmentCount,

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -357,6 +357,8 @@ PYBIND11_MODULE(shasta, module)
              &Assembler::analyzeReadGraph)
         .def("readGraphClustering",
              &Assembler::readGraphClustering)
+        .def("writeReadGraphEdges",
+             &Assembler::writeReadGraphEdges)
 
 
 


### PR DESCRIPTION
Simple methods and scripts for writing the full set of candidates and read graph edges to a csv. 

- The existing `Assembler::writeAlignmentCandidates()` method was given a separate python script
- The ReadGraph needed a new C++ implementation for writing edges