### PR TITLE
New method for writing local candidate graph reads

### DIFF
--- a/scripts/WriteLocalAlignmentCandidateReads.py
+++ b/scripts/WriteLocalAlignmentCandidateReads.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import shasta
+import argparse
+
+
+parser = argparse.ArgumentParser(description=
+    'Write a FASTA file containing all the reads present in a local alignment candidate graph.')
+    
+parser.add_argument('--readId', type=int, required=True)
+parser.add_argument('--strand', type=int, choices=range(2), required=True)
+parser.add_argument('--maxDistance', type=int, required=True)
+parser.add_argument('--allowChimericReads', action='store_true')
+parser.add_argument('--allowCrossStrandEdges', action='store_true')
+parser.add_argument('--allowInconsistentAlignmentEdges', action='store_true')
+arguments = parser.parse_args()
+
+readId = arguments.readId
+strand = arguments.strand
+maxDistance = arguments.maxDistance
+allowChimericReads = arguments.allowChimericReads
+allowCrossStrandEdges = arguments.allowCrossStrandEdges
+allowInconsistentAlignmentEdges = arguments.allowInconsistentAlignmentEdges
+
+a = shasta.Assembler()
+a.accessMarkers()
+a.accessAlignmentCandidates()
+a.accessAlignmentCandidateTable()
+a.accessAlignmentData()
+a.accessReadGraph()
+a.writeLocalAlignmentCandidateReads(
+    readId=readId, strand=strand,
+    maxDistance=maxDistance,
+    allowChimericReads=allowChimericReads,
+    allowCrossStrandEdges=allowCrossStrandEdges,
+    allowInconsistentAlignmentEdges=allowInconsistentAlignmentEdges)
+
+

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -698,6 +698,7 @@ public:
     );
     void markAlignmentCandidatesAllPairs();
     void accessAlignmentCandidates();
+    void accessAlignmentCandidateTable();
     vector<OrientedReadPair> getAlignmentCandidates() const;
 private:
     void checkAlignmentCandidatesAreOpen() const;
@@ -719,7 +720,8 @@ private:
         double timeout,                     // Or 0 for no timeout.
         bool inGoodAlignmentsRequired,      // Only add an edge to the local graph if it's in the "good" alignments
         bool inReadgraphRequired,           // Only add an edge to the local graph if it's in the ReadGraph
-        LocalAlignmentCandidateGraph& graph);
+        LocalAlignmentCandidateGraph& graph
+    );
 
     // This method is used as an alternative to createLocalAlignmentCandidateGraph, in the case that the user
     // wants to see only the edges that are inferred from the PAF, and none others. Coloring/labelling w.r.t.
@@ -729,8 +731,20 @@ private:
         uint32_t maxDistance,           // How far to go from starting oriented read.
         bool allowChimericReads,
         double timeout,                 // Or 0 for no timeout.
-        LocalAlignmentCandidateGraph& graph);
-
+        LocalAlignmentCandidateGraph& graph
+    );
+public:
+    // Construct a subgraph around a read in the candidate graph
+    // and write all subgraph reads to a Fasta file.
+    void writeLocalAlignmentCandidateReads(
+            ReadId readId,
+            Strand strand,
+            uint32_t maxDistance,
+            bool allowChimericReads,
+            bool allowCrossStrandEdges,
+            bool allowInconsistentAlignmentEdges
+    );
+private:
     // Compute a marker alignment of two oriented reads.
     void alignOrientedReads(
         OrientedReadId,

--- a/src/AssemblerAlignmentCandidates.cpp
+++ b/src/AssemblerAlignmentCandidates.cpp
@@ -125,7 +125,7 @@ bool Assembler::createLocalReferenceGraph(
 
 
 // Write a FASTA file containing all reads that appear in
-// the local read graph.
+// the local alignment candidate graph.
 void Assembler::writeLocalAlignmentCandidateReads(
         ReadId readId,
         Strand strand,
@@ -136,7 +136,7 @@ void Assembler::writeLocalAlignmentCandidateReads(
 {
     vector<OrientedReadId> starts = {OrientedReadId(readId, strand)};
 
-    // Create the requested local read graph.
+    // Create the requested local candidate graph.
     LocalAlignmentCandidateGraph localCandidateGraph;
     SHASTA_ASSERT(createLocalAlignmentCandidateGraph(
             starts,

--- a/src/AssemblerLowHash.cpp
+++ b/src/AssemblerLowHash.cpp
@@ -61,6 +61,11 @@ void Assembler::accessAlignmentCandidates()
     alignmentCandidates.candidates.accessExistingReadOnly(largeDataName("AlignmentCandidates"));
 }
 
+void Assembler::accessAlignmentCandidateTable()
+{
+    alignmentCandidates.candidateTable.accessExistingReadOnly(largeDataName("CandidateTable"));
+}
+
 void Assembler::accessReadLowHashStatistics()
 {
     readLowHashStatistics.accessExistingReadOnly(largeDataName("ReadLowHashStatistics"));

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -208,6 +208,8 @@ PYBIND11_MODULE(shasta, module)
             arg("threadCount") = 0)
         .def("accessAlignmentCandidates",
             &Assembler::accessAlignmentCandidates)
+        .def("accessAlignmentCandidateTable",
+            &Assembler::accessAlignmentCandidateTable)
         .def("getAlignmentCandidates",
             &Assembler::getAlignmentCandidates)
         .def("writeOverlappingReads",
@@ -232,6 +234,14 @@ PYBIND11_MODULE(shasta, module)
              &Assembler::writeAlignmentCandidates,
              arg("useReadName") = false,
              arg("verbose") = false)
+        .def("writeLocalAlignmentCandidateReads",
+             &Assembler::writeLocalAlignmentCandidateReads,
+             arg("readId"),
+             arg("strand"),
+             arg("maxDistance"),
+             arg("allowChimericReads"),
+             arg("allowCrossStrandEdges"),
+             arg("allowInconsistentAlignmentEdges"))
         .def("alignOrientedReads",
             (
                 void (Assembler::*)


### PR DESCRIPTION
Many of our test data sets are based on reads extracted from the ReadGraph, which in some cases is not suitable because it introduces a bias in the reads that are included in the test. Ideally all true overlaps are included for any test that involves filtering candidates or alignments.

So this method provides a means for a extracting a more comprehensive set of overlaps.
