### PR TITLE
Do not hardcode BLAS and Lapack libraries. Find them!

### DIFF
--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -53,6 +53,7 @@ file(GLOB SOURCES ../srcMain/*.cpp)
 
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
+find_package(PNG REQUIRED)
 
 # Include directory.
 include_directories(../src)
@@ -67,21 +68,19 @@ set_target_properties(shastaDynamicExecutable PROPERTIES OUTPUT_NAME "shastaDyna
 # library in the same directory.
 set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN")
 
-find_library(PNG_LIBRARY libpng.so REQUIRED)
-
 # Libraries to link with.
 if(X86_64)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
         atomic boost_system boost_program_options boost_chrono spoa
-        cpu_features ${PNG_LIBRARY} z 
+        cpu_features ${PNG_LIBRARIES} z
         ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} gfortran quadmath pthread)
 else(X86_64)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
-        atomic boost_system boost_program_options boost_chrono spoa ${PNG_LIBRARY} z 
+        atomic boost_system boost_program_options boost_chrono spoa ${PNG_LIBRARIES} z
         ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} gfortran pthread)
 endif(X86_64)
 
@@ -91,4 +90,3 @@ endif(BUILD_DEBUG)
 
 # Install the dynamic executable into the bin directory.
 install(TARGETS shastaDynamicExecutable DESTINATION shasta-install/bin)
-

--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -51,8 +51,13 @@ add_definitions(-DSHASTA_PYTHON_API)
 # Source files
 file(GLOB SOURCES ../srcMain/*.cpp)
 
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+
 # Include directory.
 include_directories(../src)
+include_directories(${BLAS_INCLUDE_DIRS})
+include_directories(${LAPACK_INCLUDE_DIRS})
 
 # Define our executable.
 add_executable(shastaDynamicExecutable ${SOURCES})
@@ -62,19 +67,22 @@ set_target_properties(shastaDynamicExecutable PROPERTIES OUTPUT_NAME "shastaDyna
 # library in the same directory.
 set_target_properties(shastaDynamicExecutable PROPERTIES INSTALL_RPATH "\$ORIGIN")
 
+find_library(PNG_LIBRARY libpng.so REQUIRED)
+
 # Libraries to link with.
 if(X86_64)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
-        atomic boost_system boost_program_options boost_chrono spoa cpu_features png z 
-        lapack blas gfortran quadmath pthread)
+        atomic boost_system boost_program_options boost_chrono spoa
+        cpu_features ${PNG_LIBRARY} z 
+        ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} gfortran quadmath pthread)
 else(X86_64)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
-        atomic boost_system boost_program_options boost_chrono spoa png z 
-        lapack blas gfortran pthread)
+        atomic boost_system boost_program_options boost_chrono spoa ${PNG_LIBRARY} z 
+        ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} gfortran pthread)
 endif(X86_64)
 
 if(BUILD_DEBUG) 

--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -52,8 +52,13 @@ add_definitions(-DSHASTA_PYTHON_API)
 # Sources files.
 file(GLOB SOURCES ../src/*.cpp)
 
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+
 # Include directory.
 include_directories(../src)
+include_directories(${BLAS_INCLUDE_DIRS})
+include_directories(${LAPACK_INCLUDE_DIRS})
 
 # Define our library.
 add_library(shastaDynamicLibrary SHARED ${SOURCES})
@@ -66,22 +71,18 @@ set_target_properties(shastaDynamicLibrary PROPERTIES DEFINE_SYMBOL "")
 
 
 # Python 3 and pybind11.
-execute_process(COMMAND /usr/bin/python3-config --embed --libs OUTPUT_VARIABLE SHASTA_PYTHON_LIBRARIES)
+execute_process(COMMAND python3-config --embed --libs OUTPUT_VARIABLE SHASTA_PYTHON_LIBRARIES)
 execute_process(COMMAND python3 -m pybind11 --includes OUTPUT_VARIABLE SHASTA_PYTHON_INCLUDES)
 add_definitions(${SHASTA_PYTHON_INCLUDES})
 string(STRIP ${SHASTA_PYTHON_LIBRARIES} SHASTA_PYTHON_LIBRARIES)
 SET(CMAKE_LINKER_FLAGS  "${CMAKE_LINKER_FLAGS} ${SHASTA_PYTHON_LIBRARIES}")
 
-
+find_library(PNG_LIBRARY libpng.so REQUIRED)
 
 # Libraries to link with.
 target_link_libraries(
     shastaDynamicLibrary 
-     atomic png boost_program_options pthread z spoa lapack blas ${SHASTA_PYTHON_LIBRARIES})
+     atomic ${PNG_LIBRARY} boost_program_options pthread z spoa ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${SHASTA_PYTHON_LIBRARIES})
 
 # Install the shared library into the bin directory.
 install(TARGETS shastaDynamicLibrary DESTINATION shasta-install/bin)
-
-
-
-

--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -54,6 +54,7 @@ file(GLOB SOURCES ../src/*.cpp)
 
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
+find_package(PNG REQUIRED)
 
 # Include directory.
 include_directories(../src)
@@ -77,12 +78,10 @@ add_definitions(${SHASTA_PYTHON_INCLUDES})
 string(STRIP ${SHASTA_PYTHON_LIBRARIES} SHASTA_PYTHON_LIBRARIES)
 SET(CMAKE_LINKER_FLAGS  "${CMAKE_LINKER_FLAGS} ${SHASTA_PYTHON_LIBRARIES}")
 
-find_library(PNG_LIBRARY libpng.so REQUIRED)
-
 # Libraries to link with.
 target_link_libraries(
     shastaDynamicLibrary 
-     atomic ${PNG_LIBRARY} boost_program_options pthread z spoa ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${SHASTA_PYTHON_LIBRARIES})
+     atomic ${PNG_LIBRARIES} boost_program_options pthread z spoa ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${SHASTA_PYTHON_LIBRARIES})
 
 # Install the shared library into the bin directory.
 install(TARGETS shastaDynamicLibrary DESTINATION shasta-install/bin)

--- a/staticExecutable/CMakeLists.txt
+++ b/staticExecutable/CMakeLists.txt
@@ -48,6 +48,8 @@ file(GLOB SOURCES ../srcMain/*.cpp)
 # Include directory.
 include_directories(../src)
 
+find_package(PNG REQUIRED)
+
 # Define our executable.
 add_executable(shastaStaticExecutable ${SOURCES})
 set_target_properties(shastaStaticExecutable PROPERTIES OUTPUT_NAME "shasta")
@@ -62,19 +64,17 @@ if(X86_64)
     target_link_libraries(
         shastaStaticExecutable
         shastaStaticLibrary
-        atomic boost_system boost_program_options boost_chrono spoa cpu_features png z
+        atomic boost_system boost_program_options boost_chrono spoa cpu_features ${PNG_LIBRARIES} z
         lapack blas gfortran quadmath
         -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 else(X86_64)
     target_link_libraries(
         shastaStaticExecutable
         shastaStaticLibrary
-        atomic boost_system boost_program_options boost_chrono spoa png z
+        atomic boost_system boost_program_options boost_chrono spoa ${PNG_LIBRARIES} z
         lapack blas gfortran
         -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 endif(X86_64) 
   
 # The static executable goes to the bin directory.
 install(TARGETS shastaStaticExecutable DESTINATION shasta-install/bin)
-
-

--- a/staticExecutable/CMakeLists.txt
+++ b/staticExecutable/CMakeLists.txt
@@ -47,7 +47,12 @@ file(GLOB SOURCES ../srcMain/*.cpp)
 
 # Include directory.
 include_directories(../src)
+include_directories(${BLAS_INCLUDE_DIRS})
+include_directories(${LAPACK_INCLUDE_DIRS})
 
+set(BLA_STATIC ON)
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
 find_package(PNG REQUIRED)
 
 # Define our executable.
@@ -65,14 +70,14 @@ if(X86_64)
         shastaStaticExecutable
         shastaStaticLibrary
         atomic boost_system boost_program_options boost_chrono spoa cpu_features ${PNG_LIBRARIES} z
-        lapack blas gfortran quadmath
+        ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} gfortran quadmath
         -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 else(X86_64)
     target_link_libraries(
         shastaStaticExecutable
         shastaStaticLibrary
         atomic boost_system boost_program_options boost_chrono spoa ${PNG_LIBRARIES} z
-        lapack blas gfortran
+        ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} gfortran
         -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 endif(X86_64) 
   


### PR DESCRIPTION
Blas and Lapack can have different provider (OpenBLAS, MKL, Flexiblas). Do not hardcode the libraries name but rather find them.
Same for libpng, find it.

Also uses `python3-config` from PATH and not hardcoded path.