### PR TITLE
Fix Data access for browser AlignmentCandidate graph

### DIFF
--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -415,6 +415,20 @@ void Assembler::exploreAlignmentCandidateGraph(
 
     // Create the local graph.
     LocalAlignmentCandidateGraph graph;
+
+    if (not alignmentCandidates.candidates.isOpen) {
+        accessAlignmentCandidates();
+    }
+    if (not alignmentCandidates.candidateTable.isOpen()) {
+        accessAlignmentCandidateTable();
+    }
+    if (not alignmentData.isOpen) {
+        accessAlignmentData();
+    }
+    if (not readGraph.connectivity.isOpen() or not readGraph.edges.isOpen) {
+        accessReadGraph();
+    }
+
     if (referenceGraphOnly){
         if(!createLocalReferenceGraph(
                 readIds,
@@ -427,19 +441,6 @@ void Assembler::exploreAlignmentCandidateGraph(
         }
     }
     else {
-        if (not alignmentCandidates.candidates.isOpen) {
-            accessAlignmentCandidates();
-        }
-        if (not alignmentCandidates.candidateTable.isOpen()) {
-            accessAlignmentCandidateTable();
-        }
-        if (not alignmentData.isOpen) {
-            accessAlignmentData();
-        }
-        if (not readGraph.connectivity.isOpen() or not readGraph.edges.isOpen) {
-            accessReadGraph();
-        }
-
         if (!createLocalAlignmentCandidateGraph(
                 readIds,
                 maxDistance,

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -427,6 +427,19 @@ void Assembler::exploreAlignmentCandidateGraph(
         }
     }
     else {
+        if (not alignmentCandidates.candidates.isOpen) {
+            accessAlignmentCandidates();
+        }
+        if (not alignmentCandidates.candidateTable.isOpen()) {
+            accessAlignmentCandidateTable();
+        }
+        if (not alignmentData.isOpen) {
+            accessAlignmentData();
+        }
+        if (not readGraph.connectivity.isOpen() or not readGraph.edges.isOpen) {
+            accessReadGraph();
+        }
+
         if (!createLocalAlignmentCandidateGraph(
                 readIds,
                 maxDistance,

--- a/src/AssemblerHttpServer-Alignments.cpp
+++ b/src/AssemblerHttpServer-Alignments.cpp
@@ -416,19 +416,6 @@ void Assembler::exploreAlignmentCandidateGraph(
     // Create the local graph.
     LocalAlignmentCandidateGraph graph;
 
-    if (not alignmentCandidates.candidates.isOpen) {
-        accessAlignmentCandidates();
-    }
-    if (not alignmentCandidates.candidateTable.isOpen()) {
-        accessAlignmentCandidateTable();
-    }
-    if (not alignmentData.isOpen) {
-        accessAlignmentData();
-    }
-    if (not readGraph.connectivity.isOpen() or not readGraph.edges.isOpen) {
-        accessReadGraph();
-    }
-
     if (referenceGraphOnly){
         if(!createLocalReferenceGraph(
                 readIds,

--- a/src/AssemblerHttpServer.cpp
+++ b/src/AssemblerHttpServer.cpp
@@ -399,6 +399,13 @@ void Assembler::accessAllSoft()
     }
 
     try {
+        accessAlignmentCandidateTable();
+    } catch(const exception& e) {
+        cout << "Alignment candidate table is not accessible." << endl;
+        allDataAreAvailable = false;
+    }
+
+    try {
         accessReadLowHashStatistics();
     } catch(const exception& e) {
         cout << "Read alignment statistics are not accessible." << endl;


### PR DESCRIPTION
Somehow during testing the necessary data objects for building/labeling the local AlignmentCandidate graph were loaded already, so I had not previously encountered the case where they needed to be accessed. This addresses that case.