### PR TITLE
Add script to compare phasing with MarginPhase

### DIFF
--- a/scripts/comparePhaseAssignments.py
+++ b/scripts/comparePhaseAssignments.py
@@ -55,9 +55,9 @@ def main(hap1MarginPath, hap2MarginPath, shastaPath):
             name = line.strip()
             marginPhases[1].add(name)
 
-    # Compare SHasta to Margin and write results to CSV + stdout
+    # Compare Shasta to Margin and write results to CSV + stdout
     with open(discordantCsvPath, 'w') as file:
-        file.write("OrientedReadId,ReadName,Component,ShastaPhase,MarginPhase")
+        file.write("OrientedReadId,ReadName,Component,ShastaPhase,MarginPhase\n")
 
         for componentId,component in shastaComponents.items():
             print("Evaluating component:", componentId)

--- a/scripts/comparePhaseAssignments.py
+++ b/scripts/comparePhaseAssignments.py
@@ -1,0 +1,171 @@
+from collections import defaultdict
+from sklearn import metrics
+import argparse
+import os
+
+
+class PhasedRead:
+    def __init__(self, id, name, component, phase):
+        self.id = id
+        self.name = name
+        self.component = int(component)
+        self.phase = int(phase)
+
+
+# Iterate the shasta CSV and yield one PhasedRead data object at a time
+def parseShastaPhaseCsv(shastaPath):
+    with open(shastaPath, 'r') as file:
+        for l,line in enumerate(file):
+            if l == 0:
+                # Skip header line
+                continue
+
+            # OrientedReadId,ReadName,Component,Phase
+            tokens = line.strip().split(',')
+
+            # Ignore unphased reads (for now)
+            if (len(tokens[-1]) == 0) and (len(tokens[-2]) == 0):
+                continue
+
+            yield PhasedRead(tokens[0], tokens[1], tokens[2], tokens[3])
+
+
+def main(hap1MarginPath, hap2MarginPath, shastaPath):
+    discordantCsvPath = os.path.join(os.path.dirname(shastaPath), "discordantPhasedReads.csv")
+
+    marginPhases = (set(),set())
+    shastaComponents = defaultdict(lambda: (set(),set()))
+    nameToId = dict()
+
+    # Read all the Shasta phase assignments
+    for read in parseShastaPhaseCsv(shastaPath):
+        shastaComponents[read.component][read.phase].add(read.name)
+        nameToId[read.name] = read.id
+
+        if read.name in shastaComponents[read.component][1-read.phase]:
+            exit("ERROR: read contained both in hap1 and hap2 of Shasta phases: " + read.name)
+
+    # Read the Margin phase assignments
+    with open(hap1MarginPath, 'r') as margin0File, open(hap2MarginPath, 'r') as margin1File:
+        for line in margin0File:
+            name = line.strip()
+            marginPhases[0].add(name)
+
+        for line in margin1File:
+            name = line.strip()
+            marginPhases[1].add(name)
+
+    # Compare SHasta to Margin and write results to CSV + stdout
+    with open(discordantCsvPath, 'w') as file:
+        file.write("OrientedReadId,ReadName,Component,ShastaPhase,MarginPhase")
+
+        for componentId,component in shastaComponents.items():
+            print("Evaluating component:", componentId)
+
+            names = list()
+            shastaPhaseArray = list()
+            marginPhaseArray = list()
+
+            # Compare phase assignments for Shasta and the user-provided dataset, for each read in each component
+            for p,phase in enumerate(component):
+                for readName in phase:
+                    marginPhase = -1
+
+                    if readName in marginPhases[0]:
+                        marginPhase = 0
+
+                    if readName in marginPhases[1]:
+                        if marginPhase == 0:
+                            exit("ERROR: read contained both in hap1 and hap2 of Margin phases: " + readName)
+                        else:
+                            marginPhase = 1
+
+                    # Only store results for reads that also exist in the user-provided dataset
+                    if marginPhase >= 0:
+                        names.append(readName)
+                        shastaPhaseArray.append(p)
+                        marginPhaseArray.append(marginPhase)
+
+            countMatrix = [[0,0],[0,0]]
+            confusionMatrix = [[0,0],[0,0]]
+
+            for i in range(len(names)):
+                countMatrix[0][shastaPhaseArray[i]] += 1
+                countMatrix[1][marginPhaseArray[i]] += 1
+
+                confusionMatrix[shastaPhaseArray[i]][marginPhaseArray[i]] += 1
+
+            # Compute the weight of the diagonal and antidiagonal, and infer which is True Positives
+            diagonalSum = confusionMatrix[0][0] + confusionMatrix[1][1] + 1e-12
+            antidiagonalSum = confusionMatrix[1][0] + confusionMatrix[0][1]
+
+            if 2 > (antidiagonalSum / diagonalSum) > 0.5:
+                print("WARNING: ratio of antidiagonalSum:diagonalSum is only " + str(antidiagonalSum / diagonalSum))
+
+            # Indicate which coordinates in the confusion matrix represent discordant reads between shasta's
+            # and the user-provided phase assignments
+            discoordinateA = (0,1)
+            discoordinateB = (1,0)
+
+            # Iterate reads again and write the ones that are discordant with the user-provided phases
+            if antidiagonalSum > diagonalSum:
+                discoordinateA = (0,0)
+                discoordinateB = (1,1)
+
+            for i in range(len(names)):
+                coordinate = (shastaPhaseArray[i], marginPhaseArray[i])
+
+                if coordinate == discoordinateA or coordinate == discoordinateB:
+                    file.write(nameToId[names[i]])
+                    file.write(',')
+                    file.write(names[i])
+                    file.write(',')
+                    file.write(str(componentId))
+                    file.write(',')
+                    file.write(str(shastaPhaseArray[i]))
+                    file.write(',')
+                    file.write(str(marginPhaseArray[i]))
+                    file.write('\n')
+
+            print("Shasta phase counts:",countMatrix[0])
+            print("Margin phase counts:",countMatrix[1])
+
+            print("Confusion matrix:")
+            print(confusionMatrix[0])
+            print(confusionMatrix[1])
+
+            adjustedRandIndex = metrics.adjusted_rand_score(marginPhaseArray, shastaPhaseArray)
+            print("ARI:", adjustedRandIndex)
+            print()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-1","--hap1",
+        type=str,
+        required=True,
+        help="path of marginphase file for hap1"
+    )
+    parser.add_argument(
+        "-2","--hap2",
+        type=str,
+        required=True,
+        help="path of marginphase file for hap2"
+    )
+    parser.add_argument(
+        "-s","--shasta",
+        type=str,
+        required=True,
+        help="path of shasta phase components csv"
+    )
+
+    args = parser.parse_args()
+
+    main(
+        hap1MarginPath=args.hap1,
+        hap2MarginPath=args.hap2,
+        shastaPath=args.shasta,
+    )
+


