### PR TITLE
Add option to use original read name in WriteLocalReadGraph

### DIFF
--- a/scripts/WriteLocalAlignmentCandidateReads.py
+++ b/scripts/WriteLocalAlignmentCandidateReads.py
@@ -10,7 +10,6 @@ parser = argparse.ArgumentParser(description=
 parser.add_argument('--readId', type=int, required=True)
 parser.add_argument('--strand', type=int, choices=range(2), required=True)
 parser.add_argument('--maxDistance', type=int, required=True)
-parser.add_argument('--useReadName', action='store_true')
 parser.add_argument('--allowChimericReads', action='store_true')
 parser.add_argument('--allowCrossStrandEdges', action='store_true')
 parser.add_argument('--allowInconsistentAlignmentEdges', action='store_true')
@@ -19,7 +18,6 @@ arguments = parser.parse_args()
 readId = arguments.readId
 strand = arguments.strand
 maxDistance = arguments.maxDistance
-useReadName = arguments.useReadName
 allowChimericReads = arguments.allowChimericReads
 allowCrossStrandEdges = arguments.allowCrossStrandEdges
 allowInconsistentAlignmentEdges = arguments.allowInconsistentAlignmentEdges
@@ -33,7 +31,6 @@ a.accessReadGraph()
 a.writeLocalAlignmentCandidateReads(
     readId=readId, strand=strand,
     maxDistance=maxDistance,
-    useReadName=useReadName,
     allowChimericReads=allowChimericReads,
     allowCrossStrandEdges=allowCrossStrandEdges,
     allowInconsistentAlignmentEdges=allowInconsistentAlignmentEdges)

--- a/scripts/WriteLocalReadGraphReads.py
+++ b/scripts/WriteLocalReadGraphReads.py
@@ -10,7 +10,6 @@ parser = argparse.ArgumentParser(description=
 parser.add_argument('--readId', type=int, required=True)
 parser.add_argument('--strand', type=int, choices=range(2), required=True)
 parser.add_argument('--maxDistance', type=int, required=True)
-parser.add_argument('--useReadName', action='store_true')
 parser.add_argument('--allowChimericReads', action='store_true')
 parser.add_argument('--allowCrossStrandEdges', action='store_true')
 parser.add_argument('--allowInconsistentAlignmentEdges', action='store_true')
@@ -19,7 +18,6 @@ arguments = parser.parse_args()
 readId = arguments.readId
 strand = arguments.strand
 maxDistance = arguments.maxDistance
-useReadName = arguments.useReadName
 allowChimericReads = arguments.allowChimericReads
 allowCrossStrandEdges = arguments.allowCrossStrandEdges
 allowInconsistentAlignmentEdges = arguments.allowInconsistentAlignmentEdges
@@ -31,7 +29,6 @@ a.accessMarkers()
 a.writeLocalReadGraphReads(
     readId=readId, strand=strand, 
     maxDistance=maxDistance,
-    useReadName=useReadName,
     allowChimericReads=allowChimericReads,
     allowCrossStrandEdges=allowCrossStrandEdges,
     allowInconsistentAlignmentEdges=allowInconsistentAlignmentEdges)

--- a/scripts/WriteLocalReadGraphReads.py
+++ b/scripts/WriteLocalReadGraphReads.py
@@ -10,6 +10,7 @@ parser = argparse.ArgumentParser(description=
 parser.add_argument('--readId', type=int, required=True)
 parser.add_argument('--strand', type=int, choices=range(2), required=True)
 parser.add_argument('--maxDistance', type=int, required=True)
+parser.add_argument('--useReadName', action='store_true')
 parser.add_argument('--allowChimericReads', action='store_true')
 parser.add_argument('--allowCrossStrandEdges', action='store_true')
 parser.add_argument('--allowInconsistentAlignmentEdges', action='store_true')
@@ -18,6 +19,7 @@ arguments = parser.parse_args()
 readId = arguments.readId
 strand = arguments.strand
 maxDistance = arguments.maxDistance
+useReadName = arguments.useReadName
 allowChimericReads = arguments.allowChimericReads
 allowCrossStrandEdges = arguments.allowCrossStrandEdges
 allowInconsistentAlignmentEdges = arguments.allowInconsistentAlignmentEdges
@@ -28,7 +30,8 @@ a.accessReadGraph()
 a.accessMarkers()
 a.writeLocalReadGraphReads(
     readId=readId, strand=strand, 
-    maxDistance=maxDistance, 
+    maxDistance=maxDistance,
+    useReadName=useReadName,
     allowChimericReads=allowChimericReads,
     allowCrossStrandEdges=allowCrossStrandEdges,
     allowInconsistentAlignmentEdges=allowInconsistentAlignmentEdges)

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -744,7 +744,6 @@ public:
             ReadId readId,
             Strand strand,
             uint32_t maxDistance,
-            bool useReadName,
             bool allowChimericReads,
             bool allowCrossStrandEdges,
             bool allowInconsistentAlignmentEdges
@@ -1200,7 +1199,6 @@ public:
         ReadId,
         Strand,
         uint32_t maxDistance,
-        bool useReadName,
         bool allowChimericReads,
         bool allowCrossStrandEdges,
         bool allowInconsistentAlignmentEdges);

--- a/src/Assembler.hpp
+++ b/src/Assembler.hpp
@@ -1191,6 +1191,7 @@ public:
         ReadId,
         Strand,
         uint32_t maxDistance,
+        bool useReadName,
         bool allowChimericReads,
         bool allowCrossStrandEdges,
         bool allowInconsistentAlignmentEdges);

--- a/src/AssemblerAlignmentCandidates.cpp
+++ b/src/AssemblerAlignmentCandidates.cpp
@@ -164,12 +164,18 @@ void Assembler::writeLocalAlignmentCandidateReads(
 
         // Write the header line with the read name.
         const auto readName = reads->getReadName(readId);
+        const auto& sequence = reads->getRead(readId);
+        const auto& counts = reads->getReadRepeatCounts(readId);
 
-        // Write the name first and the ID second
+        // Write the name first and the ID second if useReadName is specified
         fasta << ">";
         copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-        fasta << " " << readId;
+        fasta << " oldReadId=" << readId;
 
+        // Write the length
+        fasta << " length=" << sequence.baseCount;
+
+        // Write the metadata from the original fasta (if there is any)
         const auto metaData = reads->getReadMetaData(readId);
         if(metaData.size() > 0) {
             fasta << " ";
@@ -178,8 +184,6 @@ void Assembler::writeLocalAlignmentCandidateReads(
         fasta << "\n";
 
         // Write the sequence.
-        const auto& sequence = reads->getRead(readId);
-        const auto& counts = reads->getReadRepeatCounts(readId);
         const size_t n = sequence.baseCount;
         SHASTA_ASSERT(counts.size() == n);
         for(size_t i=0; i<n; i++) {

--- a/src/AssemblerAlignmentCandidates.cpp
+++ b/src/AssemblerAlignmentCandidates.cpp
@@ -130,7 +130,6 @@ void Assembler::writeLocalAlignmentCandidateReads(
         ReadId readId,
         Strand strand,
         uint32_t maxDistance,
-        bool useReadName,
         bool allowChimericReads,
         bool allowCrossStrandEdges,
         bool allowInconsistentAlignmentEdges)
@@ -166,16 +165,10 @@ void Assembler::writeLocalAlignmentCandidateReads(
         // Write the header line with the read name.
         const auto readName = reads->getReadName(readId);
 
-        // Write the name first and the ID second if useReadName is specified
-        if (useReadName) {
-            fasta << ">";
-            copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-            fasta << " " << readId;
-        }
-        else {
-            fasta << ">" << readId << " ";
-            copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-        }
+        // Write the name first and the ID second
+        fasta << ">";
+        copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
+        fasta << " " << readId;
 
         const auto metaData = reads->getReadMetaData(readId);
         if(metaData.size() > 0) {

--- a/src/AssemblerReadGraph.cpp
+++ b/src/AssemblerReadGraph.cpp
@@ -796,12 +796,18 @@ void Assembler::writeLocalReadGraphReads(
 
         // Write the header line with the read name.
         const auto readName = reads->getReadName(readId);
+        const auto& sequence = reads->getRead(readId);
+        const auto& counts = reads->getReadRepeatCounts(readId);
 
         // Write the name first and the ID second if useReadName is specified
         fasta << ">";
         copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-        fasta << " " << readId;
+        fasta << " oldReadId=" << readId;
 
+        // Write the length
+        fasta << " length=" << sequence.baseCount;
+
+        // Write the metadata from the original fasta (if there is any)
         const auto metaData = reads->getReadMetaData(readId);
         if(metaData.size() > 0) {
             fasta << " ";
@@ -810,8 +816,6 @@ void Assembler::writeLocalReadGraphReads(
         fasta << "\n";
 
         // Write the sequence.
-        const auto& sequence = reads->getRead(readId);
-        const auto& counts = reads->getReadRepeatCounts(readId);
         const size_t n = sequence.baseCount;
         SHASTA_ASSERT(counts.size() == n);
         for(size_t i=0; i<n; i++) {

--- a/src/AssemblerReadGraph.cpp
+++ b/src/AssemblerReadGraph.cpp
@@ -766,7 +766,6 @@ void Assembler::writeLocalReadGraphReads(
     ReadId readId,
     Strand strand,
     uint32_t maxDistance,
-    bool useReadName,
     bool allowChimericReads,
     bool allowCrossStrandEdges,
     bool allowInconsistentAlignmentEdges)
@@ -799,15 +798,9 @@ void Assembler::writeLocalReadGraphReads(
         const auto readName = reads->getReadName(readId);
 
         // Write the name first and the ID second if useReadName is specified
-        if (useReadName) {
-            fasta << ">";
-            copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-            fasta << " " << readId;
-        }
-        else {
-            fasta << ">" << readId << " ";
-            copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
-        }
+        fasta << ">";
+        copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
+        fasta << " " << readId;
 
         const auto metaData = reads->getReadMetaData(readId);
         if(metaData.size() > 0) {

--- a/src/AssemblerReadGraph.cpp
+++ b/src/AssemblerReadGraph.cpp
@@ -766,6 +766,7 @@ void Assembler::writeLocalReadGraphReads(
     ReadId readId,
     Strand strand,
     uint32_t maxDistance,
+    bool useReadName,
     bool allowChimericReads,
     bool allowCrossStrandEdges,
     bool allowInconsistentAlignmentEdges)
@@ -796,8 +797,18 @@ void Assembler::writeLocalReadGraphReads(
 
         // Write the header line with the read name.
         const auto readName = reads->getReadName(readId);
-        fasta << ">" << readId << " ";
-        copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
+
+        // Write the name first and the ID second if useReadName is specified
+        if (useReadName) {
+            fasta << ">";
+            copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
+            fasta << " " << readId;
+        }
+        else {
+            fasta << ">" << readId << " ";
+            copy(readName.begin(), readName.end(), ostream_iterator<char>(fasta));
+        }
+
         const auto metaData = reads->getReadMetaData(readId);
         if(metaData.size() > 0) {
             fasta << " ";

--- a/src/AssemblerReadGraph.cpp
+++ b/src/AssemblerReadGraph.cpp
@@ -805,7 +805,7 @@ void Assembler::writeLocalReadGraphReads(
         fasta << " oldReadId=" << readId;
 
         // Write the length
-        fasta << " length=" << sequence.baseCount;
+        fasta << " length=" << reads->getReadRawSequenceLength(readId);
 
         // Write the metadata from the original fasta (if there is any)
         const auto metaData = reads->getReadMetaData(readId);

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -374,6 +374,7 @@ PYBIND11_MODULE(shasta, module)
             arg("readId"),
             arg("strand"),
             arg("maxDistance"),
+            arg("useReadName"),
             arg("allowChimericReads"),
             arg("allowCrossStrandEdges"),
             arg("allowInconsistentAlignmentEdges"))

--- a/src/PythonModule.cpp
+++ b/src/PythonModule.cpp
@@ -242,7 +242,6 @@ PYBIND11_MODULE(shasta, module)
              arg("readId"),
              arg("strand"),
              arg("maxDistance"),
-             arg("useReadName"),
              arg("allowChimericReads"),
              arg("allowCrossStrandEdges"),
              arg("allowInconsistentAlignmentEdges"))
@@ -378,7 +377,6 @@ PYBIND11_MODULE(shasta, module)
             arg("readId"),
             arg("strand"),
             arg("maxDistance"),
-            arg("useReadName"),
             arg("allowChimericReads"),
             arg("allowCrossStrandEdges"),
             arg("allowInconsistentAlignmentEdges"))


### PR DESCRIPTION
(After some discussion, removed the option and made it the default action to use read names)