### PR DESCRIPTION
This script takes 2 files containing phased read names from Pepper-Marginphase-DeepVariant and compares them to the phasing described in Shasta's Phasing.csv. Some summary stats are generated, and each read which is in disagreement between the 2 phase datasets is written to a CSV.

Example stdout:
```
Evaluating component: 5
Shasta phase counts: [368, 397]
Margin phase counts: [398, 367]
Confusion matrix:
[1, 367]
[397, 0]
ARI: 0.9947712416020529
```
(where ARI = adjusted rand index)

Example CSV log:
```
OrientedReadId,ReadName,Component,ShastaPhase,MarginPhase
798-1,39be7cb7-4ea1-4d3d-8135-0ebd50e895de,0,0,1
3327-1,6315035e-25d3-4fa6-8432-fcb5525024af,0,0,1
194-1,c853b653-c9aa-4af5-bfa6-c71430e8f018,0,0,1
2861-1,ce91af8d-7f4c-4d65-85dc-de7c90c31889,0,0,1
1823-1,b30e612d-4bf6-4b7a-9540-f9ee16ce22db,0,0,1
2831-1,6d8a8961-c1ff-4244-bf6f-f17a934b1a67,0,0,1
3627-1,b775fb67-fa1b-4586-b156-e28c9d799a12,0,0,1
2083-1,7de64bc4-cbd4-4265-8e5d-5963c408e6d8,0,0,1
3567-1,fa9fe977-d864-4532-9a6d-4af95a3cee22,0,1,0
798-1,39be7cb7-4ea1-4d3d-8135-0ebd50e895de,1,0,1
3327-1,6315035e-25d3-4fa6-8432-fcb5525024af,1,0,1
194-1,c853b653-c9aa-4af5-bfa6-c71430e8f018,1,0,1
2861-1,ce91af8d-7f4c-4d65-85dc-de7c90c31889,1,0,1
```